### PR TITLE
Speed up scrollback (faster compaction + saner default capture)

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -256,6 +256,13 @@ explicitly over TRAMP, e.g. `C-x C-f /ssh:dev:~/path/to/file`.
 
 ## Scrollback
 
+`tmux-control-scrollback-lines` (default `10000`) sets how many lines of pane
+history each scrollback view captures.  Opening scrollback captures, colorizes,
+and — when compaction is on — collapses that many lines, all of which scale
+with the number, so a very large value over a busy repainting pane can make the
+view take a moment to appear.  Raise it if you routinely scroll back further and
+can accept the extra cost; it is capped by the pane's own tmux `history-limit`.
+
 Scrollback joins soft-wrapped tmux lines by default; disable that with:
 
 ```elisp

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -69,8 +69,16 @@ When nil or empty, connect to local tmux."
   "Shell snippet used before running tmux on a remote host."
   :type 'string)
 
-(defcustom tmux-control-scrollback-lines 50000
-  "Number of pane-history lines to show in scrollback view."
+(defcustom tmux-control-scrollback-lines 10000
+  "Number of pane-history lines to capture for the scrollback view.
+
+This bounds the work `tmux-control-scrollback' does on every invocation --
+capturing the lines (a round trip, possibly over SSH), colorizing them, and,
+when `tmux-control-compact-scrollback' is on, collapsing repeated TUI
+redraws.  All of that scales with this number, so a very large value (tens of
+thousands of lines of a busy repainting pane) can make opening scrollback
+visibly lag.  10000 lines is generous for browsing recent history; raise it
+if you routinely need to scroll back further and can accept the extra cost."
   :type 'integer)
 
 (defcustom tmux-control-pause-after nil
@@ -2296,12 +2304,23 @@ small table, a two-line banner) is never silently dropped.")
   "Return non-nil when LINES are substantial enough to be a redraw body.
 Requires several nonblank lines with enough distinct content, so that
 generic filler (blank lines, repeated rule characters) is not mistaken
-for a repeated full-screen panel."
-  (let ((nonblank (seq-filter (lambda (line)
-                                (not (string-empty-p (string-trim line))))
-                              lines)))
-    (and (>= (length nonblank) 4)
-         (>= (length (seq-uniq (mapcar #'string-trim nonblank))) 3))))
+for a repeated full-screen panel.  Counts in one pass and stops as soon as
+both thresholds are met -- this runs in the innermost compaction loop, so an
+O(n) early-exit count beats building and de-duplicating intermediate lists."
+  (let ((nonblank 0)
+        (distinct 0)
+        (seen (make-hash-table :test 'equal)))
+    (catch 'enough
+      (dolist (line lines)
+        (let ((trimmed (string-trim line)))
+          (unless (string-empty-p trimmed)
+            (setq nonblank (1+ nonblank))
+            (unless (gethash trimmed seen)
+              (puthash trimmed t seen)
+              (setq distinct (1+ distinct)))
+            (when (and (>= nonblank 4) (>= distinct 3))
+              (throw 'enough t)))))
+      nil)))
 
 (defun tmux-control--seen-run-length (haystack chunk start n)
   "Return the length of the longest already-seen redraw run of CHUNK at START.
@@ -2309,15 +2328,26 @@ Considers runs from START up to N, returning the longest contiguous run
 that is distinctive (`tmux-control--redraw-run-distinctive-p') and already
 present in HAYSTACK, or nil when no qualifying run starts at START."
   (let ((len (min (- n start) tmux-control-compact-scrollback-window))
-        (found nil))
+        (in-haystack nil))
+    ;; Find the LONGEST run at START present in HAYSTACK.  Presence is
+    ;; monotonic in LEN -- a longer run embeds its shorter prefix, so once a
+    ;; length is absent every greater length is too -- hence the first hit
+    ;; scanning down from the max is the longest, and we stop there.
     (while (and (>= len tmux-control--scrollback-min-redraw-run)
-                (not found))
-      (let ((candidate (cl-subseq chunk start (+ start len))))
-        (when (and (tmux-control--redraw-run-distinctive-p candidate)
-                   (cl-search candidate haystack :test #'string=))
-          (setq found len)))
+                (not in-haystack))
+      (when (cl-search (cl-subseq chunk start (+ start len)) haystack
+                       :test #'string=)
+        (setq in-haystack len))
       (setq len (1- len)))
-    found))
+    ;; Distinctiveness is monotonic too (a longer run has at least as much
+    ;; distinct content as its prefix), so if the longest seen run is not
+    ;; distinctive no shorter one is either -- the old scan that tested both
+    ;; conditions at every length would reach the same nil.  Testing it once
+    ;; on the winner, rather than at every candidate length, is the speedup.
+    (when (and in-haystack
+               (tmux-control--redraw-run-distinctive-p
+                (cl-subseq chunk start (+ start in-haystack))))
+      in-haystack)))
 
 (defun tmux-control--strip-seen-runs (out chunk)
   "Remove from CHUNK contiguous line runs already present in recent OUT.


### PR DESCRIPTION
## The problem

> engaging the scrollback behavior is creating a lag on my other mac (M1, 32 GB). it eventually resolves itself but it can take over 10 seconds

Opening the scrollback view (`C-c C-e` / wheel-up) on a busy **repainting** pane (a TUI that reprints its whole screen, common with `alternate-screen off`) with a large tmux `history-limit` could freeze Emacs for many seconds.

Profiling pinned two compounding causes.

## 1. Compaction was quadratic in the hot spot

`tmux-control--redraw-run-distinctive-p` built and de-duplicated intermediate lists on every call (`seq-filter` + `seq-uniq`, O(k²)), and `tmux-control--seen-run-length` called it **once per candidate run length** — ~74,000 calls accounting for ~2.1s of a 3.6s compaction pass over 50k lines.

- `redraw-run-distinctive-p` now counts nonblank/distinct lines in one pass and **early-exits** as soon as both thresholds are met — O(k), usually far less.
- `seen-run-length` exploits that both *"present in the haystack"* and *"distinctive"* are monotonic in run length: find the longest run present in the haystack first, then run the distinctiveness test **once** on that winner, instead of at every length.

Output is **byte-identical** (the full compaction test suite passes unchanged). Measured: the pass over 50k lines drops **3.6s → 1.5s**, 100k **9s → 4.4s**.

## 2. The default capture was an over-default

`tmux-control-scrollback-lines` defaulted to **50000**. Everything scrollback does — the capture round trip (possibly over SSH), colorizing, compaction, and the buffer render — scales with that number, and tmux's own `history-limit` defaults to just **2000**, so 50000 only ever bit users who raise `history-limit` (agent work). Lowered to **10000**: still generous for browsing recent history, and it bounds *every* cost component at once.

## Verified live (real tmux pane, 57k-line repainting history)

| | capture+prepare | scrollback shown |
|---|---|---|
| old default (50000) | ~2.0s *(and that's already with the faster algorithm; ~5s+ before)* | repeats collapsed |
| **new default (10000)** | **~0.45s** | 10011 lines → **547** shown |

Compaction still collapses the repeats correctly. 92 tests pass; byte-compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
