### PR TITLE
Tiling preserves a non-tmux window sharing the frame

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -121,9 +121,11 @@ over buffers that are already live — no extra connections.
   argument — `C-u C-c C-f` — it first connects *every* session on the host and
   socket, so one keystroke gives you the whole host.
 
-Like the tiled view it takes the **whole frame** and resizes each session to
-its cell, so a session also attached elsewhere (another client) follows tmux's
-`window-size` rule.  Experimental.
+The flock takes the **whole frame** and resizes each session to its cell, so a
+session also attached elsewhere (another client) follows tmux's `window-size`
+rule.  (To keep a non-tmux buffer beside a single session instead, the tiled
+view above preserves a window sharing the frame; the flock always owns it —
+see below.)  Experimental.
 
 #### Watching the flock beside your code
 
@@ -207,17 +209,18 @@ tiled view; each window tiles its own panes, like iTerm's per-window tabs.
 `C-c C-t` again (or `M-x tmux-control-untile`) returns to the single-pane
 view on the currently active pane.
 
-Tiling is **experimental** and devotes the whole frame to the session
-(`delete-other-windows`).  Each pane's terminal is sized to tmux's grid, so the
-rendering matches tmux cell-for-cell, and the Emacs windows split to match.
-Re-tiles are debounced and their tmux queries batched, so a busy remote session
-is not stalled by layout changes.
+Tiling is **experimental** and fills the tmux-control buffer's **own window
+region**, not the whole frame: a non-tmux window sharing the frame (a code
+buffer, notes, a REPL) is preserved, and the panes tile only in the space the
+single-pane view occupied.  When the tmux-control buffer already fills the
+frame, the tiling fills the frame.  Each pane's terminal is sized to tmux's
+grid, so the rendering matches tmux cell-for-cell, and the Emacs windows split
+to match.  Re-tiles are debounced and their tmux queries batched, so a busy
+remote session is not stalled by layout changes.
 
 Known limitations of the tiled view (none of which affect the single-pane
 view):
 
-- It takes the **whole frame** (`delete-other-windows`); there is no
-  tile-within-a-region mode.
 - Switching windows while tiled rebuilds the new window's pane buffers, so a
   window's Emacs-side scrollback is not kept across a switch.
 - A vertical stack spends one row on an Emacs mode line where tmux spends it on

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -1371,5 +1371,74 @@ each wrapped in an evolving prompt line and a status bar.")
           (should (equal committed "b")))       ; committed b
       (kill-buffer bbuf))))
 
