### PR TITLE
Scrollback pager: toggle compaction with 'c' (escape hatch for over-collapsed agent output)

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -2006,5 +2006,24 @@ output), :calls (side-effect invocations in order), :active-pane,
                   tmux-control--windows '((:index "0" :name "x" :id "@1")))
       (should (eq (tmux-control--session-display-buffer) (current-buffer))))))
 
+(ert-deftest tmux-control-test-scrollback-toggle-compaction ()
+  ;; The pager toggle flips the buffer-local compaction flag and re-renders,
+  ;; without touching the global default.
+  (let ((tmux-control-compact-scrollback t))   ; global default unchanged
+    (with-temp-buffer
+      (tmux-control-scrollback-mode)
+      (setq-local tmux-control-compact-scrollback t)
+      (let ((refreshed 0))
+        (cl-letf (((symbol-function 'tmux-control-scrollback-refresh)
+                   (lambda () (cl-incf refreshed))))
+          (tmux-control-scrollback-toggle-compaction)
+          (should-not tmux-control-compact-scrollback)
+          (should (= refreshed 1))
+          (tmux-control-scrollback-toggle-compaction)
+          (should tmux-control-compact-scrollback)
+          (should (= refreshed 2))))
+      ;; Global default was never mutated.
+      (should (eq (default-value 'tmux-control-compact-scrollback) t)))))
+
 (provide 'tmux-control-test)
 ;;; tmux-control-test.el ends here

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -506,6 +506,7 @@ the cross-session activity strip (see `tmux-control-session-activity').")
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map special-mode-map)
     (define-key map (kbd "g") #'tmux-control-scrollback-refresh)
+    (define-key map (kbd "c") #'tmux-control-scrollback-toggle-compaction)
     (define-key map (kbd "C-c C-e") #'tmux-control-live)
     (define-key map (kbd "RET") #'tmux-control-live)
     (define-key map (kbd "q") #'tmux-control-live)
@@ -1523,18 +1524,21 @@ orientation) and appends a scroll-mode hint, so entering scrollback does not
 look like the tabs vanished.  Falls back to a plain info line when the tab bar
 is disabled or no live buffer is available."
   (let* ((live tmux-control--live-buffer)
+         (cmode (if tmux-control-compact-scrollback "c:verbatim" "c:compact"))
          (tabs (and tmux-control-window-tab-bar
                     (buffer-live-p live)
                     (with-current-buffer live
                       (tmux-control--window-tab-bar t)))))
     (if (and tabs (> (length tabs) 0))
-        (concat tabs (propertize "  ⇡ scrollback  g:refresh  q/RET:live "
+        (concat tabs (propertize (format "  ⇡ scrollback  g:refresh  %s  q/RET:live "
+                                         cmode)
                                  'face 'tmux-control-tab-inactive))
-      (format " %s socket:%s session:%s target:%s    g:refresh  q/l/RET:live"
+      (format " %s socket:%s session:%s target:%s    g:refresh  %s  q/l/RET:live"
               (or tmux-control--host "local")
               tmux-control--socket-name
               tmux-control--session
-              tmux-control--scrollback-target))))
+              tmux-control--scrollback-target
+              cmode))))
 
 (defun tmux-control-other-pane ()
   "Switch the live view to the next pane in the current window.
@@ -1792,6 +1796,22 @@ the live interactive pane."
                                       tmux-control--capture-trailing-p
                                       (unless at-end line)
                                       (unless at-end column))))
+
+(defun tmux-control-scrollback-toggle-compaction ()
+  "Toggle redraw-compaction in this scrollback view and re-render.
+Compaction collapses repeated full-screen redraws (common with TUIs under
+`alternate-screen off'), but on dense, heavily-repainted output its
+de-duplication can elide more than you want; this flips to the verbatim
+capture -- every line as tmux has it -- and back, without leaving the
+pager.  Buffer-local, so it does not change the global default."
+  (interactive)
+  (unless (derived-mode-p 'tmux-control-scrollback-mode)
+    (user-error "Not in tmux-control scrollback mode"))
+  (setq-local tmux-control-compact-scrollback
+              (not tmux-control-compact-scrollback))
+  (message "tmux-control scrollback: compaction %s"
+           (if tmux-control-compact-scrollback "on" "verbatim (off)"))
+  (tmux-control-scrollback-refresh))
 
 (defun tmux-control-live ()
   "Return from scrollback view to the live interactive tmux pane."


### PR DESCRIPTION
## The report

Clay: "copilot TUI is all messed up during scrollback now."

## Diagnosis (stress-tested locally against live copilot + claude + pi + htop + watch + vim)

Bisected the three layers that touch scrollback:

1. **In-band capture transport** (PR #28) — **clean**. 10k+ line captures from a pane streaming 50 lines/sec over SSH: zero protocol contamination, perfect ordering. tmux serializes reply blocks atomically even at scale.
2. **Per-window render buffers** (PR #29) — **clean**. All 7 windows (incl. htop, vim, watch, and three live agents) match tmux's own `capture-pane` cell-for-cell after flipping through them under streaming load.
3. **Redraw compaction** — **the culprit.** Flipping `tmux-control-compact-scrollback` off makes the same pager clean and faithful. It got more aggressive this morning when PR #24 made it width-insensitive (it now collapses frames repainted across resizes — exactly the layout-change repaints an agent workflow generates), so on dense interleaved output the de-duplication stitches unrelated regions together with no seam → reads as garbled.

## This PR

A one-key escape hatch: **`c`** in the pager toggles compaction and re-renders, buffer-local (global default untouched), header shows the mode. Never be stuck with a view you don't like.

114 unit tests green (1 new); clean strict byte-compile; toggle live-verified visually on the gauntlet.

## Open question for you (not decided here)

Whether compaction should stay **on by default**. Off-by-default would make the pager always-faithful out of the box (power users opt into collapsing); on-by-default keeps repeat-suppression for the `alternate-screen off` case you originally wanted. A middle option: keep it on but render a visible seam ("⋯ repeated screen collapsed ⋯") where a frame is elided, so a collapse never reads as garbled. Your call — the toggle unblocks you either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)