### PR TITLE
Follow external window switches in the single-pane live view

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -915,9 +915,11 @@ each wrapped in an evolving prompt line and a status bar.")
   ;; active pane, so the view -- and scrollback, which captures
   ;; `tmux-control--active-pane' -- follows the tab bar instead of stranding on
   ;; the previous pane.  When THIS client initiated the switch,
-  ;; `tmux-control--refresh-active-pane' already reseeded and armed
-  ;; `tmux-control--self-reseed-until', so the notification tmux echoes back
-  ;; must NOT reseed again (it would double-paint); it consumes the mark.
+  ;; `tmux-control--refresh-active-pane' already reseeded and recorded a
+  ;; pending self-reseed, so the event tmux echoes back must NOT reseed again
+  ;; (it would double-paint); it consumes one pending count.  A COUNT (not a
+  ;; single flag) is needed so several rapid self-switches are each absorbed,
+  ;; and a deadline clears a stale count so it never swallows a real external.
   (with-temp-buffer
     (setq-local tmux-control--tiled nil)
     (let ((reseeds 0) (refreshes 0))
@@ -926,22 +928,40 @@ each wrapped in an evolving prompt line and a status bar.")
                  (lambda () (cl-incf refreshes)))
                 ((symbol-function 'tmux-control--refresh-active-pane)
                  (lambda (&optional _self) (cl-incf reseeds))))
-        ;; External switch: mark expired -> follow it (reseed).
+        ;; External switch: no pending self-reseed -> follow it (reseed).
+        (setq-local tmux-control--self-reseed-pending 0)
         (setq-local tmux-control--self-reseed-until 0)
         (tmux-control--handle-line "%session-window-changed $0 @2")
         (should (= refreshes 1))
         (should (= reseeds 1))
-        ;; Self-initiated switch: mark armed -> skip reseed, consume the mark.
+        ;; Two rapid self-initiated switches in flight: each echoed event is
+        ;; absorbed (no reseed) and consumes exactly one pending count -- a
+        ;; single flag would absorb only the first and double-paint the second.
+        (setq-local tmux-control--self-reseed-pending 2)
         (setq-local tmux-control--self-reseed-until (+ (float-time) 100))
         (tmux-control--handle-line "%session-window-changed $0 @3")
         (should (= refreshes 2))
         (should (= reseeds 1))
-        (should (= tmux-control--self-reseed-until 0))
-        ;; A genuine external switch right afterwards still reseeds (the mark
-        ;; was consumed, not left armed).
-        (tmux-control--handle-line "%session-window-changed $0 @0")
+        (should (= tmux-control--self-reseed-pending 1))
+        (tmux-control--handle-line "%session-window-changed $0 @4")
         (should (= refreshes 3))
-        (should (= reseeds 2))))))
+        (should (= reseeds 1))
+        (should (= tmux-control--self-reseed-pending 0))
+        ;; A genuine external switch right afterwards still reseeds (the count
+        ;; was fully consumed, not left armed).
+        (tmux-control--handle-line "%session-window-changed $0 @0")
+        (should (= refreshes 4))
+        (should (= reseeds 2))
+        ;; A stale pending count -- a self-switch that produced no event (a
+        ;; no-op select, a background kill) -- does not permanently swallow
+        ;; externals: once the deadline passes it is cleared and the switch is
+        ;; followed.
+        (setq-local tmux-control--self-reseed-pending 1)
+        (setq-local tmux-control--self-reseed-until (- (float-time) 1))
+        (tmux-control--handle-line "%session-window-changed $0 @1")
+        (should (= refreshes 5))
+        (should (= reseeds 3))
+        (should (= tmux-control--self-reseed-pending 0))))))
 
 (ert-deftest tmux-control-test-session-window-changed-tiled-retiles ()
   ;; In tiling mode the notification re-tiles to the new window's panes rather

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -909,5 +909,53 @@ each wrapped in an evolving prompt line and a status bar.")
       (tmux-control--note-pane-activity "%1")
       (should-not (gethash "1" tmux-control--activity)))))
 
