### PR TITLE
Session switcher: flip between tmux sessions like tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ attaches, typing a new name creates it.
   terminal and no tmux chrome.
 - **Windows as tabs** in a header-line tab bar, with an activity **dot** on
   background windows; flip them like browser tabs (`C-c C-n` / `C-c C-p`).
+- **Switch between sessions** on the host in place (`C-c C-s`) — each tmux
+  session is its own buffer with its own scrollback and tabs.
 - **Scrollback** as ordinary Emacs text (`C-c C-e`), auto-collapsing repeated
   full-screen redraws.
 - **Tiled view** (`C-c C-t`, experimental) — every pane of a window at once,

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -45,7 +45,11 @@ like tabs, **in place** in the current window:
 - `C-c C-s` (`tmux-control-select-session`) prompts for a session on the same
   host and socket, completing over the ones that exist there, and switches the
   view to it.  Picking a session that is already connected reuses its live
-  buffer (no respawn); picking a fresh one connects it on the spot.
+  buffer (no respawn); picking one that exists in tmux but isn't shown yet
+  connects it on the spot.  The prompt requires a match, so a typo can't
+  accidentally spawn a session — to *create* one, use `M-x
+  tmux-control-connect` (which attaches an existing session or creates a new
+  one).
 - `M-x tmux-control-next-session` and `M-x tmux-control-previous-session` step
   to the next/previous session in tmux's list order, wrapping around — a quick
   way to cycle a small set without the prompt.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -8,8 +8,8 @@ that session).
 
 ## Window and session management
 
-These commands act on the connected session (`C-c C-n`/`C-c C-p` are bound in
-the live buffer; the rest are `M-x`, bind them to taste):
+These commands act on the connected session (`C-c C-n`/`C-c C-p`/`C-c C-s` are
+bound in the live buffer; the rest are `M-x`, bind them to taste):
 
 - `M-x tmux-control-select-window` switches the live view to another window.
   By default it opens a two-pane chooser with a live preview of the
@@ -34,6 +34,27 @@ the live buffer; the rest are `M-x`, bind them to taste):
 
 Switching, creating, or removing a window changes the session's active
 window, so any other client attached to the same session follows along.
+
+### Switching sessions
+
+A host/socket usually runs **several tmux sessions** (one per project, say).
+`tmux-control` gives each its own buffer and control connection — so each keeps
+its own scrollback, tab bar, and activity state — and lets you flip between them
+like tabs, **in place** in the current window:
+
+- `C-c C-s` (`tmux-control-select-session`) prompts for a session on the same
+  host and socket, completing over the ones that exist there, and switches the
+  view to it.  Picking a session that is already connected reuses its live
+  buffer (no respawn); picking a fresh one connects it on the spot.
+- `M-x tmux-control-next-session` and `M-x tmux-control-previous-session` step
+  to the next/previous session in tmux's list order, wrapping around — a quick
+  way to cycle a small set without the prompt.
+
+Switching replaces the session in the **selected window** (it does not split the
+frame or rearrange your other Emacs windows), so a code buffer beside the live
+view stays put.  Because every session is its own buffer, you can also just keep
+several open and switch with the ordinary `C-x b` / `switch-to-buffer`; the
+session commands are the tmux-aware shortcut.
 
 ### The window tab bar
 

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -1111,5 +1111,40 @@ each wrapped in an evolving prompt line and a status bar.")
         (should (null made))
         (should (null tmux-control--panes))))))
 
