### PR TITLE
Make scrollback redraw-frame auto-detection robust

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -514,6 +514,70 @@ each wrapped in an evolving prompt line and a status bar.")
     ;; The repeated panel collapsed.
     (should-not (tmux-control-test--window-repeats-p out 6))))
 
+(ert-deftest tmux-control-test-auto-compaction-marker-above-volatile-line ()
+  ;; A capture that begins mid-frame leaves the tie-winning frame edge sitting
+  ;; just above a volatile line (a token counter).  The shared redraw body is
+  ;; then one line BELOW the marker, not at it; compaction must still detect
+  ;; the frame and collapse it while keeping every volatile line.  (Regression:
+  ;; the share-body check used to require the run to start at the marker, so it
+  ;; vetoed this marker and disabled compaction entirely.)
+  (let* ((tmux-control-compact-scrollback-window 300)
+         (tmux-control-scrollback-frame-start-regexp nil)
+         (tmux-control-scrollback-chrome-regexps nil)
+         (frame (concat "==== panel bottom ====\n"
+                        "  tokens: %d\n"
+                        "---- panel top ----\n"
+                        "  Claude Code\n"
+                        "  > Try edit a file\n"
+                        "  Ask me to build code\n"
+                        "  explain this code\n"
+                        "  ? for shortcuts\n"
+                        "  ready.\n"))
+         (text (concat (format frame 100) (format frame 200)
+                       (format frame 300) (format frame 400)))
+         (auto (tmux-control--auto-frame-start-line
+                (mapcar #'string-trim-right (split-string text "\n"))))
+         (tmux-control--auto-frame-start auto)
+         (out (tmux-control--compact-repeated-redraw-lines text))
+         (lines (split-string out "\n")))
+    ;; A marker is found despite the volatile line right after it.
+    (should auto)
+    ;; The repeated panel body survives exactly once...
+    (should (= 1 (length (seq-filter (lambda (l) (equal l "  Claude Code")) lines))))
+    ;; ...while every per-frame token line is preserved.
+    (dolist (n '(100 200 300 400))
+      (should (member (format "  tokens: %d" n) lines)))))
+
+(ert-deftest tmux-control-test-auto-compaction-skips-subthreshold-frequent-line ()
+  ;; The most frequent candidate is not blindly accepted.  A small panel whose
+  ;; shared body is below the redraw-run threshold recurs more often than a
+  ;; larger one, but cannot anchor compaction; the detector must fall through
+  ;; to the larger panel that genuinely repaints.  (Regression: detection used
+  ;; to commit to the single most frequent line and give up if it failed.)
+  (let* ((tmux-control-compact-scrollback-window 300)
+         (tmux-control-scrollback-frame-start-regexp nil)
+         (tmux-control-scrollback-chrome-regexps nil)
+         (small (concat "== small ==\n  s-a\n  s-b\n  uniq-%d\n"))      ; shared body 3 lines (< 6)
+         (big (concat "[ big panel ]\n  b-1\n  b-2\n  b-3\n  b-4\n"
+                      "  b-5\n  b-6\n  count %d\n"))                     ; shared body 7 lines
+         (text (concat (format small 1) (format small 2) (format small 3)
+                       (format small 4) (format small 5)
+                       (format big 1) (format big 2) (format big 3) (format big 4)))
+         (auto (tmux-control--auto-frame-start-line
+                (mapcar #'string-trim-right (split-string text "\n"))))
+         (tmux-control--auto-frame-start auto)
+         (out (tmux-control--compact-repeated-redraw-lines text))
+         (lines (split-string out "\n")))
+    (should auto)
+    ;; The big panel body collapsed to a single copy...
+    (should (= 1 (length (seq-filter (lambda (l) (equal l "  b-3")) lines))))
+    ;; ...its per-frame counts are kept...
+    (dolist (n '(1 2 3 4))
+      (should (member (format "  count %d" n) lines)))
+    ;; ...and the sub-threshold small panel is left intact (all 5 uniq lines).
+    (dolist (n '(1 2 3 4 5))
+      (should (member (format "  uniq-%d" n) lines)))))
+
 ;;; Live-state decision logic (pure predicates extracted from the
 ;;; side-effecting wheel/alt-screen code, so the truth tables can be
 ;;; exhaustively tested without a live tmux server or Eat terminal).

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -1652,9 +1652,15 @@ completion so the user is never stranded in a half-built chooser."
 
 (defun tmux-control--scrollback-chunks (text)
   "Split captured pane TEXT into likely TUI redraw chunks."
+  (tmux-control--scrollback-chunks-from-lines (split-string text "\n")))
+
+(defun tmux-control--scrollback-chunks-from-lines (lines)
+  "Split already-split LINES into likely TUI redraw chunks.
+Lets a caller that already holds the line list -- auto-detection trying each
+candidate marker in turn -- skip a join-then-resplit round trip over the
+whole (up to several-thousand-line) scrollback each time."
   (let (chunks current)
-    (dolist (line (mapcar #'string-trim-right
-                          (split-string text "\n")))
+    (dolist (line (mapcar #'string-trim-right lines))
       (when (and current
                  (tmux-control--scrollback-frame-start-line-p line))
         (push (nreverse current) chunks)
@@ -1702,7 +1708,10 @@ sits below that line, and an only-at-the-top check would miss it and veto an
 otherwise perfect frame marker."
   (let* ((tmux-control--auto-frame-start marker)
          (tmux-control-scrollback-frame-start-regexp nil)
-         (chunks (tmux-control--scrollback-chunks (string-join lines "\n")))
+         ;; Chunk straight from LINES; auto-detection calls this once per
+         ;; candidate marker, so joining to a string and re-splitting it each
+         ;; time would be wasted O(n) work over the whole scrollback.
+         (chunks (tmux-control--scrollback-chunks-from-lines lines))
          (shared nil))
     (while (and (cdr chunks) (not shared))
       (let ((a (tmux-control--trim-blank-line-list (car chunks)))

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -1693,8 +1693,13 @@ so a run of identical filler lines is not taken for frame boundaries.")
 
 (defun tmux-control--frames-share-redraw-body-p (lines marker)
   "Return non-nil when splitting LINES at MARKER yields adjacent frames that
-share a distinctive run -- evidence of a genuine repainting TUI rather than a
-coincidentally repeated line."
+share a distinctive redraw run -- evidence of a genuine repainting TUI rather
+than a coincidentally repeated line.  Mirrors what the merge step actually
+collapses: a shared run anywhere in the later frame, not only one starting at
+its top.  That matters when the capture begins mid-frame, leaving the marker
+just above a volatile line (a token counter, a clock) -- the shared body then
+sits below that line, and an only-at-the-top check would miss it and veto an
+otherwise perfect frame marker."
   (let* ((tmux-control--auto-frame-start marker)
          (tmux-control-scrollback-frame-start-regexp nil)
          (chunks (tmux-control--scrollback-chunks (string-join lines "\n")))
@@ -1702,7 +1707,8 @@ coincidentally repeated line."
     (while (and (cdr chunks) (not shared))
       (let ((a (tmux-control--trim-blank-line-list (car chunks)))
             (b (tmux-control--trim-blank-line-list (cadr chunks))))
-        (when (and a b (tmux-control--seen-run-length a b 0 (length b)))
+        (when (and a b
+                   (< (length (tmux-control--strip-seen-runs a b)) (length b)))
           (setq shared t)))
       (setq chunks (cdr chunks)))
     shared))
@@ -1722,7 +1728,7 @@ the frames it delimits actually share a redrawn body."
         (unless (string-empty-p key)
           (push i (gethash key indices))))
       (setq i (1+ i)))
-    (let ((best nil) (best-count 0) (best-first most-positive-fixnum))
+    (let ((candidates nil))
       (maphash
        (lambda (key idxs)
          (let* ((idxs (nreverse idxs))
@@ -1730,13 +1736,27 @@ the frames it delimits actually share a redrawn body."
                 (first (car idxs)))
            (when (and (>= count tmux-control--auto-frame-min-occurrences)
                       (>= (length key) 3)
-                      (tmux-control--auto-frame-evenly-spread-p idxs)
-                      (or (> count best-count)
-                          (and (= count best-count) (< first best-first))))
-             (setq best key best-count count best-first first))))
+                      (tmux-control--auto-frame-evenly-spread-p idxs))
+             (push (list count first key) candidates))))
        indices)
-      (when (and best (tmux-control--frames-share-redraw-body-p lines best))
-        best))))
+      ;; Most frequent first, tie broken by earliest occurrence.  Accept the
+      ;; first candidate whose delimited frames actually share a redrawn body,
+      ;; rather than committing to the single most frequent line: when the
+      ;; capture starts mid-frame both frame edges recur equally often, and the
+      ;; tie-winner can be the edge sitting just above a volatile line whose
+      ;; body is unrecognisable -- the real frame top is one place down the
+      ;; list.  Also lets a mix of panels fall through to whichever genuinely
+      ;; repaints.
+      (setq candidates
+            (sort candidates
+                  (lambda (a b)
+                    (if (= (nth 0 a) (nth 0 b))
+                        (< (nth 1 a) (nth 1 b))
+                      (> (nth 0 a) (nth 0 b))))))
+      (cl-loop for cand in candidates
+               for key = (nth 2 cand)
+               when (tmux-control--frames-share-redraw-body-p lines key)
+               return key))))
 
 (defun tmux-control--strip-scrollback-chrome (lines)
   "Remove obvious TUI chrome from captured LINES."


### PR DESCRIPTION
## Problem

Scrollback compaction collapses the repeated full-screen redraws that agents like Claude Code print (the box that repaints on every token). The generic auto-detector that finds the repeated frame's top line **silently disabled itself** in two common situations — so the repeats stayed fully duplicated in scrollback:

1. **Capture starts mid-frame.** A panel's top and bottom edge each recur once per frame, so they tie on frequency. The tie-break (earliest occurrence) can land on the edge that sits *just above a volatile line* — a token counter, a clock. The share-body confirmation only looked for a shared run **starting at** the marker, hit the volatile line, and rejected the marker → no compaction.

2. **A more-frequent non-frame line.** A small panel whose shared body is under the redraw-run threshold (or a recurring separator) recurs more often than the real frame top. The detector committed to the single most frequent candidate and **gave up** if it failed confirmation, instead of trying the next.

Found while dogfooding: a repeated Claude-style box stayed at 8–11 copies in scrollback instead of collapsing to one.

## Fix

- **Confirmation matches the merge.** `--frames-share-redraw-body-p` now looks for a shared distinctive run *anywhere* in the next frame (via the same `--strip-seen-runs` the merge uses), not only one starting at the marker. A marker one line above volatile content is accepted.
- **Try candidates in order.** `--auto-frame-start-line` collects all qualifying candidates, sorts by frequency (tie-break earliest), and accepts the **first** whose frames actually share a redrawn body — falling through a sub-threshold or coincidental line to the genuine frame top.

## Verification

- **Live** (GUI Eat scrollback view): a repeated box now collapses to **1 copy** while all per-frame token lines are preserved; a mixed small+big panel history collapses the big panel and leaves the small one; genuinely plain scrollback yields **no marker** (no false collapse).
- **Unit tests** (71/71): `…-auto-compaction-marker-above-volatile-line` (marker above a volatile line still detected + collapses, volatile lines kept) and `…-auto-compaction-skips-subthreshold-frequent-line` (falls through a more-frequent sub-threshold panel to the real frame top). Existing `…-nil-on-plain` still guards against false positives.
- Clean byte-compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)