### PR TITLE
Show scrollback verbatim by default (compaction opt-in)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,9 @@ attaches, typing a new name creates it.
   session is its own buffer with its own scrollback and tabs — with a dot
   flagging another session that wants you, or tile **every session at once**
   in a live grid (`C-c C-f`, experimental).
-- **Scrollback** as ordinary Emacs text (`C-c C-e`), auto-collapsing repeated
-  full-screen redraws.
+- **Scrollback** as ordinary Emacs text (`C-c C-e`) — faithful by default, with
+  opt-in compaction of repeated full-screen redraws (toggle in the pager with
+  `c`).
 - **Tiled view** (`C-c C-t`, experimental) — every pane of a window at once,
   split to match tmux's layout.
 - **Persistent & remote** — the session lives on the server and outlives Emacs;

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -301,25 +301,36 @@ Scrollback joins soft-wrapped tmux lines by default; disable that with:
 (setq tmux-control-scrollback-join-wrapped-lines nil)
 ```
 
-### Compacting repeated TUI redraws
+### Compacting repeated TUI redraws (opt-in)
 
 Some TUIs repaint by reprinting their whole screen instead of using the
-alternate screen — common when tmux runs with `alternate-screen off`, which
-keeps full-screen apps on the normal screen so their history is preserved.
-Each repaint is then appended to the pane history, so scrolling back would
-otherwise show the same screen many times over.
+alternate screen — which happens when tmux runs with `alternate-screen off`,
+keeping full-screen apps on the normal screen so their history is preserved.
+Each repaint is then appended to the pane history, so scrolling back shows the
+same screen many times over.
 
-`tmux-control` collapses those repeats **automatically**: it detects the
-repeated frame in the captured history and shows it once, followed by whatever
-changed between repaints (a spinner, a token count, an evolving prompt), so you
-see the progression instead of dozens of copies.  It is conservative — with no
-repeating frame the text is left untouched (plain scrollback is verbatim);
-collapsing a repeat trims trailing whitespace from the surrounding lines.  Turn
-it off with:
+`tmux-control` can collapse those repeats: it detects the repeated frame in the
+captured history and shows it once, followed by whatever changed between
+repaints (a spinner, a token count, an evolving prompt), so you see the
+progression instead of dozens of copies.
+
+It is **off by default** — scrollback is shown verbatim, exactly as tmux
+captured it. That is the right default for most setups: tmux keeps
+`alternate-screen` *on* by default, so full-screen TUIs use the alternate
+screen and never flow into scrollback as repeats in the first place; and on
+dense, evolving output (an agent streaming a long answer, where each "frame"
+grows rather than repeats) the collapse can elide more than intended. Verbatim
+is always faithful. Turn compaction on if you run `alternate-screen off` and
+want repeats suppressed:
 
 ```elisp
