### PR TITLE
Route GUI/macOS paste to the pane instead of the Eat buffer

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -909,5 +909,17 @@ each wrapped in an evolving prompt line and a status bar.")
       (tmux-control--note-pane-activity "%1")
       (should-not (gethash "1" tmux-control--activity)))))
 
+(ert-deftest tmux-control-test-paste-remapped-to-terminal ()
+  ;; GUI / macOS paste gestures -- Cmd-V (`s-v'), the `[paste]' event, the
+  ;; Edit > Paste menu -- resolve to the `yank' / `clipboard-yank' commands.
+  ;; Eat's own map only rebinds C-y, M-y, S-insert and mouse yank, so those
+  ;; gestures otherwise fall through to plain `yank' and insert into the Eat
+  ;; buffer instead of sending to the pane.  tmux-control-mode-map must remap
+  ;; the yank commands to the terminal yank.
+  (should (eq (lookup-key tmux-control-mode-map [remap yank]) 'eat-yank))
+  (should (eq (lookup-key tmux-control-mode-map [remap clipboard-yank]) 'eat-yank))
+  (should (eq (lookup-key tmux-control-mode-map [remap yank-pop])
+              'eat-yank-from-kill-ring)))
+
 (provide 'tmux-control-test)
 ;;; tmux-control-test.el ends here

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -327,6 +327,17 @@ resulting prompt/redraw burst in every pane does not flag every window.")
     (define-key map (kbd "C-c C-t") #'tmux-control-toggle-tiling)
     (define-key map (kbd "C-c C-n") #'tmux-control-next-window)
     (define-key map (kbd "C-c C-p") #'tmux-control-previous-window)
+    ;; Route every "paste" gesture to the terminal.  Eat's own map covers
+    ;; C-y, M-y, S-insert and mouse yank, but a GUI/macOS paste -- `s-v'
+    ;; (Cmd-V), the `[paste]' event, the Edit > Paste menu -- stays bound to
+    ;; plain `yank', which inserts into the terminal buffer instead of sending
+    ;; to the pane: the text never reaches tmux, leaves stray characters in
+    ;; the buffer, and pasted into a full-screen TUI desyncs Eat.  Remap the
+    ;; yank commands so those gestures go through `eat-yank' (bracketed paste,
+    ;; chunked send-keys to the pane) exactly like C-y already does.
+    (define-key map [remap yank] #'eat-yank)
+    (define-key map [remap clipboard-yank] #'eat-yank)
+    (define-key map [remap yank-pop] #'eat-yank-from-kill-ring)
     map)
   "Keymap for `tmux-control-mode'.")
 


### PR DESCRIPTION
## Problem (reported: "weird EAT error when I pasted into a tmux window")

Eat's keymap rebinds `C-y`, `M-y`, `S-insert` and mouse yank to `eat-yank` (which sends to the terminal). But it does **not** cover the GUI / macOS paste gestures — **Cmd-V** (`s-v`), the **`[paste]`** event, and the **Edit > Paste** menu all stay bound to plain `yank`.

In a tmux-control buffer, plain `yank` inserts the text **into the Eat terminal buffer**:
- the text never reaches tmux (paste silently does nothing useful),
- it leaves stray characters in the buffer, and
- pasted while a full-screen TUI holds the cursor mid-screen, it shifts Eat's markers and desyncs the model — the "EAT error" symptom.

## Fix

Remap `yank`, `clipboard-yank`, and `yank-pop` in `tmux-control-mode-map` to Eat's terminal yanks (`eat-yank` / `eat-yank-from-kill-ring`). A `[remap yank]` catches **every** key/menu that resolves to `yank` (Cmd-V, `[paste]`, the menu) in one place, so each paste gesture goes through `eat-yank` — bracketed paste, chunked `send-keys` to the pane — exactly like `C-y` already does.

## Verification

- **Live** (GUI Eat): `s-v` and `[paste]` now resolve to `eat-yank`; a single-line paste reaches the pane; a multi-line paste arrives **intact** (piped to `cat`, every line echoes back) instead of being dropped into the buffer.
- **Unit test** (70/70): `tmux-control-test-paste-remapped-to-terminal` asserts the remaps.
- Clean byte-compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
