### PR TITLE
Open files at the live pane's directory and host (find-file/dired)

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -245,14 +245,24 @@ view):
 
 Line numbers are disabled locally in live and scrollback buffers.
 
-## Files are local
+## Opening files from a pane
 
-A tmux-control buffer is a local Emacs buffer that *renders* a remote pane;
-it is not a remote filesystem context.  Its `default-directory` stays local
-and the package does no directory tracking, so `find-file`, `dired`,
-`M-x compile`, and similar commands operate on the machine running Emacs —
-not on the remote host.  To edit a file you see in a remote pane, open it
-explicitly over TRAMP, e.g. `C-x C-f /ssh:dev:~/path/to/file`.
+A tmux-control buffer renders a pane that has its own working directory — and,
+for a remote session, lives on another host. So **`find-file` and `dired`
+default to that pane's directory, on the pane's host**: from a buffer
+mirroring a pane on `dev` sitting in `~/proj`, `C-x C-f` opens at
+`/ssh:dev:~/proj/` and you type just the filename, instead of spelling out the
+full TRAMP path. `C-x 4 f` does the same in another window (keeping the live
+pane in view), and `C-x d` opens Dired there.
+
+- A prefix argument (`C-u C-x C-f`) opens at this buffer's own **local**
+  directory instead, for the occasional local file.
+- Only the file-finding commands are pane-aware. The buffer's
+  `default-directory` itself stays local and there is no directory tracking, so
+  `M-x compile`, `M-x grep`, and similar still run on the machine running
+  Emacs — not on the remote host.
+- To turn the pane-directory behavior off entirely (back to plain local
+  `find-file`), set `tmux-control-pane-aware-find-file` to nil.
 
 ## Scrollback
 

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -1440,5 +1440,46 @@ the same rows once a full-height foreign window shares the frame."
       (kill-buffer ctrl-buf)
       (kill-buffer foreign-buf))))
 
