### PR TITLE
Fix the tiling split-double-render: feed freshly-split panes live

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,10 +156,6 @@ view):
   tile-within-a-region mode.
 - Switching windows while tiled rebuilds the new window's pane buffers, so a
   window's Emacs-side scrollback is not kept across a switch.
-- Splitting an already-tiled pane into a command that **immediately prints a
-  screenful** (a `cat`, an agent's start-up banner) can render that one pane's
-  first screen twice: the pane is both seeded from `capture-pane` and sent the
-  same content as live `%output`.  Other panes are unaffected.
 - A vertical stack spends one row on an Emacs mode line where tmux spends it on
   a pane border, so a stacked pane can sit one row short — but content is never
   clipped.

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -1053,5 +1053,44 @@ each wrapped in an evolving prompt line and a status bar.")
         (should tmux-control--retile-pending)
         (should (= reseeds 0))))))
 
+(ert-deftest tmux-control-test-eager-register-new-panes ()
+  ;; A %layout-change that introduces a new pane registers a render buffer for
+  ;; it NOW, marked fed-live, so its %output streams in live from the first
+  ;; byte and the re-tile never seeds it (which would double-paint a freshly
+  ;; split pane's opening screenful).  Existing panes are left untouched, and
+  ;; nothing happens when the controller is not tiled.
+  (let ((made '()))
+    (cl-letf (((symbol-function 'tmux-control--make-pane-buffer)
+               (lambda (pane-id &rest _)
+                 (push pane-id made)
+                 (generate-new-buffer (format " *tc-test-eager-%s*" pane-id)))))
+      (with-temp-buffer
+        (setq-local tmux-control--tiled t)
+        (let ((buf0 (generate-new-buffer " *tc-test-eager-existing*")))
+          (setq-local tmux-control--panes (list (cons "%0" buf0)))
+          (unwind-protect
+              (progn
+                ;; A horizontal split of panes %0 (existing) and %1 (new).
+                (tmux-control--eager-register-new-panes
+                 (current-buffer)
+                 "abcd,80x24,0,0{40x24,0,0,0,39x24,41,0,1}")
+                ;; Only the NEW pane is made; the existing one is not remade.
+                (should (equal made '("%1")))
+                (should (assoc "%1" tmux-control--panes))
+                (should (buffer-local-value 'tmux-control--pane-fed-live
+                                            (cdr (assoc "%1" tmux-control--panes))))
+                (should (eq (cdr (assoc "%0" tmux-control--panes)) buf0)))
+            (dolist (c tmux-control--panes)
+              (when (buffer-live-p (cdr c)) (kill-buffer (cdr c)))))))
+      ;; Not tiled: a no-op (single-pane mode owns no per-pane buffers).
+      (setq made '())
+      (with-temp-buffer
+        (setq-local tmux-control--tiled nil)
+        (setq-local tmux-control--panes nil)
+        (tmux-control--eager-register-new-panes
+         (current-buffer) "abcd,80x24,0,0{40x24,0,0,0,39x24,41,0,1}")
+        (should (null made))
+        (should (null tmux-control--panes))))))
+
 (provide 'tmux-control-test)
 ;;; tmux-control-test.el ends here

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -2105,7 +2105,14 @@ the matching pane's render buffer instead, so every pane updates at once."
       ;; mode reconcile the active pane's size and refresh the pane->window map
       ;; (panes came or went) for the tab bar's activity marker.
       (if tmux-control--tiled
-          (setq tmux-control--retile-pending t)
+          (progn
+            ;; Register any just-appeared pane NOW, from the layout this line
+            ;; carries, so its %output (which follows) streams in live from the
+            ;; first byte; the debounced re-tile then places it without seeding
+            ;; it (avoiding the split-into-a-screenful double-render).
+            (tmux-control--eager-register-new-panes
+             (current-buffer) (nth 2 (split-string line " ")))
+            (setq tmux-control--retile-pending t))
         (tmux-control--refresh-pane-size)
         (tmux-control--refresh-pane-window-map)))
      ((string-prefix-p "%session-window-changed " line)
@@ -2901,6 +2908,16 @@ that previously ran for every re-tile."
 (defvar-local tmux-control--pane-info nil
   "Plist of a tiled render buffer's tmux pane metadata, for its mode line.")
 
+(defvar-local tmux-control--pane-fed-live nil
+  "Non-nil in a tiled render buffer that was created the moment its pane
+appeared (a split), so its `%output' has streamed in from the pane's very
+first byte.  Such a pane is never seeded from `capture-pane': the live stream
+already holds its whole content, and a capture seed would paint a second copy
+of the screenful a freshly-split pane often prints at once (a `cat', an
+agent's start-up banner).  Set by `tmux-control--eager-register-new-panes';
+honored by `tmux-control--build-tiling', which resizes such a pane (Eat
+reflows) but does not reseed it.")
+
 (defun tmux-control--pane-mode-line ()
   "Return a concise mode-line string for a tiled pane render buffer.
 Leads with the pane id (so teammates in a split window are easy to tell
@@ -2993,6 +3010,41 @@ its own and routes commands through CONTROLLER."
       (tmux-control--disable-line-numbers)
       (tmux-control--disable-margins))
     buffer))
+
+(defun tmux-control--eager-register-new-panes (controller layout)
+  "Register render buffers for panes that are new in LAYOUT, fed live.
+LAYOUT is the window-layout string from a `%layout-change' (a split, a pane
+close).  A pane that just appeared has not been rendered yet; create its
+buffer NOW -- synchronously, from the layout already in hand, no CLI -- and
+add it to `tmux-control--panes' so its `%output' (which tmux sends strictly
+after this notification) streams straight in from the pane's first byte
+instead of being dropped for want of a buffer.  Mark it `fed-live' so the
+debounced `tmux-control--build-tiling' that follows does NOT also seed it from
+`capture-pane': the live stream is already the pane's whole content, and a
+seed would paint a second copy of the screenful a freshly-split pane often
+dumps at once.  A window SWITCH sends `%session-window-changed', not
+`%layout-change', so its pre-existing panes are not registered here and are
+still seeded normally."
+  (when (buffer-live-p controller)
+    (with-current-buffer controller
+      (when tmux-control--tiled
+        (let* ((tree (tmux-control--parse-layout layout))
+               (leaves (and tree (tmux-control--layout-leaves tree)))
+               (meta (list :host tmux-control--host
+                           :socket tmux-control--socket-name
+                           :session tmux-control--session
+                           :trailing tmux-control--capture-trailing-p
+                           :process tmux-control--process
+                           :fallback tmux-control--fallback-target)))
+          (dolist (leaf leaves)
+            (let ((pane (concat "%" (plist-get leaf :id))))
+              (unless (assoc pane tmux-control--panes)
+                (let ((buf (tmux-control--make-pane-buffer
+                            pane leaf controller meta)))
+                  (with-current-buffer buf
+                    (setq tmux-control--pane-fed-live t))
+                  (setq tmux-control--panes
+                        (cons (cons pane buf) tmux-control--panes)))))))))))
 
 (defun tmux-control--pane-buffer-killed ()
   "Recover a tiled pane buffer killed by the user, by scheduling a re-tile."
@@ -3237,8 +3289,20 @@ screen.  Safe to call repeatedly; a %layout-change routes here."
                                    (eat-term-live-p tmux-control--terminal))
                           (let ((sz (eat-term-size tmux-control--terminal)))
                             (unless (and sz (= (car sz) w) (= (cdr sz) h))
-                              (setq seed t)
-                              (eat-term-resize tmux-control--terminal w h)))))
+                              ;; A fed-live pane (registered the moment it
+                              ;; appeared) is not seeded on this first placement
+                              ;; -- its %output is streaming the whole content,
+                              ;; so a capture seed would double-paint.  Still
+                              ;; resize, so Eat reflows.
+                              (unless tmux-control--pane-fed-live
+                                (setq seed t))
+                              (eat-term-resize tmux-control--terminal w h))))
+                        ;; The fed-live skip is for the opening placement only.
+                        ;; Clear it now so a LATER resize reseeds normally: by
+                        ;; then the pane is quiescent (no seed/stream race), and
+                        ;; Eat's own reflow can drift from tmux's grid on a
+                        ;; shrink, so a capture seed keeps it cell-exact.
+                        (setq tmux-control--pane-fed-live nil))
                       (push (cons pane buf) new-panes)
                       (when seed (push buf to-seed))))))
               (setq new-panes (nreverse new-panes))

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -2911,12 +2911,15 @@ that previously ran for every re-tile."
 (defvar-local tmux-control--pane-fed-live nil
   "Non-nil in a tiled render buffer that was created the moment its pane
 appeared (a split), so its `%output' has streamed in from the pane's very
-first byte.  Such a pane is never seeded from `capture-pane': the live stream
-already holds its whole content, and a capture seed would paint a second copy
-of the screenful a freshly-split pane often prints at once (a `cat', an
-agent's start-up banner).  Set by `tmux-control--eager-register-new-panes';
-honored by `tmux-control--build-tiling', which resizes such a pane (Eat
-reflows) but does not reseed it.")
+first byte.  Set by `tmux-control--eager-register-new-panes' and honored by
+`tmux-control--build-tiling' to skip seeding such a pane from `capture-pane'
+on its INITIAL placement: the live stream already holds its whole content, so
+a capture seed would paint a second copy of the screenful a freshly-split
+pane often prints at once (a `cat', an agent's start-up banner).  The pane is
+still resized (Eat reflows) on that first placement.  build-tiling then clears
+this flag, so a LATER resize reseeds the pane normally -- by then it is
+quiescent, so the seed cannot race output, and a reseed keeps it cell-exact
+where Eat's own reflow could have drifted from tmux's grid.")
 
 (defun tmux-control--pane-mode-line ()
   "Return a concise mode-line string for a tiled pane render buffer.


### PR DESCRIPTION
## Problem

A pane **split off an already-tiled window** often prints a screenful at once — a `cat`, an agent's start-up banner. `build-tiling` created the new pane's render buffer and **seeded it from `capture-pane`**, while tmux **also** streamed that same output as live `%output`. The pane rendered its opening screen **twice**: the seed, plus the late `%output` that arrived after it. The out-of-band CLI capture had no ordering relationship with the in-band `%output` stream, so the overlap couldn't be deduped. (Other panes were unaffected; this was the last documented tiled-view limitation.)

## Fix — eager-register on `%layout-change`

The key is *which notification fires*:
- a **split** sends `%layout-change` (carrying the new layout) **before** the new pane's `%output`;
- a window **switch** sends `%session-window-changed`.

So on `%layout-change`, create a render buffer for any just-appeared pane **immediately** — synchronously, from the layout already in the notification, **no CLI** — and add it to the pane registry so its `%output` streams in from the very first byte instead of being dropped. Mark it **fed-live**: `build-tiling` then *places* it without seeding, because the live stream is already the pane's whole content.

- **Window-switch panes** (`%session-window-changed`, not `%layout-change`) are not eager-registered, so they still go through the `capture-pane` seed — unchanged.
- The fed-live mark is **cleared after the first placement**, so a later **resize** still reseeds: Eat's own reflow can drift from tmux's grid on a shrink, and by then the pane is quiescent, so the seed can't race output.

The eager-register does no CLI and runs in the filter, so it doesn't reintroduce the SSH-blocking the tiling debounce was built to avoid.

## Verification (live, GUI Eat — per-pane oracle vs `capture-pane`)

- **split into an immediate dump** → renders **once** (was twice)
- split into **vim** (alt-screen), **multiple** splits, a **non-dumping** split → all MATCH
- **switching windows** while tiled → the new window's panes are still seeded → MATCH
- **resize** grow **and** shrink → fed-live pane reseeds after placement → MATCH (shrink previously drifted)
- the **same over SSH** to a remote host → MATCH, dump rendered once

Clean byte-compile; **75/75** unit tests including `tmux-control-test-eager-register-new-panes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
