### PR TITLE
Add CI: byte-compile strictly, test source and .elc, tmux version matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        emacs-version: ['29.1', '30.1']
+        tmux: ['distro', '3.6a']
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: purcell/setup-emacs@master
+        with:
+          version: ${{ matrix.emacs-version }}
+
+      - name: Install eat (pinned)
+        run: |
+          git clone --depth 1 --branch v0.9.4 https://codeberg.org/akib/emacs-eat.git "$HOME/eat"
+          # Compile eat's terminfo so a real terminal can run in integration tests.
+          sudo apt-get update -q && sudo apt-get install -y -q ncurses-bin
+          make -C "$HOME/eat" terminfo
+
+      - name: Install tmux (distro)
+        if: matrix.tmux == 'distro'
+        run: sudo apt-get install -y -q tmux && tmux -V
+
+      - name: Install tmux (built from source)
+        if: matrix.tmux != 'distro'
+        run: |
+          sudo apt-get install -y -q libevent-dev libncurses-dev bison
+          curl -fsSL "https://github.com/tmux/tmux/releases/download/${{ matrix.tmux }}/tmux-${{ matrix.tmux }}.tar.gz" | tar xz
+          cd "tmux-${{ matrix.tmux }}" && ./configure --prefix="$HOME/.local" && make -j2 && make install
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/tmux" -V
+
+      - name: Byte-compile (warnings are errors)
+        run: make compile EAT_DIR="$HOME/eat"
+
+      - name: Unit tests (source)
+        run: make test EAT_DIR="$HOME/eat"
+
+      - name: Unit tests (byte-compiled)
+        run: make test-elc EAT_DIR="$HOME/eat"
+
+      - name: Integration tests (live tmux render oracle)
+        run: make test-integration EAT_DIR="$HOME/eat"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -16,13 +19,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: purcell/setup-emacs@master
+      # Pinned to a commit SHA: the action only publishes a moving master.
+      - uses: purcell/setup-emacs@509bfe03ba1ffddb67b3c6d9eaaeb96b45182cc7
         with:
           version: ${{ matrix.emacs-version }}
 
-      - name: Install eat (pinned)
+      - name: Install eat (pinned) and its compat dependency
         run: |
           git clone --depth 1 --branch v0.9.4 https://codeberg.org/akib/emacs-eat.git "$HOME/eat"
+          # eat's Package-Requires includes compat, which package managers
+          # install automatically but a raw clone does not; drop its files
+          # next to eat.el so the one -L covers both.
+          git clone --depth 1 --branch 31.0.0.1 https://github.com/emacs-compat/compat.git "$HOME/compat"
+          cp "$HOME/compat"/compat*.el "$HOME/eat/"
           # Compile eat's terminfo so a real terminal can run in integration tests.
           sudo apt-get update -q && sudo apt-get install -y -q ncurses-bin
           make -C "$HOME/eat" terminfo
@@ -35,7 +44,8 @@ jobs:
         if: matrix.tmux != 'distro'
         run: |
           sudo apt-get install -y -q libevent-dev libncurses-dev bison
-          curl -fsSL "https://github.com/tmux/tmux/releases/download/${{ matrix.tmux }}/tmux-${{ matrix.tmux }}.tar.gz" | tar xz
+          curl -fsSL -o tmux-src.tar.gz "https://github.com/tmux/tmux/releases/download/${{ matrix.tmux }}/tmux-${{ matrix.tmux }}.tar.gz"
+          tar xzf tmux-src.tar.gz
           cd "tmux-${{ matrix.tmux }}" && ./configure --prefix="$HOME/.local" && make -j2 && make install
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           "$HOME/.local/bin/tmux" -V

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,32 @@ test:
 	  -l test/tmux-control-test.el \
 	  -f ert-run-tests-batch-and-exit
 
+# Byte-compile with warnings promoted to errors.  Compiled and interpreted
+# elisp can genuinely diverge (specialness of a let-bound variable is decided
+# at compile time), so warnings here are treated as bugs.
+.PHONY: compile
+compile:
+	$(EMACS) -Q --batch \
+	  -L "$(EAT_DIR)" -L . \
+	  --eval '(setq byte-compile-error-on-warn t)' \
+	  -f batch-byte-compile tmux-control.el
+
+# Run the unit suite against the BYTE-COMPILED package.  Users run compiled
+# builds, and a compiled build once behaved differently from the source load
+# `make test' exercises (a let-binding compiled as lexical silently disabled
+# memoization) -- so CI runs both.
+.PHONY: test-elc
+test-elc: compile
+	$(EMACS) -Q --batch \
+	  -L "$(EAT_DIR)" -L . \
+	  -l tmux-control.elc \
+	  -l test/tmux-control-test.el \
+	  -f ert-run-tests-batch-and-exit
+
+.PHONY: clean
+clean:
+	rm -f tmux-control.elc
+
 # Live integration tests: assert that the rendered Eat buffer matches tmux's
 # own `capture-pane' for the same screen, across plain text / colors /
 # box-drawing / wide lines.  These need a real tmux on PATH -- they use a

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # tmux-control
 
+[![CI](https://github.com/csheaff/tmux-control/actions/workflows/ci.yml/badge.svg)](https://github.com/csheaff/tmux-control/actions/workflows/ci.yml)
+
 `tmux-control` turns Emacs into a **control-mode client for a tmux pane** —
 the [iTerm2 tmux-integration](https://iterm2.com/documentation-tmux-integration.html)
 idea, but in Emacs.


### PR DESCRIPTION
Adds the missing GitHub Actions workflow. Motivation is fresh: PR #24's review caught a byte-compile warning whose real effect was a silently ~6x slower compiled build — the kind of regression only caught by compiling strictly and testing what users actually run.

- **Byte-compile with warnings-as-errors** (new \`make compile\`)
- **Unit suite twice**: source load and byte-compiled (\`make test-elc\`) — interpreted/compiled elisp can genuinely diverge
- **Integration suite** (live tmux render oracle) across **distro tmux 3.4 + source-built 3.6a**, on **Emacs 29.1 + 30.1**
- eat pinned at v0.9.4 (the Package-Requires floor), terminfo compiled for real-terminal tests
- README CI badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)