+;;; Pane-directory-aware file commands.
+
+(ert-deftest tmux-control-test-pane-directory-wraps-remote ()
+  "`tmux-control--pane-directory' returns the pane's cwd as a directory --
+plain for a local session, TRAMP-wrapped for a remote host -- and nil when
+the path cannot be read."
+  (cl-letf (((symbol-function 'derived-mode-p) (lambda (&rest _) t)))
+    (let ((tmux-control--active-pane "%0")
+          (tmux-control--socket-name "s"))
+      (cl-letf (((symbol-function 'tmux-control--run-tmux)
+                 (lambda (_) "/home/u/proj")))
+        (let ((tmux-control--host nil))
+          (should (equal (tmux-control--pane-directory) "/home/u/proj/")))
+        (let ((tmux-control--host ""))
+          (should (equal (tmux-control--pane-directory) "/home/u/proj/")))
+        (let ((tmux-control--host "claylien"))
+          (should (equal (tmux-control--pane-directory)
+                         "/ssh:claylien:/home/u/proj/"))))
+      ;; An empty/failed query yields nil, so callers fall back to local.
+      (cl-letf (((symbol-function 'tmux-control--run-tmux) (lambda (_) "")))
+        (let ((tmux-control--host "claylien"))
+          (should-not (tmux-control--pane-directory)))))))
+
+(ert-deftest tmux-control-test-call-in-pane-directory ()
+  "`tmux-control--call-in-pane-directory' roots at the pane dir, but uses the
+buffer's own directory with a prefix arg or when the option is off."
+  (let ((seen nil))
+    (cl-letf (((symbol-function 'tmux-control--pane-directory)
+               (lambda () "/ssh:host:/proj/"))
+              ((symbol-function 'tmux-control-test--record-dir)
+               (lambda () (interactive) (setq seen default-directory))))
+      (let ((default-directory "/local/")
+            (tmux-control-pane-aware-find-file t))
+        (tmux-control--call-in-pane-directory 'tmux-control-test--record-dir nil)
+        (should (equal seen "/ssh:host:/proj/"))           ; no prefix -> pane dir
+        (tmux-control--call-in-pane-directory 'tmux-control-test--record-dir t)
+        (should (equal seen "/local/"))                    ; prefix -> local
+        (let ((tmux-control-pane-aware-find-file nil))
+          (tmux-control--call-in-pane-directory 'tmux-control-test--record-dir nil)
+          (should (equal seen "/local/")))))))             ; option off -> local
+
 (provide 'tmux-control-test)
 ;;; tmux-control-test.el ends here

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -166,6 +166,18 @@ or when the application requests mouse events itself, the wheel event
 is forwarded to the terminal unchanged."
   :type 'boolean)
 
+(defcustom tmux-control-pane-aware-find-file t
+  "Non-nil means file commands in a tmux-control buffer start at the pane's dir.
+
+`tmux-control-find-file' and friends normally open at the live pane's own
+current directory, on the pane's host -- so from a buffer mirroring a tmux
+pane on a remote host, finding a file roots at `/ssh:HOST:PANE-CWD/' and you
+type only the filename, instead of spelling out a full TRAMP path.  Other
+commands (`compile', `grep', and so on) are untouched and still run locally.
+Set this nil to make those commands open at the buffer's own (local)
+directory instead, like ordinary `find-file'."
+  :type 'boolean)
+
 (defcustom tmux-control-window-preview t
   "How `tmux-control-select-window' previews windows as you choose.
 
@@ -412,6 +424,14 @@ the cross-session activity strip (see `tmux-control-session-activity').")
     (define-key map [remap yank] #'eat-yank)
     (define-key map [remap clipboard-yank] #'eat-yank)
     (define-key map [remap yank-pop] #'eat-yank-from-kill-ring)
+    ;; Open files at the live pane's own directory (on the pane's host), so
+    ;; finding a file from a buffer mirroring a remote pane does not mean
+    ;; spelling out a full TRAMP path.  Eat's semi-char mode leaves C-x and
+    ;; M-x for Emacs, so the ordinary file keys reach these.  See
+    ;; `tmux-control-pane-aware-find-file'.
+    (define-key map [remap find-file] #'tmux-control-find-file)
+    (define-key map [remap find-file-other-window] #'tmux-control-find-file-other-window)
+    (define-key map [remap dired] #'tmux-control-dired)
     map)
   "Keymap for `tmux-control-mode'.")
 
@@ -1428,6 +1448,64 @@ tmux reports so the view repaints on it."
   (let ((pane (or pane (tmux-control--read-pane))))
     (tmux-control--send-command (format "select-pane -t %s" pane))))
 
+(defun tmux-control--pane-directory ()
+  "Return the live pane's working directory as a `default-directory' string.
+Queries tmux for the active pane's `#{pane_current_path}'.  For a remote
+session the path is wrapped as a TRAMP `/ssh:HOST:...' directory, so file
+commands open on the host the pane runs on; for a local session it is the
+plain directory.  Returns nil when there is no pane or the path cannot be
+read, so callers fall back to the buffer's own directory."
+  (when (and (derived-mode-p 'tmux-control-mode)
+             (or tmux-control--active-pane tmux-control--fallback-target))
+    (let* ((pane (or tmux-control--active-pane tmux-control--fallback-target))
+           (path (ignore-errors
+                   (string-trim
+                    (tmux-control--run-tmux
+                     (list "display-message" "-p" "-t" pane
+                           "#{pane_current_path}"))))))
+      (when (and path (not (string-empty-p path)))
+        (let ((dir (file-name-as-directory path)))
+          (if (and tmux-control--host (not (string-empty-p tmux-control--host)))
+              (concat "/ssh:" tmux-control--host ":" dir)
+            dir))))))
+
+(defun tmux-control--call-in-pane-directory (command arg)
+  "Call interactive COMMAND with `default-directory' at the pane's directory.
+With ARG non-nil (a prefix argument), or when
+`tmux-control-pane-aware-find-file' is nil, call COMMAND with this buffer's
+own (local) directory instead -- like the plain command."
+  (let ((default-directory
+         (or (and (not arg)
+                  tmux-control-pane-aware-find-file
+                  (tmux-control--pane-directory))
+             default-directory)))
+    (call-interactively command)))
+
+(defun tmux-control-find-file (&optional arg)
+  "Find a file starting at the live pane's directory, on the pane's host.
+A tmux-control buffer renders a pane that has its own current directory --
+often a project or a remote host's working tree -- so opening a file roots
+the prompt there (`/ssh:HOST:PANE-CWD/' for a remote session) and you type
+just the filename instead of a full TRAMP path.  With a prefix ARG, start at
+this buffer's own (local) directory instead.  Bound to the `find-file' key
+\(\\[find-file]) in tmux-control buffers; honors
+`tmux-control-pane-aware-find-file'."
+  (interactive "P")
+  (tmux-control--call-in-pane-directory #'find-file arg))
+
+(defun tmux-control-find-file-other-window (&optional arg)
+  "Like `tmux-control-find-file', but show the file in another window.
+Keeps the live pane visible beside the file.  With a prefix ARG, start at
+this buffer's own (local) directory.  Bound to \\[find-file-other-window]."
+  (interactive "P")
+  (tmux-control--call-in-pane-directory #'find-file-other-window arg))
+
+(defun tmux-control-dired (&optional arg)
+  "Open Dired on the live pane's directory, on the pane's host.
+With a prefix ARG, use this buffer's own (local) directory.  Bound to
+\\[dired]."
+  (interactive "P")
+  (tmux-control--call-in-pane-directory #'dired arg))
 
 (defun tmux-control-scrollback ()
   "Show tmux pane history in a separate scrollback buffer as normal Emacs text.


### PR DESCRIPTION
## The itch

> I miss being able to know what host I'm on when doing find-file from a tmux window… I'm often in a terminal using an agent and want to look at a file, and I don't like having to type the full path including ssh and the hostname.

A tmux-control buffer renders a pane that has its own working directory — and, for a remote session, lives on another host — but `find-file` from it opened at the buffer's **local** directory. So reaching a file you could *see* in the pane meant spelling out a full `/ssh:host:~/long/path` by hand.

## The change

`find-file`, `find-file-other-window`, and `dired` in a tmux-control buffer now default to the **live pane's own `#{pane_current_path}`, on the pane's host**:

| key | behavior in a tmux-control buffer |
|---|---|
| `C-x C-f` | `Find file: /ssh:dev:~/proj/` — type just the filename |
| `C-x 4 f` | same, in another window (keeps the live pane in view) |
| `C-x d`   | Dired on the pane's directory |

This is the terminal directory-tracking affordance vterm/eshell give you, and it's a win for **local** sessions too — it lands you wherever the pane's shell or agent is `cd`'d (often an agent's worktree).

(Eat's semi-char mode leaves `C-x`/`M-x` for Emacs, so the standard file keys reach the remaps — no new keybindings to learn.)

## Scoped deliberately

- **Only file-finding is pane-aware.** The buffer's `default-directory` stays local and there's no directory tracking, so `M-x compile`, `M-x grep`, etc. still run on the machine running Emacs — no "wait, why did my compile run on the remote box?" surprises.
- **A prefix arg (`C-u C-x C-f`)** opens at the buffer's own local directory, for the occasional local file.
- **`tmux-control-pane-aware-find-file` nil** turns it off entirely.

## Verified live

- **Local** (`tmux -L tc-ff`, pane `cd`'d into a subdir): the keys remap to the new commands and resolve to the pane's cwd; no-prefix → pane dir, prefix → local, option-off → local.
- **Remote over SSH** to a real host: `tmux-control--pane-directory` resolved to `/ssh:host:/tmp/.../inner/`, and TRAMP's `file-directory-p` / `file-exists-p` confirmed the path is real and openable.

2 ERT tests (local/remote/empty path wrapping; prefix + option selection). 94 tests pass; byte-compile clean. Default on; no config needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
