### PR TITLE
Capture scrollback in-band over the control connection (async, no SSH freeze)

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -280,6 +280,11 @@ with the number, so a very large value over a busy repainting pane can make the
 view take a moment to appear.  Raise it if you routinely scroll back further and
 can accept the extra cost; it is capped by the pane's own tmux `history-limit`.
 
+The capture itself rides the **live control connection** — no separate `tmux`
+or `ssh` process — and arrives asynchronously: the view opens immediately and
+fills when the reply lands, so a remote session's network round trip never
+freezes Emacs.
+
 Scrollback joins soft-wrapped tmux lines by default; disable that with:
 
 ```elisp

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -1566,5 +1566,93 @@ buffer's own directory with a prefix arg or when the option is off."
           (tmux-control--call-in-pane-directory 'tmux-control-test--record-dir nil)
           (should (equal seen "/local/")))))))             ; option off -> local
 
+;;; In-band command replies: id-matched block termination, closure queries.
+
+(defmacro tmux-control-test--with-reply-buffer (&rest body)
+  "Run BODY in a temp buffer with clean command-reply state."
+  `(with-temp-buffer
+     (setq-local tmux-control--command-queue nil
+                 tmux-control--current-command-kind :ignore
+                 tmux-control--collecting-command nil
+                 tmux-control--command-output nil
+                 tmux-control--command-block-number nil
+                 tmux-control--output-batch nil)
+     ,@body))
+
+(ert-deftest tmux-control-test-block-end-requires-matching-number ()
+  ;; A captured pane can CONTAIN lines that look like protocol -- someone
+  ;; viewing a control-mode transcript -- so %end/%error close the block
+  ;; only when their command number matches the %begin's, and a %begin
+  ;; inside a block is content, not a new block.
+  (tmux-control-test--with-reply-buffer
+   (let (got)
+     (setq tmux-control--command-queue
+           (list (lambda (lines) (setq got lines))))
+     (tmux-control--handle-line "%begin 1717 42 1")
+     (should tmux-control--collecting-command)
+     (tmux-control--handle-line "real content")
+     (tmux-control--handle-line "%end 999 7 0")      ; wrong number: content
+     (tmux-control--handle-line "%begin 5 5 0")      ; inside block: content
+     (tmux-control--handle-line "%error 999 7 0")    ; wrong number: content
+     (should tmux-control--collecting-command)
+     (tmux-control--handle-line "%end 1718 42 1")    ; same number, later time
+     (should-not tmux-control--collecting-command)
+     (should (equal got '("real content"
+                          "%end 999 7 0"
+                          "%begin 5 5 0"
+                          "%error 999 7 0"))))))
+
+(ert-deftest tmux-control-test-query-callback-gets-nil-on-error ()
+  ;; %error completes a closure query with nil so an async consumer can
+  ;; show the failure instead of waiting forever.
+  (tmux-control-test--with-reply-buffer
+   (let ((called :not-called))
+     (setq tmux-control--command-queue
+           (list (lambda (lines) (setq called lines))))
+     (tmux-control--handle-line "%begin 1 9 0")
+     (tmux-control--handle-line "some diagnostics")
+     (tmux-control--handle-line "%error 2 9 0")
+     (should (null called))
+     (should-not tmux-control--collecting-command))))
+
+(ert-deftest tmux-control-test-scrollback-capture-command ()
+  (let ((tmux-control-scrollback-join-wrapped-lines nil))
+    (should (equal (tmux-control--scrollback-capture-command "%5" 10000 nil)
+                   "capture-pane -p -e -S -10000 -t %5"))
+    (should (equal (tmux-control--scrollback-capture-command nil 200 t)
+                   "capture-pane -p -e -N -S -200")))
+  (let ((tmux-control-scrollback-join-wrapped-lines t))
+    (should (equal (tmux-control--scrollback-capture-command "%1" 50 nil)
+                   "capture-pane -p -e -J -S -50 -t %1"))))
+
+(ert-deftest tmux-control-test-scrollback-request-uses-in-band-query ()
+  ;; With a live connection the scrollback capture rides the control
+  ;; connection as a query; the callback fills the buffer through the
+  ;; compaction pipeline.
+  (tmux-control-test--with-reply-buffer
+   (let* ((tmux-control-scrollback-join-wrapped-lines nil)
+          (live (current-buffer))
+          (sent nil)
+          (sb (generate-new-buffer " *tc-sb-test*")))
+     (unwind-protect
+         (progn
+           (setq-local tmux-control--process 'fake-proc)
+           (with-current-buffer sb
+             (setq-local tmux-control--live-buffer live))
+           (cl-letf (((symbol-function 'process-live-p) (lambda (p) (eq p 'fake-proc)))
+                     ((symbol-function 'tmux-control--query)
+                      (lambda (command callback) (setq sent (cons command callback)))))
+             (with-current-buffer sb
+               (tmux-control--scrollback-request sb "%3" 500 nil)))
+           (should (equal (car sent) "capture-pane -p -e -S -500 -t %3"))
+           ;; Deliver the reply; the buffer fills and follows the bottom.
+           (funcall (cdr sent) '("line one" "line two"))
+           (with-current-buffer sb
+             (should (string-match-p "line one\nline two"
+                                     (buffer-substring-no-properties
+                                      (point-min) (point-max))))
+             (should (eobp))))
+       (kill-buffer sb)))))
+
 (provide 'tmux-control-test)
 ;;; tmux-control-test.el ends here

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -293,6 +293,12 @@ is treated as stale and cleared, so a self-initiated reseed that produced no
 (defvar-local tmux-control--current-command-kind :ignore)
 (defvar-local tmux-control--collecting-command nil)
 (defvar-local tmux-control--command-output nil)
+(defvar-local tmux-control--command-block-number nil
+  "Command number from the current reply's %begin line, as a string.
+A %end or %error line closes the block only when its number matches;
+a captured pane whose CONTENT contains a line starting with \"%end \"
+(someone viewing a control-mode transcript, say) must not terminate
+the block early.")
 (defvar-local tmux-control--seed-cursor nil
   "Most recent (X . Y) cursor position queried for a screen seed.
 X and Y are tmux's 0-indexed cursor column and row on the visible
@@ -1534,10 +1540,86 @@ With a prefix ARG, use this buffer's own (local) directory.  Bound to
   (interactive "P")
   (tmux-control--call-in-pane-directory #'dired arg))
 
+(defun tmux-control--scrollback-capture-command (target lines trailing)
+  "Build the in-band capture-pane command for the scrollback view.
+TARGET, LINES and TRAILING mirror `tmux-control--capture-pane''s flags."
+  (concat "capture-pane -p -e"
+          (when tmux-control-scrollback-join-wrapped-lines " -J")
+          (when trailing " -N")
+          (format " -S -%d" lines)
+          (when target (format " -t %s" target))))
+
+(defun tmux-control--scrollback-populate (buffer text &optional line column)
+  "Fill scrollback BUFFER with prepared TEXT and restore the view.
+With LINE and COLUMN, return point there (a refresh away from the
+bottom); otherwise follow the bottom.  Runs from a query callback or
+synchronously; BUFFER may have been killed in between."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (let ((inhibit-read-only t)
+            (at-end (null line)))
+        (when-let* ((window (get-buffer-window buffer t)))
+          (set-window-margins window 0 0))
+        (erase-buffer)
+        (insert (tmux-control--prepare-scrollback-text text))
+        (unless (bolp)
+          (insert "\n"))
+        (cond
+         (at-end
+          (goto-char (point-max))
+          (when-let* ((window (get-buffer-window buffer t)))
+            (with-selected-window window
+              (goto-char (point-max))
+              (recenter -1))))
+         (t
+          (goto-char (point-min))
+          (forward-line (1- line))
+          (move-to-column (or column 0))
+          (when-let* ((window (get-buffer-window buffer t)))
+            (set-window-point window (point)))))))))
+
+(defun tmux-control--scrollback-request (buffer target lines trailing
+                                                &optional restore-line
+                                                restore-column)
+  "Capture pane history for scrollback BUFFER and populate it.
+Prefers an IN-BAND capture-pane query over the live control connection
+-- no extra tmux or ssh process, and Emacs never blocks on the round
+trip (which spans the network for a remote session).  Falls back to the
+out-of-band CLI capture when the connection is gone, so the pager still
+works for a post-mortem look.  TARGET, LINES, TRAILING as in
+`tmux-control--capture-pane'; RESTORE-LINE/RESTORE-COLUMN as in
+`tmux-control--scrollback-populate'."
+  (let* ((live tmux-control--live-buffer)
+         (proc (and (buffer-live-p live)
+                    (buffer-local-value 'tmux-control--process live))))
+    (if (process-live-p proc)
+        (with-current-buffer live
+          (tmux-control--query
+           (tmux-control--scrollback-capture-command target lines trailing)
+           (lambda (reply-lines)
+             (if reply-lines
+                 (tmux-control--scrollback-populate
+                  buffer (string-join reply-lines "\n")
+                  restore-line restore-column)
+               (when (buffer-live-p buffer)
+                 (with-current-buffer buffer
+                   (let ((inhibit-read-only t))
+                     (erase-buffer)
+                     (insert "[tmux-control] capture failed\n"))))))))
+      (tmux-control--scrollback-populate
+       buffer
+       (tmux-control--capture-pane tmux-control--host
+                                   tmux-control--socket-name
+                                   target lines trailing)
+       restore-line restore-column))))
+
 (defun tmux-control-scrollback ()
   "Show tmux pane history in a separate scrollback buffer as normal Emacs text.
 
-Use `tmux-control-live' to return to the live interactive pane."
+The capture rides the live control connection (asynchronously -- a
+remote session's round trip never freezes Emacs); the buffer shows a
+capturing notice until it lands.  Use `tmux-control-live' to return to
+the live interactive pane."
   (interactive)
   (unless tmux-control--session
     (user-error "No tmux-control session in this buffer"))
@@ -1546,18 +1628,14 @@ Use `tmux-control-live' to return to the live interactive pane."
          (session tmux-control--session)
          (target (or tmux-control--active-pane tmux-control--fallback-target))
          (trailing tmux-control--capture-trailing-p)
-         (text (tmux-control--capture-pane host socket-name target
-                                           tmux-control-scrollback-lines
-                                           trailing))
          (live-buffer (current-buffer))
          (scrollback-buffer-name (format "*%s-scrollback*" (buffer-name)))
          (scrollback-buffer (get-buffer-create scrollback-buffer-name)))
     (with-current-buffer scrollback-buffer
       (let ((inhibit-read-only t))
         (erase-buffer)
-        (insert (tmux-control--prepare-scrollback-text text))
-        (unless (bolp)
-          (insert "\n"))
+        (insert (format "[tmux-control] capturing %d lines…\n"
+                        tmux-control-scrollback-lines))
         (tmux-control-scrollback-mode)
         (tmux-control--disable-line-numbers)
         (setq-local tmux-control--host host)
@@ -1579,38 +1657,25 @@ Use `tmux-control-live' to return to the live interactive pane."
     (switch-to-buffer scrollback-buffer)
     (when-let* ((window (get-buffer-window scrollback-buffer)))
       (set-window-margins window 0 0))
-    (goto-char (point-max))
-    (when (get-buffer-window scrollback-buffer)
-      (recenter -1))))
+    (with-current-buffer scrollback-buffer
+      (tmux-control--scrollback-request scrollback-buffer target
+                                        tmux-control-scrollback-lines
+                                        trailing))))
 
 (defun tmux-control-scrollback-refresh ()
   "Refresh the current tmux-control scrollback view."
   (interactive)
   (unless (derived-mode-p 'tmux-control-scrollback-mode)
     (user-error "Not in tmux-control scrollback mode"))
-  (let* ((line (line-number-at-pos))
-         (column (current-column))
-         (at-end (eobp))
-         (text (tmux-control--capture-pane tmux-control--host
-                                           tmux-control--socket-name
-                                           tmux-control--scrollback-target
-                                           tmux-control-scrollback-lines
-                                           tmux-control--capture-trailing-p))
-         (inhibit-read-only t))
-    (when-let* ((window (get-buffer-window (current-buffer))))
-      (set-window-margins window 0 0))
-    (erase-buffer)
-    (insert (tmux-control--prepare-scrollback-text text))
-    (unless (bolp)
-      (insert "\n"))
-    (if at-end
-        (progn
-          (goto-char (point-max))
-          (when (get-buffer-window (current-buffer))
-            (recenter -1)))
-      (goto-char (point-min))
-      (forward-line (1- line))
-      (move-to-column column))))
+  (let ((line (line-number-at-pos))
+        (column (current-column))
+        (at-end (eobp)))
+    (tmux-control--scrollback-request (current-buffer)
+                                      tmux-control--scrollback-target
+                                      tmux-control-scrollback-lines
+                                      tmux-control--capture-trailing-p
+                                      (unless at-end line)
+                                      (unless at-end column))))
 
 (defun tmux-control-live ()
   "Return from scrollback view to the live interactive tmux pane."
@@ -2690,18 +2755,37 @@ the matching pane's render buffer instead, so every pane updates at once."
     ;; state change (a resize, a seed, a pane switch) that follows it.
     (tmux-control--flush-output-batch)
     (cond
-     ((string-prefix-p "%begin " line)
+     ;; Reply blocks never nest, so a %begin while already collecting is
+     ;; pane CONTENT (a capture of a control-mode transcript), not protocol.
+     ((and (string-prefix-p "%begin " line)
+           (not tmux-control--collecting-command))
       (setq tmux-control--current-command-kind
             (or (pop tmux-control--command-queue) :ignore))
       (setq tmux-control--collecting-command t)
+      ;; %begin <time> <number> <flags>: the number also appears on the
+      ;; matching %end/%error (the time may differ between the two).
+      (setq tmux-control--command-block-number
+            (nth 2 (split-string line " ")))
       (setq tmux-control--command-output nil))
-     ((string-prefix-p "%end " line)
+     ;; %end/%error close the block only when their command number matches
+     ;; the %begin's; otherwise a captured line that merely LOOKS like one
+     ;; falls through to be collected as content below.
+     ((and (string-prefix-p "%end " line)
+           (tmux-control--block-terminator-p line))
       (tmux-control--finish-command-output))
-     ((string-prefix-p "%error " line)
-      (setq tmux-control--collecting-command nil)
-      (setq tmux-control--command-output nil)
-      (setq tmux-control--current-command-kind :ignore)
-      (tmux-control--message "tmux command failed"))
+     ((and (string-prefix-p "%error " line)
+           (tmux-control--block-terminator-p line))
+      (let ((kind tmux-control--current-command-kind))
+        (setq tmux-control--collecting-command nil)
+        (setq tmux-control--command-output nil)
+        (setq tmux-control--current-command-kind :ignore)
+        ;; A closure query still gets called -- with nil -- so an async
+        ;; consumer (a scrollback capture, say) can show the failure
+        ;; instead of waiting forever.
+        (if (functionp kind)
+            (funcall kind nil)
+          (tmux-control--message
+           (format "tmux command failed (%s)" kind)))))
      ((or (string= line "%exit") (string-prefix-p "%exit " line))
       ;; tmux is closing the control connection (the session was killed,
       ;; the server exited, or the client was detached).  The process
@@ -2781,9 +2865,34 @@ the matching pane's render buffer instead, so every pane updates at once."
       (tmux-control--refresh-windows)
       (tmux-control--refresh-pane-window-map))))))
 
+(defun tmux-control--block-terminator-p (line)
+  "Return non-nil when %end/%error LINE closes the current reply block.
+True while collecting only if LINE's command number matches the block's
+\(the timestamp differs between %begin and %end, the number does not).
+Outside a block any terminator-shaped line is stray; accept it so state
+can't wedge, unless no block was ever opened."
+  (and tmux-control--collecting-command
+       (equal (nth 2 (split-string line " "))
+              tmux-control--command-block-number)))
+
+(defun tmux-control--query (command callback)
+  "Send control-mode COMMAND; call CALLBACK with its reply.
+CALLBACK receives the reply's lines in order, or nil when tmux answers
+with %error.  It runs from the process filter in the controller buffer,
+so it should capture any other buffer it needs lexically.  The query
+rides the regular command queue over the existing connection -- no
+out-of-band tmux or ssh process -- so it works identically for local
+and remote sessions."
+  (tmux-control--send-command command callback))
+
 (defun tmux-control--finish-command-output ()
   "Handle the end of a tmux command reply."
   (pcase tmux-control--current-command-kind
+    ;; A function kind is a one-shot `tmux-control--query' callback; it
+    ;; receives the reply lines in order.
+    ((pred functionp)
+     (funcall tmux-control--current-command-kind
+              (reverse tmux-control--command-output)))
     (:pane-id
      (let ((pane (cl-find-if (lambda (line)
                                (string-match-p "\\`%[0-9]+\\'" line))


### PR DESCRIPTION
Scrollback shelled out to a fresh \`tmux\`/\`ssh\` per capture and **blocked Emacs** for the round trip — the dominant cost of \`C-c C-e\` on remote sessions. The control connection can run \`capture-pane\` itself: no extra process, no ssh handshake, no \`TMUX_TMPDIR\`/PATH mismatch class of failures, reply arrives through the regular filter. The view opens instantly and fills when the reply lands (CLI path kept as fallback for a dead connection).

**Measured on a real remote session (claylien): 0ms blocking** where the old path stalled for the full round trip; 2k-line capture lands faithfully ~1s later.

Also ships infrastructure + a real protocol fix:
- **\`tmux-control--query\`** — one-shot closure callbacks for control-mode commands (reply lines in order; nil on \`%error\`), alongside the fixed reply kinds
- **Id-matched reply termination** — \`%end\`/\`%error\` close a block only when their command *number* matches the \`%begin\` (timestamps legitimately differ), and a \`%begin\` while collecting is content. This fixes a pre-existing hazard affecting ALL in-band replies *including the screen seed*: capturing a pane whose visible content contains a line starting with \`%end \` (e.g. viewing a control-mode transcript) terminated the block early and corrupted the reply
- \`%error\` messages now name the failing command kind

4 new unit tests; 102 green; clean strict byte-compile; live-validated locally (output identical to the CLI path on real Copilot history) and over SSH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)