### PR TITLE
Flock the dashboard in its own frame (beside your code)

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -105,6 +105,22 @@ Like the tiled view it takes the **whole frame** and resizes each session to
 its cell, so a session also attached elsewhere (another client) follows tmux's
 `window-size` rule.  Experimental.
 
+#### Watching the flock beside your code
+
+Because the flock owns a whole frame, the clean way to keep a **code buffer in
+view at the same time** is a second Emacs *frame* (a separate OS window — put it
+on another monitor if you have one).  `M-x tmux-control-flock-other-frame`
+creates (or raises) a dedicated *“sessions”* frame and flocks there, leaving
+your current frame on your code; re-run it to refresh and raise that frame
+(`C-u` connects the whole host first, as above).  The flock and its on/off
+state are per-frame, so the two never interfere.
+
+A *single* session needs none of this — the single-pane view is just a buffer,
+so put one next to your code with an ordinary `C-x 3` split or pop it to its own
+frame with `C-x 5 b`.  And the activity dot is frame-aware: a session is flagged
+only when it is not visible on *any* frame, so a sessions frame you can see
+won’t throw false dots, and one you’ve hidden will.
+
 ### The window tab bar
 
 In the single-pane view, a **tab bar** in the header line lists the session's

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -1278,5 +1278,23 @@ each wrapped in an evolving prompt line and a status bar.")
                 (should-not tmux-control--session-activity)))))   ; self-cleared
       (kill-buffer self) (kill-buffer other) (kill-buffer quiet))))
 
+(ert-deftest tmux-control-test-flock-other-frame-ordering ()
+  ;; flock-other-frame: with a prefix it connects all first, then focuses the
+  ;; dedicated frame and flocks; without a prefix it skips connect-all.
+  (let ((calls '()))
+    (cl-letf (((symbol-function 'tmux-control--connect-all-sessions)
+               (lambda () (push 'connect-all calls)))
+              ((symbol-function 'tmux-control--sessions-frame)
+               (lambda () (push 'frame calls) 'dummy-frame))
+              ((symbol-function 'select-frame-set-input-focus)
+               (lambda (_f) (push 'focus calls)))
+              ((symbol-function 'tmux-control-flock)
+               (lambda (&rest _) (push 'flock calls))))
+      (tmux-control-flock-other-frame t)
+      (should (equal (nreverse calls) '(connect-all frame focus flock)))
+      (setq calls '())
+      (tmux-control-flock-other-frame nil)
+      (should (equal (nreverse calls) '(frame focus flock))))))
+
 (provide 'tmux-control-test)
 ;;; tmux-control-test.el ends here

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -738,7 +738,8 @@ before flocking (see `tmux-control-flock')."
     (tmux-control-flock connect-all)))
 
 (defun tmux-control--sessions-frame ()
-  "Return the dedicated sessions frame, creating and raising it if needed."
+  "Return the dedicated sessions frame, creating it if there isn't one.
+The caller raises and focuses it (see `tmux-control-flock-other-frame')."
   (let ((frame (seq-find (lambda (fr) (frame-parameter fr 'tmux-control-sessions-frame))
                          (frame-list))))
     (if (frame-live-p frame)

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -737,6 +737,37 @@ before flocking (see `tmux-control-flock')."
       (tmux-control-unflock)
     (tmux-control-flock connect-all)))
 
+(defun tmux-control--sessions-frame ()
+  "Return the dedicated sessions frame, creating and raising it if needed."
+  (let ((frame (seq-find (lambda (fr) (frame-parameter fr 'tmux-control-sessions-frame))
+                         (frame-list))))
+    (if (frame-live-p frame)
+        frame
+      (make-frame '((name . "tmux-control — sessions")
+                    (tmux-control-sessions-frame . t))))))
+
+;;;###autoload
+(defun tmux-control-flock-other-frame (&optional connect-all)
+  "Flock every connected session in a separate, reusable frame.
+Creates (or raises) a dedicated \"sessions\" frame and runs
+`tmux-control-flock' there, so you can watch every session beside your code
+\(or on another monitor) instead of giving the current frame to the grid --
+the flock devotes a whole frame, so a second frame is the clean way to keep
+a code buffer in view.  Re-run it to refresh and raise that frame.
+
+\(A single session needs none of this: the single-pane view is just a buffer,
+so put one beside your code with an ordinary window split or `C-x 5 b'.)
+
+With a prefix argument CONNECT-ALL, connect every session on this buffer's
+host/socket first (run it from a session buffer so the host is known)."
+  (interactive "P")
+  ;; Connect-all needs this buffer's host/socket, so do it before leaving for
+  ;; the (buffer-agnostic) sessions frame.
+  (when connect-all
+    (tmux-control--connect-all-sessions))
+  (select-frame-set-input-focus (tmux-control--sessions-frame))
+  (tmux-control-flock))
+
 (defun tmux-control-disconnect ()
   "Disconnect the current tmux-control client."
   (interactive)


### PR DESCRIPTION
## What

`tmux-control-flock-other-frame` — pop the all-sessions dashboard into a **dedicated, reusable Emacs frame**, so you can watch the fleet *while keeping a code buffer in view*. The motivating case: driving an agent framework (a session per agent) and wanting the overview beside your work.

## Why a frame

The flock (like the tiled pane view) devotes a **whole frame**, so it can't share a frame with code. A second frame (a separate OS window, or another monitor) is the clean fit — and the flock is already frame-local (its `delete-other-windows`, grid, and on/off state are per-frame), so this is a thin convenience over what already works manually (`C-x 5 2` then `C-c C-f`).

- `tmux-control-flock-other-frame` creates (or raises) a dedicated *"sessions"* frame (`--sessions-frame`, tagged with a frame parameter so it's reused) and flocks there, leaving your current frame on your code. Re-run to refresh/raise it.
- A prefix arg connects every host session first (done before leaving the current buffer, since connect-all needs its host/socket).

## A single session needs nothing new

The single-pane view is just a buffer, so `C-x 3` (split) or `C-x 5 b` (other frame) already puts one session beside your code — documented that too, along with the multi-frame workflow and the frame-aware activity dot (a session is flagged only when not visible on *any* frame).

## Verified live

Two GUI frames: `tmux-control-flock-other-frame` created a "tmux-control — sessions" frame with the 3-session flock (`flocked=t`, 3 windows) while the main frame **stayed on README.md** (`frames=3, main-still-shows=README.md`). Screenshot: the dashboard as its own OS window.

Unit test covers the connect-all → focus-frame → flock ordering and the no-prefix path. 85 unit green, byte-compile clean. Guide updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