-(setq tmux-control-compact-scrollback nil)
+(setq tmux-control-compact-scrollback t)
 ```
+
+You can also flip it for the current view from inside the pager with **`c`**
+(`tmux-control-scrollback-toggle-compaction`) — handy to switch on when a
+particular history is repetitive, and off the moment a collapse looks wrong.
+The header line shows which mode a press will switch to.
 
 For a particular TUI you can fine-tune the result: pin the frame boundary with
 `tmux-control-scrollback-frame-start-regexp` (when auto-detection picks a poor

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -2009,7 +2009,7 @@ output), :calls (side-effect invocations in order), :active-pane,
 (ert-deftest tmux-control-test-scrollback-toggle-compaction ()
   ;; The pager toggle flips the buffer-local compaction flag and re-renders,
   ;; without touching the global default.
-  (let ((tmux-control-compact-scrollback t))   ; global default unchanged
+  (let ((global-before (default-value 'tmux-control-compact-scrollback)))
     (with-temp-buffer
       (tmux-control-scrollback-mode)
       (setq-local tmux-control-compact-scrollback t)
@@ -2022,8 +2022,9 @@ output), :calls (side-effect invocations in order), :active-pane,
           (tmux-control-scrollback-toggle-compaction)
           (should tmux-control-compact-scrollback)
           (should (= refreshed 2))))
-      ;; Global default was never mutated.
-      (should (eq (default-value 'tmux-control-compact-scrollback) t)))))
+      ;; The global default was never mutated by the buffer-local toggle.
+      (should (eq (default-value 'tmux-control-compact-scrollback)
+                  global-before)))))
 
 (provide 'tmux-control-test)
 ;;; tmux-control-test.el ends here

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -102,20 +102,30 @@ error) and never pause."
   "Non-nil means join soft-wrapped pane lines in scrollback captures."
   :type 'boolean)
 
-(defcustom tmux-control-compact-scrollback t
+(defcustom tmux-control-compact-scrollback nil
   "Non-nil means compact repeated full-screen redraws in the scrollback view.
 
-A TUI that repaints by reprinting its whole screen -- common under tmux with
-`alternate-screen' disabled -- leaves many near-identical copies of its screen
-in pane history.  When enabled (the default), tmux-control auto-detects the
-repeated frame and collapses it to a single copy plus whatever changed between
-repaints, so scrolling back shows the progression instead of dozens of copies.
-The collapse is conservative: with no repeating frame it changes nothing, so a
-session without a repainting TUI is shown verbatim.  Collapsing a repeat does
-trim trailing whitespace from the surrounding lines.
+A TUI that repaints by reprinting its whole screen -- which happens under tmux
+with `alternate-screen' disabled -- leaves many near-identical copies of its
+screen in pane history.  When enabled, tmux-control auto-detects the repeated
+frame and collapses it to a single copy plus whatever changed between repaints,
+so scrolling back shows the progression instead of dozens of copies.
 
-For a specific TUI you can override the auto-detected frame boundary and drop
-volatile per-frame lines with `tmux-control-scrollback-frame-start-regexp' and
+Off by default, so scrollback is shown VERBATIM -- exactly as tmux captured it.
+Two reasons that is the right default for most setups: tmux keeps
+`alternate-screen' ON by default, so full-screen TUIs use the alternate screen
+and never flow into scrollback as repeated frames in the first place; and on
+dense, evolving output (an agent streaming a long answer, where each \"frame\"
+grows rather than repeats) the collapse can elide more than intended and read
+as garbled.  Verbatim is always faithful.
+
+Turn it on if you run `alternate-screen off' and want repeated redraws
+suppressed.  In the pager you can also toggle it for the current view with
+\\<tmux-control-scrollback-mode-map>\\[tmux-control-scrollback-toggle-compaction],
+so it is easy to flip on when a particular history is repetitive and off when a
+collapse looks wrong.  For a specific TUI you can override the auto-detected
+frame boundary and drop volatile per-frame lines with
+`tmux-control-scrollback-frame-start-regexp' and
 `tmux-control-scrollback-chrome-regexps'."
   :type 'boolean)
 

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -1534,7 +1534,11 @@ orientation) and appends a scroll-mode hint, so entering scrollback does not
 look like the tabs vanished.  Falls back to a plain info line when the tab bar
 is disabled or no live buffer is available."
   (let* ((live tmux-control--live-buffer)
-         (cmode (if tmux-control-compact-scrollback "c:verbatim" "c:compact"))
+         ;; Show the CURRENT mode, then what `c' switches to, so it never
+         ;; reads as if verbatim were active while compaction is on.
+         (cmode (if tmux-control-compact-scrollback
+                    "compacted·c:verbatim"
+                  "verbatim·c:compact"))
          (tabs (and tmux-control-window-tab-bar
                     (buffer-live-p live)
                     (with-current-buffer live


### PR DESCRIPTION
Follow-up to #30, answering its open question with "best for most users."

## Why off by default

- **tmux defaults to `alternate-screen on`.** Compaction exists to clean up the repeated-frame stacking that only happens with `alternate-screen off`. For the default-config majority, that scenario never occurs — compaction is pure downside risk on their normal scrollback.
- **It can corrupt dense, evolving output.** When each "frame" grows rather than repeats (an agent streaming a long answer), the de-duplication elides more than intended and reads as garbled — the exact symptom from testing a real Copilot/Claude session under `alternate-screen off`.
- **Faithful beats clever** for a scroll-up-and-read-history feature. Verbatim is always correct.

## What stays

The whole detection/merge engine is untouched — only the default and docs move. Compaction is a one-liner opt-in (`tmux-control-compact-scrollback t`) for `alternate-screen off` users who want repeats suppressed, plus the per-view pager toggle (`c`) from #30. So both audiences are served; the default just stops surprising the majority.

114 unit tests green; clean strict byte-compile; README + guide updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)