### PR TITLE
find-file: honor the user's TRAMP method (e.g. tramp-rpc), not hardcoded ssh

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -255,6 +255,13 @@ mirroring a pane on `dev` sitting in `~/proj`, `C-x C-f` opens at
 full TRAMP path. `C-x 4 f` does the same in another window (keeping the live
 pane in view), and `C-x d` opens Dired there.
 
+The remote path is built with **your configured TRAMP method** for that host
+(`tramp-default-method`, or a per-host entry in `tramp-default-method-alist`) —
+so if you use a faster backend like [tramp-rpc] the path is `/rpc:dev:…`, not a
+hardcoded `/ssh:…`.
+
+[tramp-rpc]: https://github.com/ArthurHeymans/emacs-tramp-rpc
+
 - A prefix argument (`C-u C-x C-f`) opens at this buffer's own **local**
   directory instead, for the occasional local file.
 - Only the file-finding commands are pane-aware. The buffer's

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -1442,11 +1442,26 @@ the same rows once a full-height foreign window shares the frame."
 
 ;;; Pane-directory-aware file commands.
 
+(ert-deftest tmux-control-test-remote-file-method-honors-config ()
+  "`tmux-control--remote-file-method' uses the user's configured TRAMP method
+\(e.g. tramp-rpc's \"rpc\"), not a hardcoded one, and ignores a user@ prefix."
+  (require 'tramp)
+  (let ((tramp-default-method-alist nil))
+    (let ((tramp-default-method "rpc"))
+      (should (equal (tmux-control--remote-file-method "somehost") "rpc"))
+      (should (equal (tmux-control--remote-file-method "me@somehost") "rpc")))
+    (let ((tramp-default-method "sshx"))
+      (should (equal (tmux-control--remote-file-method "somehost") "sshx")))))
+
 (ert-deftest tmux-control-test-pane-directory-wraps-remote ()
   "`tmux-control--pane-directory' returns the pane's cwd as a directory --
-plain for a local session, TRAMP-wrapped for a remote host -- and nil when
-the path cannot be read."
-  (cl-letf (((symbol-function 'derived-mode-p) (lambda (&rest _) t)))
+plain for a local session, wrapped with the user's TRAMP method for a remote
+host -- and nil when the path cannot be read."
+  (cl-letf (((symbol-function 'derived-mode-p) (lambda (&rest _) t))
+            ;; Pin the resolved method so the test does not depend on the
+            ;; ambient `tramp-default-method'.
+            ((symbol-function 'tmux-control--remote-file-method)
+             (lambda (_) "rpc")))
     (let ((tmux-control--active-pane "%0")
           (tmux-control--socket-name "s"))
       (cl-letf (((symbol-function 'tmux-control--run-tmux)
@@ -1455,12 +1470,12 @@ the path cannot be read."
           (should (equal (tmux-control--pane-directory) "/home/u/proj/")))
         (let ((tmux-control--host ""))
           (should (equal (tmux-control--pane-directory) "/home/u/proj/")))
-        (let ((tmux-control--host "claylien"))
+        (let ((tmux-control--host "dev"))
           (should (equal (tmux-control--pane-directory)
-                         "/ssh:claylien:/home/u/proj/"))))
+                         "/rpc:dev:/home/u/proj/"))))
       ;; An empty/failed query yields nil, so callers fall back to local.
       (cl-letf (((symbol-function 'tmux-control--run-tmux) (lambda (_) "")))
-        (let ((tmux-control--host "claylien"))
+        (let ((tmux-control--host "dev"))
           (should-not (tmux-control--pane-directory)))))))
 
 (ert-deftest tmux-control-test-call-in-pane-directory ()

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -1448,13 +1448,39 @@ tmux reports so the view repaints on it."
   (let ((pane (or pane (tmux-control--read-pane))))
     (tmux-control--send-command (format "select-pane -t %s" pane))))
 
+(defun tmux-control--remote-file-method (host)
+  "Return the TRAMP method to reach HOST, honoring the user's TRAMP config.
+Resolves the method TRAMP would itself use for HOST -- a per-host default
+from `tramp-default-method-alist', otherwise `tramp-default-method' -- so a
+remote pane's files open through the method the user configured (for example
+\"rpc\" for tramp-rpc, or \"sshx\") rather than a hardcoded \"ssh\".  Falls
+back to `tramp-default-method', then \"ssh\", if TRAMP is unavailable."
+  ;; `tramp-find-method' returns a string carrying a `tramp-default' text
+  ;; property; strip it so the constructed `default-directory' is a clean
+  ;; string.
+  (substring-no-properties
+   (or (and (require 'tramp nil t)
+            (fboundp 'tramp-find-method)
+            ;; `tramp-find-method' wants a bare host; drop any user@ part.
+            (ignore-errors
+              (tramp-find-method
+               nil nil
+               (if (string-match "@\\([^@]*\\)\\'" host)
+                   (match-string 1 host)
+                 host))))
+       (bound-and-true-p tramp-default-method)
+       "ssh")))
+
 (defun tmux-control--pane-directory ()
   "Return the live pane's working directory as a `default-directory' string.
 Queries tmux for the active pane's `#{pane_current_path}'.  For a remote
-session the path is wrapped as a TRAMP `/ssh:HOST:...' directory, so file
-commands open on the host the pane runs on; for a local session it is the
-plain directory.  Returns nil when there is no pane or the path cannot be
-read, so callers fall back to the buffer's own directory."
+session the path is wrapped as a TRAMP `/METHOD:HOST:...' directory -- METHOD
+being whatever the user configured for that host (see
+`tmux-control--remote-file-method'), so it rides the user's own TRAMP method
+\(tramp-rpc, sshx, ...) -- so file commands open on the host the pane runs on;
+for a local session it is the plain directory.  Returns nil when there is no
+pane or the path cannot be read, so callers fall back to the buffer's own
+directory."
   (when (and (derived-mode-p 'tmux-control-mode)
              (or tmux-control--active-pane tmux-control--fallback-target))
     (let* ((pane (or tmux-control--active-pane tmux-control--fallback-target))
@@ -1466,7 +1492,8 @@ read, so callers fall back to the buffer's own directory."
       (when (and path (not (string-empty-p path)))
         (let ((dir (file-name-as-directory path)))
           (if (and tmux-control--host (not (string-empty-p tmux-control--host)))
-              (concat "/ssh:" tmux-control--host ":" dir)
+              (concat "/" (tmux-control--remote-file-method tmux-control--host)
+                      ":" tmux-control--host ":" dir)
             dir))))))
 
 (defun tmux-control--call-in-pane-directory (command arg)


### PR DESCRIPTION
Follow-up to #22. Spotted by a user who runs [tramp-rpc](https://github.com/ArthurHeymans/emacs-tramp-rpc): *"will it be used appropriately?"* — it wouldn't have.

`tmux-control--pane-directory` built the remote path as **`/ssh:HOST:…`**, hardcoding the `ssh` method. That bypasses the user's TRAMP configuration entirely: someone with `tramp-default-method` set to `"rpc"` (tramp-rpc) or `"sshx"`, or a per-host method in `tramp-default-method-alist`, would still have files opened over plain ssh — losing the faster backend.

## Fix

New `tmux-control--remote-file-method` resolves the method TRAMP would itself use for the host (`tramp-find-method` → `tramp-default-method-alist`, then `tramp-default-method`, with `require`/fallbacks), and `pane-directory` builds `/METHOD:HOST:dir`:

- tramp-rpc user → `/rpc:dev:…`
- ssh user → `/ssh:dev:…`
- per-host override → whatever they configured

The `user@` part of a host is stripped for the method lookup but kept in the path, and the method string is property-stripped (`tramp-find-method` tags it with a `tramp-default` text property) so `default-directory` stays clean.

## Tests

New ERT: the method honors `tramp-default-method` (`rpc`/`sshx`) and ignores a `user@` prefix; the pane-directory test now asserts the configured method is used (`/rpc:dev:…`). 95 tests pass; byte-compile clean. Verified in batch that with `tramp-default-method "rpc"`, hosts `dev` / `me@nebius-0` both resolve to `rpc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