+(ert-deftest tmux-control-test-cycle-session-wraps ()
+  ;; next/previous-session step through the host/socket's sessions in tmux's
+  ;; list order, wrapping at the ends, routing the target through
+  ;; --connect-or-switch (reuse-or-connect).
+  (with-temp-buffer
+    (setq-local tmux-control--host nil)
+    (setq-local tmux-control--socket-name "s")
+    (setq-local tmux-control--session "b")
+    (let ((switched nil))
+      (cl-letf (((symbol-function 'tmux-control--list-sessions)
+                 (lambda (_host _socket) '("a" "b" "c")))
+                ((symbol-function 'tmux-control--connect-or-switch)
+                 (lambda (_host _socket session) (setq switched session))))
+        (tmux-control-next-session)       (should (equal switched "c"))
+        (tmux-control-previous-session)   (should (equal switched "a"))
+        (setq-local tmux-control--session "c")
+        (tmux-control-next-session)       (should (equal switched "a"))   ; wrap fwd
+        (setq-local tmux-control--session "a")
+        (tmux-control-previous-session)   (should (equal switched "c")))))) ; wrap back
+
+(ert-deftest tmux-control-test-cycle-session-single-is-noop ()
+  ;; With only the current session present, cycling does nothing.
+  (with-temp-buffer
+    (setq-local tmux-control--host nil)
+    (setq-local tmux-control--socket-name "s")
+    (setq-local tmux-control--session "only")
+    (let ((switched nil))
+      (cl-letf (((symbol-function 'tmux-control--list-sessions)
+                 (lambda (_host _socket) '("only")))
+                ((symbol-function 'tmux-control--connect-or-switch)
+                 (lambda (&rest _) (setq switched t)))
+                ((symbol-function 'tmux-control--message) #'ignore))
+        (tmux-control-next-session)
+        (should-not switched)))))
+
 (provide 'tmux-control-test)
 ;;; tmux-control-test.el ends here

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -1131,6 +1131,24 @@ each wrapped in an evolving prompt line and a status bar.")
         (setq-local tmux-control--session "a")
         (tmux-control-previous-session)   (should (equal switched "c")))))) ; wrap back
 
+(ert-deftest tmux-control-test-select-session-requires-match ()
+  ;; C-c C-s must not let a typo spawn a session: completing-read is called
+  ;; with REQUIRE-MATCH non-nil, so only an existing session can be chosen.
+  (with-temp-buffer
+    (setq-local tmux-control--host nil)
+    (setq-local tmux-control--socket-name "s")
+    (setq-local tmux-control--session "a")
+    (let ((require-match-arg 'unset))
+      (cl-letf (((symbol-function 'tmux-control--list-sessions)
+                 (lambda (_host _socket) '("a" "b")))
+                ((symbol-function 'completing-read)
+                 (lambda (_prompt _coll &optional _pred require-match &rest _)
+                   (setq require-match-arg require-match)
+                   "b"))
+                ((symbol-function 'tmux-control--connect-or-switch) #'ignore))
+        (tmux-control-select-session)
+        (should require-match-arg)))))
+
 (ert-deftest tmux-control-test-cycle-session-single-is-noop ()
   ;; With only the current session present, cycling does nothing.
   (with-temp-buffer

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -317,6 +317,7 @@ kills, which are deliberate.")
     (define-key map (kbd "C-c C-t") #'tmux-control-toggle-tiling)
     (define-key map (kbd "C-c C-n") #'tmux-control-next-window)
     (define-key map (kbd "C-c C-p") #'tmux-control-previous-window)
+    (define-key map (kbd "C-c C-s") #'tmux-control-select-session)
     (define-key map [wheel-up] #'tmux-control-wheel-scroll)
     map)
   "High-precedence keymap for tmux-control buffers.")
@@ -353,6 +354,7 @@ resulting prompt/redraw burst in every pane does not flag every window.")
     (define-key map (kbd "C-c C-t") #'tmux-control-toggle-tiling)
     (define-key map (kbd "C-c C-n") #'tmux-control-next-window)
     (define-key map (kbd "C-c C-p") #'tmux-control-previous-window)
+    (define-key map (kbd "C-c C-s") #'tmux-control-select-session)
     ;; Route every "paste" gesture to the terminal.  Eat's own map covers
     ;; C-y, M-y, S-insert and mouse yank, but a GUI/macOS paste -- `s-v'
     ;; (Cmd-V), the `[paste]' event, the Edit > Paste menu -- stays bound to
@@ -518,6 +520,80 @@ session (tmux attaches if it exists, otherwise creates it)."
          (format "refresh-client -f pause-after=%d" tmux-control-pause-after)))
       (tmux-control--disable-line-numbers))
     buffer))
+
+(defun tmux-control--session-live-buffer (host session)
+  "Return the live tmux-control buffer already showing HOST/SESSION, or nil.
+Mirrors `tmux-control-connect's buffer naming so a session that is already
+connected is reused instead of respawned."
+  (let* ((local (or (null host) (string-empty-p host)))
+         (buffer (get-buffer (format "*tmux-control:%s:%s*"
+                                     (if local "local" host) session))))
+    (when (and buffer
+               (buffer-live-p buffer)
+               (process-live-p (buffer-local-value 'tmux-control--process buffer)))
+      buffer)))
+
+(defun tmux-control--connect-or-switch (host socket-name session)
+  "Show SESSION on HOST/SOCKET-NAME, reusing a live connection if there is one.
+Each tmux session is its own tmux-control buffer with its own control
+connection (so each keeps its scrollback and tab-bar state); switching means
+showing that buffer, or connecting it the first time.
+
+The view switches *in place*: the target replaces the current session in the
+selected window (like flipping a terminal tab) instead of splitting the frame,
+even when `tmux-control-connect' would otherwise pop a new window."
+  (let ((buffer (tmux-control--session-live-buffer host session))
+        (display-buffer-overriding-action '((display-buffer-same-window))))
+    (if buffer
+        (pop-to-buffer buffer)
+      (tmux-control-connect host socket-name session))))
+
+;;;###autoload
+(defun tmux-control-select-session ()
+  "Switch the view to another tmux session on the same host and socket.
+Completes over the sessions that currently exist there; an existing
+connection is reused, otherwise the session is connected.  Bound to
+\\`C-c C-s'.  See also `tmux-control-next-session'."
+  (interactive)
+  (unless tmux-control--session
+    (user-error "Not in a tmux-control session buffer"))
+  (let* ((host tmux-control--host)
+         (socket tmux-control--socket-name)
+         (sessions (tmux-control--list-sessions host socket))
+         (choice (completing-read
+                  (format "Session (current: %s): " tmux-control--session)
+                  sessions nil nil)))
+    (when (and choice (not (string-empty-p choice)))
+      (tmux-control--connect-or-switch host socket choice))))
+
+(defun tmux-control--cycle-session (delta)
+  "Switch to the session DELTA steps from the current one (wrapping).
+Cycles over the sessions that exist on this buffer's host and socket, in
+tmux's own list order, connecting the target on demand."
+  (unless tmux-control--session
+    (user-error "Not in a tmux-control session buffer"))
+  (let* ((host tmux-control--host)
+         (socket tmux-control--socket-name)
+         (sessions (tmux-control--list-sessions host socket)))
+    (cond
+     ((null sessions) (tmux-control--message "No sessions to switch to"))
+     ((not (cdr sessions)) (tmux-control--message "Only one session"))
+     (t (let* ((n (length sessions))
+               (cur (or (cl-position tmux-control--session sessions :test #'equal) 0))
+               (next (nth (mod (+ cur delta) n) sessions)))
+          (tmux-control--connect-or-switch host socket next))))))
+
+;;;###autoload
+(defun tmux-control-next-session ()
+  "Switch to the next tmux session on this host/socket, wrapping around."
+  (interactive)
+  (tmux-control--cycle-session 1))
+
+;;;###autoload
+(defun tmux-control-previous-session ()
+  "Switch to the previous tmux session on this host/socket, wrapping around."
+  (interactive)
+  (tmux-control--cycle-session -1))
 
 (defun tmux-control-disconnect ()
   "Disconnect the current tmux-control client."

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -551,9 +551,11 @@ even when `tmux-control-connect' would otherwise pop a new window."
 ;;;###autoload
 (defun tmux-control-select-session ()
   "Switch the view to another tmux session on the same host and socket.
-Completes over the sessions that currently exist there; an existing
-connection is reused, otherwise the session is connected.  Bound to
-\\`C-c C-s'.  See also `tmux-control-next-session'."
+Completes over the sessions that currently exist there, requiring a match so
+a typo cannot accidentally spawn a new session; an existing connection is
+reused, otherwise the session is connected.  Bound to \\`C-c C-s'.  To
+*create* a session, use `tmux-control-connect' (which attaches or creates).
+See also `tmux-control-next-session'."
   (interactive)
   (unless tmux-control--session
     (user-error "Not in a tmux-control session buffer"))
@@ -562,7 +564,7 @@ connection is reused, otherwise the session is connected.  Bound to
          (sessions (tmux-control--list-sessions host socket))
          (choice (completing-read
                   (format "Session (current: %s): " tmux-control--session)
-                  sessions nil nil)))
+                  sessions nil t)))
     (when (and choice (not (string-empty-p choice)))
       (tmux-control--connect-or-switch host socket choice))))
 


### PR DESCRIPTION
## What

A host/socket usually runs several tmux sessions (one per project). `tmux-control` already gives each session its own buffer and control connection — this adds first-class commands to move the live view between them, like flipping tabs:

- **`tmux-control-select-session`** (`C-c C-s`) — prompt with completion over the sessions that exist on the current buffer's host/socket, and switch to the chosen one.
- **`tmux-control-next-session`** / **`tmux-control-previous-session`** — cycle through them in tmux's list order, wrapping around.

## How it behaves

- **Reuse-or-connect.** An already-connected session pops to its live buffer (same control connection, scrollback, and tab-bar state preserved); a fresh one is connected on the spot. Backed by new helpers `--session-live-buffer` (name-mirroring lookup) and `--connect-or-switch`.
- **In place.** The target replaces the current session in the *selected window* instead of splitting the frame — done by binding `display-buffer-overriding-action` to `display-buffer-same-window` around the connect/switch, so even the first-time-connect path (which otherwise pops a new window) reuses the current one. A code buffer beside the live view stays put.
- `C-c C-s` is bound in both the high-precedence override map (beats Eat's bindings) and the major-mode map, matching the window-nav keys.

## Testing

Verified **live** in a GUI Emacs against an isolated 3-session tmux (`alpha`/`beta`/`gamma`):

- forward and backward cycling, with wrap at both ends;
- in-place switching — window count stays `1` across switches (no frame split);
- **buffer reuse** — same process object after switching away and back (`same-process=t`);
- the `C-c C-s` binding resolves to `tmux-control-select-session` in the live buffer;
- `select-session` via the completing-read prompt.

Two unit tests added: cycle math (wrap both directions) and the single-session no-op. Full suite green (78/78), byte-compile clean. Docs updated in `README.md` and `docs/guide.md` (new *Switching sessions* section).

## Known follow-ups (not in this PR)

- Switching sessions *from a tiled view* replaces only the selected pane-window; tiling already owns the whole frame, so this is an uncommon path. A cleaner interaction (untile-then-switch, or per-session tiling) can come with the broader multi-session "flock" view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