+;;; Tiling preserves a foreign (non-tmux) window sharing the frame.
+
+(ert-deftest tmux-control-test-our-tiling-window-p ()
+  "`tmux-control--our-tiling-window-p' recognizes the controller window and a
+tagged pane window as ours, and a foreign window as not ours."
+  (let ((ctrl-buf (generate-new-buffer " tc-test-ctrl"))
+        (foreign-buf (generate-new-buffer " tc-test-foreign")))
+    (unwind-protect
+        (save-window-excursion
+          (delete-other-windows)
+          (let* ((cw (selected-window))
+                 (ow (split-window cw nil 'right)))
+            (set-window-buffer cw ctrl-buf)
+            (set-window-buffer ow foreign-buf)
+            (should (tmux-control--our-tiling-window-p cw ctrl-buf))      ; controller
+            (should-not (tmux-control--our-tiling-window-p ow ctrl-buf))  ; foreign
+            (set-window-parameter ow 'tmux-control-pane "%3")
+            (should (tmux-control--our-tiling-window-p ow ctrl-buf))))    ; tagged pane
+      (kill-buffer ctrl-buf)
+      (kill-buffer foreign-buf))))
+
+(ert-deftest tmux-control-test-collapse-preserves-foreign-window ()
+  "`tmux-control--collapse-tile-windows' removes the tiling's own windows but
+leaves a foreign window sharing the frame untouched -- the regression behind
+\"switching tmux windows clobbers my other buffer\"."
+  (let ((ctrl-buf (generate-new-buffer " tc-test-ctrl"))
+        (foreign-buf (generate-new-buffer " tc-test-foreign")))
+    (unwind-protect
+        (save-window-excursion
+          (delete-other-windows)
+          (let* ((root (selected-window))
+                 (foreign-win (split-window root nil 'right)))
+            (set-window-buffer root ctrl-buf)
+            (set-window-buffer foreign-win foreign-buf)
+            (let ((pane2 (split-window root nil 'below)))
+              (set-window-parameter root 'tmux-control-pane "%1")
+              (set-window-parameter pane2 'tmux-control-pane "%2")
+              (tmux-control--collapse-tile-windows root)
+              (should (window-live-p foreign-win))                  ; foreign survives
+              (should (eq (window-buffer foreign-win) foreign-buf)) ; still its buffer
+              (should-not (window-live-p pane2))                    ; sibling pane collapsed
+              (should (window-live-p root))                         ; keeper survives
+              (should-not (window-parameter root 'tmux-control-pane))))) ; marker cleared
+      (kill-buffer ctrl-buf)
+      (kill-buffer foreign-buf))))
+
+(ert-deftest tmux-control-test-tiled-region-size-subtracts-foreign ()
+  "`tmux-control--tiled-region-size' is the whole frame with no foreign window
+\(the old size, so a frame-owning tiling is unchanged), and fewer columns at
+the same rows once a full-height foreign window shares the frame."
+  (let ((ctrl-buf (generate-new-buffer " tc-test-ctrl"))
+        (foreign-buf (generate-new-buffer " tc-test-foreign")))
+    (unwind-protect
+        (save-window-excursion
+          (delete-other-windows)
+          (let* ((frame (selected-frame))
+                 (cw (selected-window)))
+            (set-window-buffer cw ctrl-buf)
+            (let ((whole (tmux-control--tiled-region-size frame ctrl-buf)))
+              (should (= (car whole) (frame-text-cols frame)))
+              (should (= (cdr whole) (1- (frame-text-lines frame))))
+              (let ((fw (split-window cw nil 'right)))
+                (set-window-buffer fw foreign-buf)
+                (let ((reduced (tmux-control--tiled-region-size frame ctrl-buf)))
+                  (should (< (car reduced) (car whole)))     ; foreign steals columns
+                  (should (= (cdr reduced) (cdr whole))))))))  ; rows unchanged (side split)
+      (kill-buffer ctrl-buf)
+      (kill-buffer foreign-buf))))
+
 (provide 'tmux-control-test)
 ;;; tmux-control-test.el ends here

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -3584,6 +3584,58 @@ so only the screen capture costs a round-trip here."
 
 ;;; Window arrangement from the parsed layout tree.
 
+(defun tmux-control--our-tiling-window-p (window controller)
+  "Return non-nil when WINDOW belongs to CONTROLLER's single-pane or tiled view.
+True for the window showing CONTROLLER itself, for a tiled pane window (it
+carries the `tmux-control-pane' parameter), and for any window showing a
+render buffer whose controller is CONTROLLER.  Everything else on the frame
+is a foreign window -- a user's non-tmux buffer the tiling must not consume."
+  (let ((b (window-buffer window)))
+    (or (eq b controller)
+        (window-parameter window 'tmux-control-pane)
+        (eq (buffer-local-value 'tmux-control--controller b) controller))))
+
+(defun tmux-control--tiled-region-size (frame controller)
+  "Return (COLS . ROWS): the size tmux should lay CONTROLLER's panes out in.
+This is FRAME's text area (its columns, and its lines minus the minibuffer
+row -- the rows must budget each stacked pane's mode line) reduced by any
+foreign window sharing the frame: a full-height neighbor steals columns, a
+full-width one steals rows.  With no foreign window it is exactly the old
+whole-frame size, so a tiling that owns the frame is unchanged; with one it
+is the smaller region the tiling may use, so panes never overrun a non-tmux
+window's space.  Computed the same way whether called before tiling (from
+the controller's own window) or while tiled (from the pane windows), so the
+size never disagrees with itself and never forces a spurious re-tile."
+  (let ((cols (frame-text-cols frame))
+        (rows (1- (frame-text-lines frame))))
+    (dolist (w (window-list frame 'no-mini))
+      (unless (tmux-control--our-tiling-window-p w controller)
+        (if (>= (window-total-height w) rows)
+            (setq cols (- cols (window-total-width w)))     ; a side column
+          (setq rows (- rows (window-total-height w))))))    ; a top/bottom band
+    (cons (max 1 cols) (max 1 rows))))
+
+(defun tmux-control--collapse-tile-windows (keep)
+  "Delete this tiling's own windows on KEEP's frame, except KEEP.
+A tiling is always grown by splitting a single window, so every pane window
+is a descendant of that one window and carries the `tmux-control-pane'
+parameter `tmux-control--tile-arrange-node' stamps on it.  Deleting those
+reclaims the tiling's rectangle back into KEEP without disturbing any
+foreign (non-tmux) window sharing the frame -- the whole point, so switching
+windows or untiling no longer wipes a user's other buffer.  When the tiling
+owned the whole frame this deletes every other window, exactly as the old
+`delete-other-windows' did.  KEEP loses its own pane marker so it reads as a
+plain window afterwards."
+  (when (window-live-p keep)
+    (let ((frame (window-frame keep)))
+      (dolist (w (window-list frame 'no-mini))
+        (when (and (window-live-p w)
+                   (not (eq w keep))
+                   (window-parameter w 'tmux-control-pane)
+                   (> (length (window-list frame 'no-mini)) 1))
+          (ignore-errors (delete-window w)))))
+    (set-window-parameter keep 'tmux-control-pane nil)))
+
 (defun tmux-control--tile-arrange-node (node window panes collect)
   "Subdivide WINDOW to match layout NODE, assigning PANES buffers to leaves.
 COLLECT is called as (PANE-ID WINDOW) for each leaf placed.  Splits follow
@@ -3621,9 +3673,12 @@ takes the remaining window."
        (tmux-control--tile-arrange-node (car kids) win panes collect)))))
 
 (defun tmux-control--tile-arrange (controller tree panes)
-  "Tile CONTROLLER's frame to match layout TREE, showing PANES buffers.
-Devotes the whole frame to the tiling (`delete-other-windows').  Returns
-an alist (PANE-ID . WINDOW), or nil when the windows could not be built."
+  "Tile CONTROLLER's window region to match layout TREE, showing PANES buffers.
+Subdivides the controller's own window (collapsing any prior tiling windows
+back into it first), so a non-tmux window sharing the frame is preserved
+rather than wiped; when the controller already fills the frame the tiling
+fills the frame as before.  Returns an alist (PANE-ID . WINDOW), or nil when
+the windows could not be built."
   ;; Prefer the selected window when it already shows the controller or one
   ;; of our pane buffers, so a re-tile never reaches onto a different frame
   ;; (an all-frames `get-buffer-window' could) and clobber its layout.
@@ -3636,7 +3691,10 @@ an alist (PANE-ID . WINDOW), or nil when the windows could not be built."
     (condition-case err
         (progn
           (select-window root)
-          (delete-other-windows root)
+          ;; Reclaim only this tiling's own windows back into ROOT, leaving a
+          ;; non-tmux window sharing the frame intact -- tiling devotes the
+          ;; controller's region, not the whole frame.
+          (tmux-control--collapse-tile-windows root)
           (let ((acc '()))
             (tmux-control--tile-arrange-node
              tree (selected-window) panes
@@ -3849,8 +3907,11 @@ window.  Does not reseed; callers that resume single-pane do that."
                          (selected-window))))
             (when (window-live-p win)
               (select-window win)
-              (set-window-buffer win controller)
-              (delete-other-windows win))))
+              ;; Collapse only the tiling's own windows back into WIN; a
+              ;; non-tmux window sharing the frame survives untiling.  With no
+              ;; foreign window this reclaims the whole frame as before.
+              (tmux-control--collapse-tile-windows win)
+              (set-window-buffer win controller))))
         (dolist (np panes)
           (when (buffer-live-p (cdr np))
             (let ((kill-buffer-query-functions nil)
@@ -3859,29 +3920,24 @@ window.  Does not reseed; callers that resume single-pane do that."
 
 ;;; Interactive entry points.
 
-(defun tmux-control--tiling-frame-size (frame)
-  "Return a (W . H) char size for the tiling area of FRAME.
-Tiling devotes the whole frame, so this is the frame's text area minus the
-minibuffer row -- the size tmux is asked to lay the window's panes out in."
-  (cons (max 1 (frame-text-cols frame))
-        (max 1 (- (frame-text-lines frame) 1))))
-
 (defun tmux-control-tile ()
   "Tile every pane of the current tmux window into Emacs windows.
 Each pane is rendered live in its own buffer, arranged to match tmux's
 own layout -- the iTerm \"show every pane\" view -- which is handy for a
-split-pane window such as a Claude Code agent team.  Devotes the whole
-frame to the session.  `tmux-control-untile' (or \\`C-c C-t') returns to
-the single-pane view."
+split-pane window such as a Claude Code agent team.  Tiles within the
+controller's own window region, so a non-tmux window sharing the frame is
+left alone; when the controller fills the frame the tiling fills it.
+`tmux-control-untile' (or \\`C-c C-t') returns to the single-pane view."
   (interactive)
   (tmux-control--ensure-live)
   (when tmux-control--controller
     (user-error "This is a tiled pane; use C-c C-t to untile"))
   (when tmux-control--tiled
     (user-error "Already tiling this session"))
-  (let ((size (tmux-control--tiling-frame-size (selected-frame))))
-    ;; Ask tmux to size the window to the Emacs area we tile into; the
-    ;; resulting %layout-change re-tiles to the exact pane sizes.
+  (let ((size (tmux-control--tiled-region-size (selected-frame) (current-buffer))))
+    ;; Ask tmux to size the window to the Emacs area we tile into -- the frame
+    ;; less any non-tmux window sharing it -- so the resulting %layout-change
+    ;; re-tiles to the exact pane sizes.
     (setq tmux-control--tiled-client-size size)
     (tmux-control--send-command
      (format "refresh-client -C %dx%d" (car size) (cdr size)))
@@ -3889,14 +3945,16 @@ the single-pane view."
 
 (defun tmux-control--reassert-tiling-size (controller frame)
   "Ask tmux to match CONTROLLER's tiling area on FRAME when it has resized.
-Only acts when the frame's tiling area actually changed, so it ignores the
-internal window splits a re-tile makes (those keep the frame size)."
+Recomputes the tiling region (the frame less any foreign window sharing it,
+the same measure tiling started from) and only acts when it actually
+changed, so it ignores the internal window splits a re-tile makes -- those
+keep the region size -- and so it never disagrees with the tile-time size."
   (when (and (buffer-live-p controller)
              (buffer-local-value 'tmux-control--tiled controller)
              (process-live-p
               (buffer-local-value 'tmux-control--process controller)))
     (with-current-buffer controller
-      (let ((size (tmux-control--tiling-frame-size frame)))
+      (let ((size (tmux-control--tiled-region-size frame controller)))
         (unless (equal size tmux-control--tiled-client-size)
           (setq tmux-control--tiled-client-size size)
           (tmux-control--send-command


### PR DESCRIPTION
## The bug

> when having tmux-control open in one buffer and a non-tmuxcontrol buffer, and then I try to switch tmux windows, selecting one from the menu seems to set all buffers to the selected one — i.e. doesn't preserve the original non-tmux buffer.

Tiling — `tmux-control-tile`, **and** the automatic re-tile that fires when you switch windows *while tiled* or when tmux sends a `%layout-change` — called **`delete-other-windows` on the whole frame** in both `tmux-control--tile-arrange` (build) and `tmux-control--teardown-tiling` (untile). Any non-tmux window sharing the frame (a code buffer, notes, a REPL beside the live view) was destroyed; every window snapped to the tiled panes.

This hits the agent-fleet workflow hardest: the tmux-control buffer routinely sits next to a working buffer and tiles a multi-pane window (or re-tiles as you flip between agent windows).

Reproduced live: `A=*tmux-control*` + `B=CODE` split, `tmux-control-tile` on a 2-pane window → **B destroyed**, both Emacs windows became tmux panes.

## The fix — tile within the controller's own window region, not the frame

- **`tmux-control--collapse-tile-windows`** replaces both `delete-other-windows` calls. It reclaims only *this tiling's own* windows — identified by the `tmux-control-pane` window parameter that `--tile-arrange-node` already stamps on every pane window — back into the kept window, leaving foreign windows untouched. The tiling is always a subtree grown from a single window, so every window in it is ours. **When the tiling owns the whole frame this still deletes every other window, exactly as before.**

- **`tmux-control--tiled-region-size`** replaces `--tiling-frame-size`. It measures the tmux layout size as the frame's text area *minus* any foreign window sharing it (a full-height neighbour steals columns, a full-width one steals rows; "foreign" = not the controller buffer, no pane parameter, not one of our render buffers). With **no** foreign window it is *exactly* the old `frame-text-cols × (frame-text-lines − 1)` — zero size change — and otherwise the panes never overrun the smaller region (no clipping). Used by **both** `tmux-control-tile` and `--reassert-tiling-size`, so tile-time and resize-time agree and never force a spurious re-tile.

`flock-grid`'s own `delete-other-windows` is a separate, intentional full-frame feature and is untouched — only the two tiling sites changed.

## Verification

Live in a GUI `emacs -Q` daemon (`eat` + `tmux-control`, throwaway `tmux` session):

| scenario | result |
|---|---|
| tile with a non-tmux window B present | **B preserved** beside the panes |
| switch windows *while tiled* (the report) | re-tile keeps **B preserved** |
| untile with B present | returns to single-pane view, **B preserved** |
| whole-frame tiling (no foreign window) | unchanged — tmux told **120×29**, fills the frame, untile → single window |

- Render oracle still matches tmux **cell-for-cell** at the new size.
- Stable: the told size is identical across samples (no re-tile loop).
- No clipping: every tmux pane width ≤ its Emacs window body.

3 new ERT regression tests (foreign-window identification, collapse preservation, region-size no-regression) → **92 unit tests pass**, byte-compile clean.

Docs (`docs/guide.md`) updated: tiling now "fills the controller's own window region… a non-tmux window sharing the frame is preserved"; dropped the whole-frame known-limitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
