### PR TITLE
Add a watchdog for control-mode commands that never get a reply

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -340,6 +340,17 @@ backlog.  It engages only on a genuinely **low-bandwidth** link — Emacs reads
 the socket eagerly, so a fast client (even a high-latency-but-fat-pipe SSH one)
 keeps up and never triggers it.  Off by default; needs tmux 3.2+.
 
+## A connection that stops replying
+
+Replies on the control connection are matched to commands strictly in order,
+so a reply that never arrives — a hung server, a half-dead SSH link — would
+otherwise stall every later command silently.  A watchdog notices when the
+oldest pending command has waited longer than `tmux-control-command-timeout`
+(default 10 seconds) and says so in the session buffer and echo area, pointing
+at `M-x tmux-control-reconnect`.  It never guesses at recovery — a late reply
+still pairs with its own command, and the client announces when one arrives.
+Set the timeout to `nil` to disable the watchdog.
+
 ## Development
 
 Run the pure-logic unit tests (no tmux server required):

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -1566,5 +1566,81 @@ buffer's own directory with a prefix arg or when the option is off."
           (tmux-control--call-in-pane-directory 'tmux-control-test--record-dir nil)
           (should (equal seen "/local/")))))))             ; option off -> local
 
+;;; Command-queue watchdog.
+
+(defmacro tmux-control-test--with-watchdog-buffer (&rest body)
+  "Run BODY in a temp buffer with watchdog state and a live mock process."
+  `(with-temp-buffer
+     (setq-local tmux-control--command-queue nil
+                 tmux-control--command-watchdog-timer nil
+                 tmux-control--command-watchdog-warned nil
+                 tmux-control--current-command-kind :ignore
+                 tmux-control--collecting-command nil
+                 tmux-control--command-output nil
+                 tmux-control--output-batch nil
+                 tmux-control--process nil)
+     (cl-letf (((symbol-function 'process-live-p) (lambda (_) t)))
+       (unwind-protect
+           (progn ,@body)
+         (when tmux-control--command-watchdog-timer
+           (cancel-timer tmux-control--command-watchdog-timer))))))
+
+(ert-deftest tmux-control-test-command-watchdog-warns-once-when-stuck ()
+  ;; An overdue head entry produces exactly one warning per stuck episode,
+  ;; leaves the queue untouched (replies pair strictly in order), and keeps
+  ;; the watchdog armed so recovery or drain is still noticed.
+  (tmux-control-test--with-watchdog-buffer
+   (let ((tmux-control-command-timeout 10))
+     (setq tmux-control--command-queue
+           (list (cons :capture (- (float-time) 60))))
+     (tmux-control--command-watchdog-check (current-buffer))
+     (should tmux-control--command-watchdog-warned)
+     (should (string-match-p "connection may be stuck" (buffer-string)))
+     (should (= 1 (length tmux-control--command-queue)))
+     (should tmux-control--command-watchdog-timer)
+     (cancel-timer tmux-control--command-watchdog-timer)
+     (setq tmux-control--command-watchdog-timer nil)
+     ;; Still stuck at the next check: no second warning.
+     (tmux-control--command-watchdog-check (current-buffer))
+     (should (= 1 (cl-count-if
+                   (lambda (line)
+                     (string-match-p "connection may be stuck" line))
+                   (split-string (buffer-string) "\n")))))))
+
+(ert-deftest tmux-control-test-command-watchdog-rearms-for-fresh-head ()
+  ;; A head entry younger than the timeout neither warns nor pops; the
+  ;; check just re-arms for the remaining wait.
+  (tmux-control-test--with-watchdog-buffer
+   (let ((tmux-control-command-timeout 10))
+     (setq tmux-control--command-queue
+           (list (cons :ignore (- (float-time) 2))))
+     (tmux-control--command-watchdog-check (current-buffer))
+     (should-not tmux-control--command-watchdog-warned)
+     (should-not (string-match-p "stuck" (buffer-string)))
+     (should tmux-control--command-watchdog-timer))))
+
+(ert-deftest tmux-control-test-command-watchdog-clears-on-drain ()
+  ;; A drained queue ends the episode: the flag resets and the watchdog
+  ;; does not re-arm.
+  (tmux-control-test--with-watchdog-buffer
+   (let ((tmux-control-command-timeout 10))
+     (setq tmux-control--command-watchdog-warned t)
+     (tmux-control--command-watchdog-check (current-buffer))
+     (should-not tmux-control--command-watchdog-warned)
+     (should-not tmux-control--command-watchdog-timer))))
+
+(ert-deftest tmux-control-test-begin-reply-pairs-kind-and-recovers ()
+  ;; A %begin reply takes its kind from the queue entry cons and, after a
+  ;; warned episode, announces recovery and clears the flag.
+  (tmux-control-test--with-watchdog-buffer
+   (setq tmux-control--command-queue
+         (list (cons :capture (float-time))))
+   (setq tmux-control--command-watchdog-warned t)
+   (tmux-control--handle-line "%begin 1717171717 42 1")
+   (should (eq tmux-control--current-command-kind :capture))
+   (should-not tmux-control--command-queue)
+   (should-not tmux-control--command-watchdog-warned)
+   (should (string-match-p "recovered" (buffer-string)))))
+
 (provide 'tmux-control-test)
 ;;; tmux-control-test.el ends here

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -3284,12 +3284,18 @@ flag reset."
         (cond
          ((null head)
           (setq tmux-control--command-watchdog-warned nil))
+         ;; The watchdog can be disabled after this check was armed.
+         ((not (numberp tmux-control-command-timeout))
+          (setq tmux-control--command-watchdog-warned nil))
          ((not (process-live-p tmux-control--process))
           ;; The sentinel already reports a dead connection; a stuck-queue
           ;; warning on top would be noise.  Stop watching.
           (setq tmux-control--command-watchdog-warned nil))
          (t
-          (let ((age (- (float-time) (cdr head))))
+          ;; `cdr-safe' tolerates a bare-symbol entry from a buffer that
+          ;; predates timestamped entries (a live upgrade); with no send
+          ;; time it counts as fresh and simply drains.
+          (let ((age (- (float-time) (or (cdr-safe head) (float-time)))))
             (if (< age tmux-control-command-timeout)
                 ;; The original head was answered and a younger command is
                 ;; at the front now; wait out its remaining time.

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -156,6 +156,23 @@ For the Claude Code TUI, for example:
             \"\\\\`[─━]\\\\{10,\\\\}\\\\\\='\" \"\\\\`❯\\\\\\='\"))"
   :type '(repeat regexp))
 
+(defcustom tmux-control-command-timeout 10
+  "Seconds to wait for tmux to reply to a control-mode command.
+
+Replies on the control connection are matched to commands strictly in
+order, so a single reply that never arrives -- a hung server, a
+half-dead SSH link -- would otherwise wedge the whole command queue
+silently: every later command waits behind it forever, and the client
+just stops reacting with no indication why.  When the oldest pending
+command has waited longer than this, a warning naming the wait is
+surfaced in the session buffer and the echo area, pointing at
+`tmux-control-reconnect'.  The queue is left untouched (a late reply
+must still match its command), so this detects and reports the wedge
+rather than guessing at recovery.
+
+nil disables the watchdog."
+  :type '(choice (const :tag "Disabled" nil) number))
+
 (defcustom tmux-control-wheel-enters-scrollback t
   "Non-nil means scrolling up with the mouse wheel enters scrollback view.
 
@@ -289,10 +306,20 @@ is treated as stale and cleared, so a self-initiated reseed that produced no
 (defvar-local tmux-control--socket-name nil)
 (defvar-local tmux-control--session nil)
 (defvar-local tmux-control--scrollback-target nil)
-(defvar-local tmux-control--command-queue nil)
+(defvar-local tmux-control--command-queue nil
+  "Pending control-mode command entries, oldest first.
+Each entry is a cons (KIND . SEND-TIME): the reply-handler kind enqueued
+by `tmux-control--send-command' and the `float-time' it was sent, read
+by the command watchdog to spot a connection that has stopped replying.")
 (defvar-local tmux-control--current-command-kind :ignore)
 (defvar-local tmux-control--collecting-command nil)
 (defvar-local tmux-control--command-output nil)
+(defvar-local tmux-control--command-watchdog-timer nil
+  "Pending watchdog timer for the command queue, or nil.")
+(defvar-local tmux-control--command-watchdog-warned nil
+  "Non-nil after the watchdog has warned about the current stuck episode.
+Cleared when a reply arrives or the queue drains, so one wedge produces
+one warning rather than one per check interval.")
 (defvar-local tmux-control--seed-cursor nil
   "Most recent (X . Y) cursor position queried for a screen seed.
 X and Y are tmux's 0-indexed cursor column and row on the visible
@@ -551,7 +578,10 @@ session (tmux attaches if it exists, otherwise creates it)."
       ;; positional reply queue stays aligned and later replies -- notably the
       ;; `#{pane_id}' query that drives the initial screen seed -- are matched
       ;; to the correct handler instead of being shifted onto the wrong one.
-      (setq tmux-control--command-queue (list :ignore))
+      ;; Arming the watchdog here also flags a connection that never
+      ;; produces its startup reply (a hung server, a stalled SSH link).
+      (setq tmux-control--command-queue (list (cons :ignore (float-time))))
+      (tmux-control--arm-command-watchdog)
       (process-put tmux-control--process 'adjust-window-size-function
                    #'tmux-control--adjust-window-size)
       (setf (eat-term-parameter tmux-control--terminal 'eat--process)
@@ -1795,6 +1825,10 @@ clip the leftmost terminal column (e.g. a prompt glyph)."
     (setq tmux-control--current-command-kind :ignore)
     (setq tmux-control--collecting-command nil)
     (setq tmux-control--command-output nil)
+    (when tmux-control--command-watchdog-timer
+      (cancel-timer tmux-control--command-watchdog-timer))
+    (setq tmux-control--command-watchdog-timer nil)
+    (setq tmux-control--command-watchdog-warned nil)
     (setq tmux-control--seed-cursor nil)
     (setq tmux-control--seed-cursor-visible :unknown)
     (setq tmux-control--terminal (eat-term-make (current-buffer) (point-min)))
@@ -2691,8 +2725,12 @@ the matching pane's render buffer instead, so every pane updates at once."
     (tmux-control--flush-output-batch)
     (cond
      ((string-prefix-p "%begin " line)
-      (setq tmux-control--current-command-kind
-            (or (pop tmux-control--command-queue) :ignore))
+      (let ((entry (pop tmux-control--command-queue)))
+        (setq tmux-control--current-command-kind
+              (or (car-safe entry) :ignore)))
+      (when tmux-control--command-watchdog-warned
+        (setq tmux-control--command-watchdog-warned nil)
+        (tmux-control--message "tmux replied after the delay -- recovered"))
       (setq tmux-control--collecting-command t)
       (setq tmux-control--command-output nil))
      ((string-prefix-p "%end " line)
@@ -2700,8 +2738,10 @@ the matching pane's render buffer instead, so every pane updates at once."
      ((string-prefix-p "%error " line)
       (setq tmux-control--collecting-command nil)
       (setq tmux-control--command-output nil)
-      (setq tmux-control--current-command-kind :ignore)
-      (tmux-control--message "tmux command failed"))
+      (tmux-control--message
+       (format "tmux command failed (%s)"
+               tmux-control--current-command-kind))
+      (setq tmux-control--current-command-kind :ignore))
      ((or (string= line "%exit") (string-prefix-p "%exit " line))
       ;; tmux is closing the control connection (the session was killed,
       ;; the server exited, or the client was detached).  The process
@@ -3213,9 +3253,64 @@ so every reply stays matched to the right handler on one queue."
         (when (process-live-p tmux-control--process)
           (setq tmux-control--command-queue
                 (append tmux-control--command-queue
-                        (list (or kind :ignore))))
+                        (list (cons (or kind :ignore) (float-time)))))
+          (tmux-control--arm-command-watchdog)
           (process-send-string tmux-control--process
                                (concat command "\n")))))))
+
+(defun tmux-control--arm-command-watchdog ()
+  "Schedule a check that the oldest pending command gets its reply in time.
+No-op when `tmux-control-command-timeout' is nil or a check is already
+scheduled.  Must run in the controller buffer."
+  (when (and tmux-control-command-timeout
+             (null tmux-control--command-watchdog-timer))
+    (setq tmux-control--command-watchdog-timer
+          (run-at-time tmux-control-command-timeout nil
+                       #'tmux-control--command-watchdog-check
+                       (current-buffer)))))
+
+(defun tmux-control--command-watchdog-check (buffer)
+  "Warn when BUFFER's oldest pending command has gone unanswered too long.
+Replies are matched to commands strictly in order, so the queue is never
+popped here -- a late reply must still meet its own entry.  The check
+re-arms itself while commands remain pending on a live connection: for
+the remaining wait when the head entry is still fresh, or for a full
+interval after warning so a recovery can be noticed and the episode
+flag reset."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (setq tmux-control--command-watchdog-timer nil)
+      (let ((head (car tmux-control--command-queue)))
+        (cond
+         ((null head)
+          (setq tmux-control--command-watchdog-warned nil))
+         ((not (process-live-p tmux-control--process))
+          ;; The sentinel already reports a dead connection; a stuck-queue
+          ;; warning on top would be noise.  Stop watching.
+          (setq tmux-control--command-watchdog-warned nil))
+         (t
+          (let ((age (- (float-time) (cdr head))))
+            (if (< age tmux-control-command-timeout)
+                ;; The original head was answered and a younger command is
+                ;; at the front now; wait out its remaining time.
+                (setq tmux-control--command-watchdog-timer
+                      (run-at-time (- tmux-control-command-timeout age) nil
+                                   #'tmux-control--command-watchdog-check
+                                   buffer))
+              (unless tmux-control--command-watchdog-warned
+                (setq tmux-control--command-watchdog-warned t)
+                (let ((text (format "no reply from tmux for %ds (%d command%s pending) -- connection may be stuck; M-x tmux-control-reconnect to recover"
+                                    (round age)
+                                    (length tmux-control--command-queue)
+                                    (if (cdr tmux-control--command-queue) "s" ""))))
+                  (tmux-control--message text)
+                  (message "tmux-control: %s" text)))
+              ;; Keep watching so a drain after the warning resets the
+              ;; episode (and a still-stuck queue stays detectable).
+              (setq tmux-control--command-watchdog-timer
+                    (run-at-time tmux-control-command-timeout nil
+                                 #'tmux-control--command-watchdog-check
+                                 buffer))))))))))
 
 (defun tmux-control--adjust-window-size (process windows)
   "Resize tmux and Eat for PROCESS according to WINDOWS."


### PR DESCRIPTION
The command queue had no timeout: replies pair with commands strictly in order, so one lost reply (hung server, half-dead SSH link) wedged the whole queue **silently** — the client just stopped reacting, no indication why.

- Queue entries now carry send time; a watchdog (armed on send and at connect) warns **once per stuck episode** when the oldest pending command exceeds `tmux-control-command-timeout` (default 10s, nil disables) — session buffer + echo area, pointing at `M-x tmux-control-reconnect`
- The queue is left untouched by design: a late reply must still pair with its own command, so the watchdog detects and reports rather than guessing at recovery — and announces when a delayed reply does arrive
- `%error` replies now name the failing command kind

**Live-validated** by SIGSTOPping a real tmux server: warning fired at 10s with queue intact; SIGCONT delivered the reply, paired correctly, recovery announced.

4 new unit tests; 102 green; clean strict byte-compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)