### PR TITLE
Inline preview for session switching

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -65,7 +65,11 @@ like tabs, **in place** in the current window:
   connects it on the spot.  The prompt requires a match, so a typo can't
   accidentally spawn a session — to *create* one, use `M-x
   tmux-control-connect` (which attaches an existing session or creates a new
-  one).
+  one).  With `tmux-control-session-preview` (default t) and `consult`, each
+  *already-connected* session is previewed in place as you move through the
+  candidates — like the window `inline` preview above — and cancelling restores
+  the session you came from.  Set `tmux-control-session-preview` to nil for a
+  plain prompt.
 - `M-x tmux-control-next-session` and `M-x tmux-control-previous-session` step
   to the next/previous session in tmux's list order, wrapping around — a quick
   way to cycle a small set without the prompt.

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -1332,5 +1332,44 @@ each wrapped in an evolving prompt line and a status bar.")
       ;; previewed window 1, then restored the original active window 0
       (should (equal (nreverse switched) '("1" "0"))))))
 
+(ert-deftest tmux-control-test-read-with-preview-cancel-calls-restore ()
+  ;; The shared preview reader previews the navigated candidate and, on a
+  ;; `quit', invokes RESTORE (and does not return a value).
+  (let ((previewed nil) (restored nil))
+    (cl-letf (((symbol-function 'consult--read)
+               (lambda (_cands &rest opts)
+                 (funcall (plist-get opts :state) 'preview "x")
+                 (signal 'quit nil))))
+      (ignore-error quit
+        (tmux-control--read-with-preview
+         "P: " '(("x" . 1) ("y" . 2))
+         (lambda (v) (setq previewed v))
+         (lambda () (setq restored t))))
+      (should (eq previewed 1))
+      (should restored))))
+
+(ert-deftest tmux-control-test-session-inline-previews-connected-commits ()
+  ;; Session preview shows an already-connected session in place (not an
+  ;; unconnected one) and commits the chosen session via --connect-or-switch.
+  (let ((bbuf (generate-new-buffer " tc-test-b"))
+        (previewed '()) (committed nil))
+    (unwind-protect
+        (cl-letf (((symbol-function 'tmux-control--session-live-buffer)
+                   (lambda (_host s) (when (equal s "b") bbuf))) ; only "b" connected
+                  ((symbol-function 'set-window-buffer)
+                   (lambda (_w buf) (push buf previewed)))
+                  ((symbol-function 'tmux-control--connect-or-switch)
+                   (lambda (_h _s session) (setq committed session)))
+                  ((symbol-function 'consult--read)
+                   (lambda (_cands &rest opts)
+                     (funcall (plist-get opts :state) 'preview "a (current)") ; unconnected → skip
+                     (funcall (plist-get opts :state) 'preview "b")           ; connected → preview
+                     "b")))
+          (tmux-control--select-session-inline nil "sock" '("a" "b" "c") "a")
+          (should (memq bbuf previewed))        ; previewed b's buffer
+          (should-not (memq nil previewed))     ; unconnected "a" did not preview
+          (should (equal committed "b")))       ; committed b
+      (kill-buffer bbuf))))
+
 (provide 'tmux-control-test)
 ;;; tmux-control-test.el ends here

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -174,6 +174,16 @@ is forwarded to the terminal unchanged."
                  (const :tag "Minibuffer + inline preview" inline)
                  (const :tag "Plain completion, no preview" nil)))
 
+(defcustom tmux-control-session-preview t
+  "Non-nil previews sessions in place as you choose one with completion.
+When `tmux-control-select-session' prompts, each *already-connected* session is
+shown in the live window as you move through the candidates (an unconnected
+session is not previewed -- it would have to be connected first); cancelling
+restores the session you came from.  Like the window `inline' preview, this
+needs `consult' and degrades to a plain prompt without it.  Set to nil for a
+plain prompt."
+  :type 'boolean)
+
 (defcustom tmux-control-window-preview-delay 0.15
   "Idle seconds to wait before refreshing the window preview as you move.
 
@@ -580,6 +590,28 @@ even when `tmux-control-connect' would otherwise pop a new window."
         (pop-to-buffer buffer)
       (tmux-control-connect host socket-name session))))
 
+(defun tmux-control--select-session-inline (host socket sessions current)
+  "Choose a session in the minibuffer, previewing connected ones in place.
+Each already-connected session is shown in the live window as you move through
+the candidates; an unconnected one is not previewed.  Cancelling restores the
+session you came from.  Uses `consult'."
+  (let* ((window (selected-window))
+         (orig-buffer (window-buffer window))
+         (choices (mapcar (lambda (s)
+                            (cons (if (equal s current) (concat s " (current)") s) s))
+                          sessions))
+         (choice (tmux-control--read-with-preview
+                  (format "Session (current: %s): " current) choices
+                  (lambda (s)
+                    (when-let* ((buf (tmux-control--session-live-buffer host s)))
+                      (when (window-live-p window) (set-window-buffer window buf))))
+                  (lambda ()
+                    (when (and (window-live-p window) (buffer-live-p orig-buffer))
+                      (set-window-buffer window orig-buffer)))
+                  'tmux-control-session)))
+    (when (and choice (not (string-empty-p choice)))
+      (tmux-control--connect-or-switch host socket choice))))
+
 ;;;###autoload
 (defun tmux-control-select-session ()
   "Switch the view to another tmux session on the same host and socket.
@@ -587,18 +619,22 @@ Completes over the sessions that currently exist there, requiring a match so
 a typo cannot accidentally spawn a new session; an existing connection is
 reused, otherwise the session is connected.  Bound to \\`C-c C-s'.  To
 *create* a session, use `tmux-control-connect' (which attaches or creates).
-See also `tmux-control-next-session'."
+With `tmux-control-session-preview' (and `consult'), connected sessions are
+previewed in place as you choose.  See also `tmux-control-next-session'."
   (interactive)
   (unless tmux-control--session
     (user-error "Not in a tmux-control session buffer"))
   (let* ((host tmux-control--host)
          (socket tmux-control--socket-name)
-         (sessions (tmux-control--list-sessions host socket))
-         (choice (completing-read
-                  (format "Session (current: %s): " tmux-control--session)
-                  sessions nil t)))
-    (when (and choice (not (string-empty-p choice)))
-      (tmux-control--connect-or-switch host socket choice))))
+         (current tmux-control--session)
+         (sessions (tmux-control--list-sessions host socket)))
+    (if (and tmux-control-session-preview (fboundp 'consult--read))
+        (tmux-control--select-session-inline host socket sessions current)
+      (let ((choice (completing-read
+                     (format "Session (current: %s): " current)
+                     sessions nil t)))
+        (when (and choice (not (string-empty-p choice)))
+          (tmux-control--connect-or-switch host socket choice))))))
 
 (defun tmux-control--cycle-session (delta)
   "Switch to the session DELTA steps from the current one (wrapping).
@@ -926,51 +962,55 @@ tmux runs with `alternate-screen off'."
     (or (cdr (assoc choice choices))
         (car (split-string choice ":")))))
 
+(defun tmux-control--read-with-preview (prompt choices preview restore &optional category)
+  "Read a value from CHOICES with PROMPT, previewing each candidate live.
+CHOICES is an alist of (DISPLAY . VALUE).  PREVIEW is called with a VALUE as
+you move through candidates (a live in-place preview); RESTORE is called with
+no arguments if you cancel, to undo the previews.  Returns the selected VALUE
+\(the caller commits it), or nil.  Uses `consult' for the live preview;
+without it, a plain completion prompt with no preview."
+  (if (not (fboundp 'consult--read))
+      (cdr (assoc (completing-read prompt choices nil t) choices))
+    (let ((committed nil))
+      (unwind-protect
+          (prog1 (cdr (assoc
+                       (consult--read
+                        (mapcar #'car choices)
+                        :prompt prompt :require-match t :sort nil
+                        :category (or category 'tmux-control)
+                        :state (lambda (action cand)
+                                 (when (and (eq action 'preview) cand)
+                                   (when-let* ((value (cdr (assoc cand choices))))
+                                     (funcall preview value)))))
+                       choices))
+            (setq committed t))
+        (unless committed (funcall restore))))))
+
 (defun tmux-control--select-window-inline ()
   "Choose a window in the minibuffer, previewing each candidate in place.
-Uses `consult' for live per-candidate preview when available -- the live view
-switches to the highlighted window as you move, and is restored to the window
-you came from if you cancel.  Without `consult', falls back to a plain prompt."
-  (let ((choices (tmux-control--window-choices)))
-    (if (not (fboundp 'consult--read))
-        (tmux-control--do-select-window
-         (tmux-control--normalize-window-index
-          (or (cdr (assoc (completing-read "Window: " choices nil t) choices))
-              (user-error "No window selected"))))
-      (let ((buffer (current-buffer))
-            ;; Derive the window to restore on cancel from the freshly-queried
-            ;; active window (its candidate carries `tmux-window-active'), not
-            ;; from `tmux-control--current-window' -- that is only maintained
-            ;; when the tab bar is on.
-            (original (or (cdr (seq-find
-                                (lambda (c)
-                                  (get-text-property 0 'tmux-window-active (car c)))
-                                choices))
-                          tmux-control--current-window))
-            (committed nil))
-        (unwind-protect
-            (let* ((display (consult--read
-                             (mapcar #'car choices)
-                             :prompt "Window: "
-                             :require-match t
-                             :sort nil
-                             :category 'tmux-control-window
-                             :state
-                             (lambda (action cand)
-                               (when (and (eq action 'preview) cand
-                                          (buffer-live-p buffer))
-                                 (when-let* ((idx (cdr (assoc cand choices))))
-                                   (with-current-buffer buffer
-                                     (tmux-control--do-select-window idx)))))))
-                   (idx (cdr (assoc display choices))))
-              (when idx
-                (with-current-buffer buffer (tmux-control--do-select-window idx))
-                (setq committed t)))
-          ;; Quit or empty selection: restore the window we started on.
-          (unless committed
-            (when (and original (buffer-live-p buffer))
-              (with-current-buffer buffer
-                (tmux-control--do-select-window original)))))))))
+With `consult' the live view switches to the highlighted window as you move and
+is restored to the window you came from if you cancel; without it, a plain
+prompt."
+  (let* ((choices (tmux-control--window-choices))
+         (buffer (current-buffer))
+         ;; Restore on cancel to the freshly-queried active window (its candidate
+         ;; carries `tmux-window-active'), not `tmux-control--current-window' --
+         ;; that is only maintained when the tab bar is on.
+         (original (or (cdr (seq-find
+                             (lambda (c) (get-text-property 0 'tmux-window-active (car c)))
+                             choices))
+                       tmux-control--current-window))
+         (idx (tmux-control--read-with-preview
+               "Window: " choices
+               (lambda (i) (when (buffer-live-p buffer)
+                             (with-current-buffer buffer (tmux-control--do-select-window i))))
+               (lambda () (when (and original (buffer-live-p buffer))
+                            (with-current-buffer buffer
+                              (tmux-control--do-select-window original))))
+               'tmux-control-window)))
+    (when idx
+      (with-current-buffer buffer
+        (tmux-control--do-select-window (tmux-control--normalize-window-index idx))))))
 
 (defun tmux-control--normalize-window-index (index)
   "Return INDEX as a validated window-index string or signal a `user-error'."


### PR DESCRIPTION
## What

Extends the [inline window preview](https://github.com/csheaff/tmux-control/pull/18) to the **other axis you navigate** — **sessions**. `tmux-control-select-session` (`C-c C-s`) now previews sessions in place as you choose: each *already-connected* session is shown in the live window as you move through the candidates, and cancelling restores the one you came from. No split, minibuffer-driven, your own completion UI.

An *unconnected* session isn't previewed (previewing would mean spawning a connection per keystroke); selecting it connects it as before.

## How

- New `tmux-control-session-preview` (default `t`); needs `consult`, degrades to a plain prompt without it.
- Factored the shared mechanism into **`tmux-control--read-with-preview`** (a display→value alist + `PREVIEW`/`RESTORE` closures, consult `:state` + `unwind-protect` restore + plain-completion fallback). Both the window and session inline previews now use it — the window refactor is behaviour-preserving (its existing tests still pass).

## Verified live (two connected sessions, alpha/beta)

- Navigating previews the connected session **in place** (the live window shows beta's content).
- Selecting commits it (view switches to beta, single window).
- Cancelling after previewing the other session **restores** the original.

+2 unit tests (the shared helper's cancel-restore path; session preview-connected-then-commit). 89 unit green, byte-compile clean. Guide updated. (`tmux-control-session-preview` defaults on, so no config change needed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