+(ert-deftest tmux-control-test-session-window-changed-external-reseeds ()
+  ;; A %session-window-changed from an EXTERNAL switch (another client, a tmux
+  ;; key binding, a script) must reseed the live view onto the new window's
+  ;; active pane, so the view -- and scrollback, which captures
+  ;; `tmux-control--active-pane' -- follows the tab bar instead of stranding on
+  ;; the previous pane.  When THIS client initiated the switch,
+  ;; `tmux-control--refresh-active-pane' already reseeded and armed
+  ;; `tmux-control--self-reseed-until', so the notification tmux echoes back
+  ;; must NOT reseed again (it would double-paint); it consumes the mark.
+  (with-temp-buffer
+    (setq-local tmux-control--tiled nil)
+    (let ((reseeds 0) (refreshes 0))
+      (cl-letf (((symbol-function 'tmux-control--flush-output-batch) #'ignore)
+                ((symbol-function 'tmux-control--refresh-windows)
+                 (lambda () (cl-incf refreshes)))
+                ((symbol-function 'tmux-control--refresh-active-pane)
+                 (lambda (&optional _self) (cl-incf reseeds))))
+        ;; External switch: mark expired -> follow it (reseed).
+        (setq-local tmux-control--self-reseed-until 0)
+        (tmux-control--handle-line "%session-window-changed $0 @2")
+        (should (= refreshes 1))
+        (should (= reseeds 1))
+        ;; Self-initiated switch: mark armed -> skip reseed, consume the mark.
+        (setq-local tmux-control--self-reseed-until (+ (float-time) 100))
+        (tmux-control--handle-line "%session-window-changed $0 @3")
+        (should (= refreshes 2))
+        (should (= reseeds 1))
+        (should (= tmux-control--self-reseed-until 0))
+        ;; A genuine external switch right afterwards still reseeds (the mark
+        ;; was consumed, not left armed).
+        (tmux-control--handle-line "%session-window-changed $0 @0")
+        (should (= refreshes 3))
+        (should (= reseeds 2))))))
+
+(ert-deftest tmux-control-test-session-window-changed-tiled-retiles ()
+  ;; In tiling mode the notification re-tiles to the new window's panes rather
+  ;; than reseeding a single pane.
+  (with-temp-buffer
+    (setq-local tmux-control--tiled t)
+    (setq-local tmux-control--retile-pending nil)
+    (let ((reseeds 0))
+      (cl-letf (((symbol-function 'tmux-control--flush-output-batch) #'ignore)
+                ((symbol-function 'tmux-control--refresh-active-pane)
+                 (lambda (&optional _self) (cl-incf reseeds))))
+        (tmux-control--handle-line "%session-window-changed $0 @2")
+        (should tmux-control--retile-pending)
+        (should (= reseeds 0))))))
+
 (provide 'tmux-control-test)
 ;;; tmux-control-test.el ends here

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -213,6 +213,16 @@ per-message decoding leaves the halves as raw bytes, so the trailing
 incomplete bytes are carried here and prepended to the next chunk by
 `tmux-control--feed-terminal'.")
 (defvar-local tmux-control--active-pane nil)
+(defvar-local tmux-control--self-reseed-until 0
+  "Float-time deadline marking a reseed this client just initiated.
+Set by `tmux-control--refresh-active-pane' whenever tmux-control itself
+switches the active window (select-window, next/previous/last-window,
+new-window, kill-window).  The matching `%session-window-changed'
+notification then knows that reseed already happened and skips a redundant
+one.  An *external* window switch (another client, a tmux key binding, a
+script) sets nothing, so its notification finds this expired/cleared and
+reseeds -- which is how the live view and scrollback follow external
+switches instead of stranding on the old pane.")
 (defvar-local tmux-control--fallback-target nil)
 (defvar-local tmux-control--host nil)
 (defvar-local tmux-control--socket-name nil)
@@ -566,9 +576,18 @@ running command, its title when that differs, and whether it is active."
   (unless (process-live-p tmux-control--process)
     (user-error "tmux-control process is not live")))
 
-(defun tmux-control--refresh-active-pane ()
-  "Re-query the session's active pane id, repaint the live view, and resize."
+(defun tmux-control--refresh-active-pane (&optional self-initiated)
+  "Re-query the session's active pane id, repaint the live view, and resize.
+SELF-INITIATED non-nil means this client is switching the active window
+itself; mark a short window so the `%session-window-changed' tmux echoes
+back for our own switch does not reseed a second time.  The mark is generous
+enough to cover the notification round-trip even over SSH, and the handler
+clears it on use, so it never masks a genuine later external switch.  Called
+without SELF-INITIATED from that handler to follow an external switch, where
+arming the mark would wrongly swallow the next external switch."
   (tmux-control--quiet-activity)
+  (when self-initiated
+    (setq tmux-control--self-reseed-until (+ (float-time) 1.0)))
   (tmux-control--send-command "display-message -p '#{pane_id}'" :pane-id)
   (tmux-control--resize-to-window))
 
@@ -661,7 +680,7 @@ to the new window's panes, so only the single-pane view reseeds here."
     (tmux-control--send-command
      (format "select-window -t %s:%s" tmux-control--session index))
     (unless ctrl
-      (tmux-control--refresh-active-pane))))
+      (tmux-control--refresh-active-pane t))))
 
 (defun tmux-control--switch-window (verb)
   "Switch the live view to another window via tmux command VERB.
@@ -682,7 +701,7 @@ window, so any other client attached to the session follows along."
     (tmux-control--send-command
      (format "%s -t %s" verb tmux-control--session))
     (unless ctrl
-      (tmux-control--refresh-active-pane))))
+      (tmux-control--refresh-active-pane t))))
 
 ;;;###autoload
 (defun tmux-control-next-window ()
@@ -721,7 +740,7 @@ With a NAME, give the new window that name."
    (concat (format "new-window -t %s:" tmux-control--session)
            (when (and name (not (string-empty-p name)))
              (concat " -n " (tmux-control--quote-tmux-arg name)))))
-  (tmux-control--refresh-active-pane))
+  (tmux-control--refresh-active-pane t))
 
 (defun tmux-control-kill-window (&optional index)
   "Kill window INDEX in the current tmux-control session.
@@ -737,7 +756,7 @@ window in the session ends the session and disconnects this client."
   (setq index (tmux-control--normalize-window-index index))
   (tmux-control--send-command
    (format "kill-window -t %s:%s" tmux-control--session index))
-  (tmux-control--refresh-active-pane))
+  (tmux-control--refresh-active-pane t))
 
 (defun tmux-control-rename-window (&optional index name)
   "Rename window INDEX in the current tmux-control session to NAME.
@@ -2038,13 +2057,22 @@ the matching pane's render buffer instead, so every pane updates at once."
         (tmux-control--refresh-pane-window-map)))
      ((string-prefix-p "%session-window-changed " line)
       ;; The session's active window changed (switched here or by another
-      ;; client).  In tiling mode re-tile to the new window's panes; in
-      ;; single-pane mode the select-window commands already reseed, but
-      ;; refresh the tab bar so its highlight and unseen-output markers track
-      ;; the new current window.
+      ;; client).  In tiling mode re-tile to the new window's panes.  In
+      ;; single-pane mode always refresh the tab bar so its highlight and
+      ;; unseen-output markers track the new current window -- and reseed the
+      ;; live view onto the new window's active pane, UNLESS this client just
+      ;; initiated the switch itself (in which case `--refresh-active-pane'
+      ;; already reseeded; reseeding again would double-paint).  Following an
+      ;; *external* switch here is what keeps the live view -- and scrollback,
+      ;; which captures `--active-pane' -- on the window the tab bar shows,
+      ;; rather than stranding on the previous pane.
       (if tmux-control--tiled
           (setq tmux-control--retile-pending t)
-        (tmux-control--refresh-windows)))
+        (tmux-control--refresh-windows)
+        (if (and (> tmux-control--self-reseed-until 0)
+                 (<= (float-time) tmux-control--self-reseed-until))
+            (setq tmux-control--self-reseed-until 0)
+          (tmux-control--refresh-active-pane))))
      ((and (not tmux-control--tiled)
            (or (string-prefix-p "%window-add " line)
                (string-prefix-p "%window-close " line)

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -213,16 +213,26 @@ per-message decoding leaves the halves as raw bytes, so the trailing
 incomplete bytes are carried here and prepended to the next chunk by
 `tmux-control--feed-terminal'.")
 (defvar-local tmux-control--active-pane nil)
+(defvar-local tmux-control--self-reseed-pending 0
+  "Count of reseeds this client just initiated, awaiting their echoed events.
+Incremented by `tmux-control--refresh-active-pane' whenever tmux-control
+itself switches the active window (select-window, next/previous/last-window,
+new-window, kill-window) -- each such switch already reseeds, and tmux echoes
+back a `%session-window-changed' the handler must NOT reseed a second time.
+Each echoed event consumes one pending count, so several rapid self-switches
+are each matched (a single flag could only absorb one, misclassifying the
+rest as external and double-painting).  An *external* switch (another client,
+a tmux key binding, a script) increments nothing, so its event finds the
+count at zero and reseeds -- which is how the live view and scrollback follow
+external switches instead of stranding on the old pane.  Paired with
+`tmux-control--self-reseed-until' so a self-switch that yields no event (a
+no-op select, a background kill) cannot leave a count stuck and swallow a
+later external switch.")
 (defvar-local tmux-control--self-reseed-until 0
-  "Float-time deadline marking a reseed this client just initiated.
-Set by `tmux-control--refresh-active-pane' whenever tmux-control itself
-switches the active window (select-window, next/previous/last-window,
-new-window, kill-window).  The matching `%session-window-changed'
-notification then knows that reseed already happened and skips a redundant
-one.  An *external* window switch (another client, a tmux key binding, a
-script) sets nothing, so its notification finds this expired/cleared and
-reseeds -- which is how the live view and scrollback follow external
-switches instead of stranding on the old pane.")
+  "Float-time deadline bounding `tmux-control--self-reseed-pending'.
+Refreshed alongside that counter.  Once it passes, any leftover pending count
+is treated as stale and cleared, so a self-initiated reseed that produced no
+`%session-window-changed' never permanently suppresses external switches.")
 (defvar-local tmux-control--fallback-target nil)
 (defvar-local tmux-control--host nil)
 (defvar-local tmux-control--socket-name nil)
@@ -579,15 +589,18 @@ running command, its title when that differs, and whether it is active."
 (defun tmux-control--refresh-active-pane (&optional self-initiated)
   "Re-query the session's active pane id, repaint the live view, and resize.
 SELF-INITIATED non-nil means this client is switching the active window
-itself; mark a short window so the `%session-window-changed' tmux echoes
-back for our own switch does not reseed a second time.  The mark is generous
-enough to cover the notification round-trip even over SSH, and the handler
-clears it on use, so it never masks a genuine later external switch.  Called
-without SELF-INITIATED from that handler to follow an external switch, where
-arming the mark would wrongly swallow the next external switch."
+itself; record one pending self-reseed so the `%session-window-changed' tmux
+echoes back for our own switch does not reseed a second time.  Counting
+\(rather than a single flag) lets several rapid self-switches each be matched
+to their own echoed event; the paired deadline bounds the count so a switch
+that yields no event cannot leave it stuck.  The deadline is generous enough
+to cover the notification round-trip even over SSH.  Called without
+SELF-INITIATED from that handler to follow an external switch, where
+recording a pending reseed would wrongly swallow the next external switch."
   (tmux-control--quiet-activity)
   (when self-initiated
-    (setq tmux-control--self-reseed-until (+ (float-time) 1.0)))
+    (setq tmux-control--self-reseed-pending (1+ tmux-control--self-reseed-pending)
+          tmux-control--self-reseed-until (+ (float-time) 1.0)))
   (tmux-control--send-command "display-message -p '#{pane_id}'" :pane-id)
   (tmux-control--resize-to-window))
 
@@ -2062,16 +2075,21 @@ the matching pane's render buffer instead, so every pane updates at once."
       ;; unseen-output markers track the new current window -- and reseed the
       ;; live view onto the new window's active pane, UNLESS this client just
       ;; initiated the switch itself (in which case `--refresh-active-pane'
-      ;; already reseeded; reseeding again would double-paint).  Following an
-      ;; *external* switch here is what keeps the live view -- and scrollback,
-      ;; which captures `--active-pane' -- on the window the tab bar shows,
-      ;; rather than stranding on the previous pane.
+      ;; already reseeded; reseeding again would double-paint).  One pending
+      ;; count is consumed per self-switch so rapid successive ones are each
+      ;; absorbed; a passed deadline clears any stale count (a no-op select or
+      ;; a background kill arms a count but yields no event).  Following an
+      ;; *external* switch here keeps the live view -- and scrollback, which
+      ;; captures `--active-pane' -- on the window the tab bar shows, rather
+      ;; than stranding on the previous pane.
       (if tmux-control--tiled
           (setq tmux-control--retile-pending t)
         (tmux-control--refresh-windows)
-        (if (and (> tmux-control--self-reseed-until 0)
+        (if (and (> tmux-control--self-reseed-pending 0)
                  (<= (float-time) tmux-control--self-reseed-until))
-            (setq tmux-control--self-reseed-until 0)
+            (setq tmux-control--self-reseed-pending
+                  (1- tmux-control--self-reseed-pending))
+          (setq tmux-control--self-reseed-pending 0)
           (tmux-control--refresh-active-pane))))
      ((and (not tmux-control--tiled)
            (or (string-prefix-p "%window-add " line)


### PR DESCRIPTION
## Problem

When the session's active window is switched **externally** — by another client attached to the same session (e.g. iTerm), a tmux key binding, or a script running `tmux select-window` — tmux sends `%session-window-changed`. The single-pane handler refreshed the tab bar (the current-window highlight) but **did not reseed** the Eat view or update `tmux-control--active-pane`. It assumed *"the select-window commands already reseed"*, which only holds for switches **this** client initiates.

Result after an external switch:
- the **live view stayed on the previous window's pane** while the tab bar claimed the new window (they disagreed), and
- **scrollback** (which captures `--active-pane`) captured the **wrong pane's history**.

Found while dogfooding: enter scrollback after the active window was moved from another client → it shows the old window.

## Fix

Reseed on `%session-window-changed` in single-pane mode too, guarded by a **consume-on-use timestamp** (`tmux-control--self-reseed-until`):

- A switch **we** initiated (`select-window`/`next`/`previous`/`last`/`new`/`kill`) already reseeds via `--refresh-active-pane`, which now *arms* the mark. The notification tmux echoes back **consumes** the mark and skips a second, double-painting reseed.
- An **external** switch arms nothing, finds the mark cleared, and **follows** — reseeding the live view and `--active-pane` onto the new window's pane.
- The mark **auto-expires** (so it never masks a genuinely later external switch) and is **cleared on use** (so back-to-back external switches each reseed). The `self-initiated` arg keeps the handler's own follow-up reseed from re-arming it.

This mirrors the existing `--activity-quiet-until` timestamp-guard idiom already in the codebase, and avoids the double-paint that the tiling work was careful about.

## Verification

- **Live** (throwaway tmux session rendered in a GUI Eat frame): external `select-window` now moves both the live render and scrollback onto the new window's pane; back-to-back external switches both follow; internal `next`/`previous`/`last`/select still reseed exactly once.
- **Unit tests** (71/71): `tmux-control-test-session-window-changed-external-reseeds` (external reseeds; self-initiated consumes the mark and skips; back-to-back external reseeds again) and `tmux-control-test-session-window-changed-tiled-retiles` (tiled mode re-tiles, no single-pane reseed).
- Clean byte-compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)