### PR TITLE
Fix the view stranding on the previous window during rapid switches

### DIFF
--- a/test/tmux-control-integration.el
+++ b/test/tmux-control-integration.el
@@ -473,5 +473,53 @@ clears it."
         (kill-buffer buf))
       (tmux-control-it--tmux-ok "kill-server"))))
 
+(ert-deftest tmux-control-it-rapid-window-switching-converges ()
+  "Back-to-back window switches (the preview menu's pattern) converge on the
+last window selected.  Regression: the swap derived the displayed buffer
+from the cached window index, which updates via a slower separate reply, so
+the second of two quick switches found no window showing its notion of the
+view and stranded the display on the previous window."
+  (skip-unless (tmux-control-it--available-p))
+  (tmux-control-it--tmux-ok "kill-server")
+  (tmux-control-it--tmux "new-session" "-d" "-s" "t" "-n" "w0" "-x" "80" "-y" "24")
+  (tmux-control-it--tmux "new-window" "-t" "t:" "-n" "w1")
+  (tmux-control-it--tmux "new-window" "-t" "t:" "-n" "w2")
+  (tmux-control-it--tmux "select-window" "-t" "t:0")
+  (tmux-control-it--tmux "send-keys" "-t" "t:0" "echo MARK_ZERO" "Enter")
+  (tmux-control-it--tmux "send-keys" "-t" "t:1" "echo MARK_ONE" "Enter")
+  (tmux-control-it--tmux "send-keys" "-t" "t:2" "echo MARK_TWO" "Enter")
+  (let* ((tmux-control-window-buffers t)
+         (buf (tmux-control-connect nil tmux-control-it--socket "t")))
+    (unwind-protect
+        (progn
+          (tmux-control-it--pump 1.5)
+          ;; Burst: three switches with NO pumping between sends, so the
+          ;; notifications and :windows replies interleave like a user
+          ;; flicking through the menu over a remote link.
+          (with-current-buffer buf
+            (tmux-control--do-select-window "1")
+            (tmux-control--do-select-window "2")
+            (tmux-control--do-select-window "1"))
+          ;; The display must converge on window 1's buffer.
+          (should (tmux-control-it--pump-until
+                   8 (lambda ()
+                       (let ((shown (window-buffer (selected-window))))
+                         (and (string-match-p ":@" (buffer-name shown))
+                              (with-current-buffer shown
+                                (and (equal tmux-control--window-id
+                                            (with-current-buffer buf
+                                              (tmux-control--window-id-for-index "1")))
+                                     (string-match-p
+                                      "MARK_ONE"
+                                      (buffer-substring-no-properties
+                                       (point-min) (point-max))))))))))
+          ;; And the session's display pointer agrees with what is shown.
+          (should (eq (tmux-control--session-display-buffer buf)
+                      (window-buffer (selected-window)))))
+      (when (buffer-live-p buf)
+        (with-current-buffer buf (ignore-errors (tmux-control-disconnect)))
+        (kill-buffer buf))
+      (tmux-control-it--tmux-ok "kill-server"))))
+
 (provide 'tmux-control-integration)
 ;;; tmux-control-integration.el ends here

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -2026,5 +2026,51 @@ output), :calls (side-effect invocations in order), :active-pane,
       (should (eq (default-value 'tmux-control-compact-scrollback)
                   global-before)))))
 
+(ert-deftest tmux-control-test-display-swap-survives-stale-window-index ()
+  ;; THE menu-switch race: rapid successive switches deliver the second
+  ;; %session-window-changed before the :windows reply has updated
+  ;; `tmux-control--current-window'.  The swap must track the displayed
+  ;; buffer explicitly, not derive it from that stale index -- deriving it
+  ;; found no window showing the (wrong) "old" buffer and silently left the
+  ;; view stranded on the previous window.
+  (with-temp-buffer
+    (let* ((tmux-control-window-buffers t)
+           (ctrl (current-buffer))
+           (buf-b (generate-new-buffer " *tc-race-b*"))
+           (buf-c (generate-new-buffer " *tc-race-c*"))
+           (win (selected-window))
+           (orig (window-buffer win)))
+      (unwind-protect
+          (progn
+            (setq-local tmux-control--window-id "@1")
+            ;; Window list STALE throughout: current-window says index 0
+            ;; (the controller's own window) the whole time.
+            (setq-local tmux-control--current-window "0")
+            (setq-local tmux-control--windows
+                        '((:index "0" :name "a" :active t :id "@1")
+                          (:index "1" :name "b" :id "@2")
+                          (:index "2" :name "c" :id "@3")))
+            (tmux-control--register-window-buffer "@1" ctrl)
+            (dolist (pair `(("@2" . ,buf-b) ("@3" . ,buf-c)))
+              (with-current-buffer (cdr pair)
+                (setq-local tmux-control--window-id (car pair)
+                            tmux-control--controller ctrl))
+              (tmux-control--register-window-buffer (car pair) (cdr pair)))
+            (set-window-buffer win ctrl)
+            ;; First switch: ctrl -> B.
+            (tmux-control--display-window-buffer "@2")
+            (should (eq (window-buffer win) buf-b))
+            ;; Second switch lands while current-window is STILL "0":
+            ;; must swap B -> C anyway.
+            (tmux-control--display-window-buffer "@3")
+            (should (eq (window-buffer win) buf-c))
+            (should (eq (tmux-control--session-display-buffer ctrl) buf-c))
+            ;; And back to the controller's own window.
+            (tmux-control--display-window-buffer "@1")
+            (should (eq (window-buffer win) ctrl)))
+        (set-window-buffer win orig)
+        (kill-buffer buf-b)
+        (kill-buffer buf-c)))))
+
 (provide 'tmux-control-test)
 ;;; tmux-control-test.el ends here

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -390,6 +390,14 @@ WINDOW-ID is tmux's stable @id string.  Includes the connect buffer
 itself under its own window id once that id is known.")
 (defvar-local tmux-control--window-id nil
   "The tmux @window-id this buffer renders, or nil before it is known.")
+(defvar-local tmux-control--session-display nil
+  "On the controller: the render buffer the live view last swapped to.
+The authoritative \"what is the session showing\" pointer.  It must NOT
+be derived from `tmux-control--current-window' at swap time: that index
+updates via a separate, slower :windows reply, so during rapid switches
+\(the window preview menu, two fast `C-c C-n') the next swap would look
+for a buffer that is no longer on screen, find no window, and silently
+strand the view on the previous window.")
 
 ;; Multi-pane tiling (experimental).  In tiling mode the controller buffer
 ;; (the process buffer) stops rendering and instead fans the session's
@@ -2025,6 +2033,7 @@ clip the leftmost terminal column (e.g. a prompt glyph)."
               (kill-buffer buf))))))
     (setq tmux-control--window-buffers nil)
     (setq tmux-control--window-id nil)
+    (setq tmux-control--session-display nil)
     (setq tmux-control--seed-cursor nil)
     (setq tmux-control--seed-cursor-visible :unknown)
     (setq tmux-control--terminal (eat-term-make (current-buffer) (point-min)))
@@ -3080,6 +3089,8 @@ the matching pane's render buffer instead, so every pane updates at once."
                                line))
         (when-let* ((buf (tmux-control--window-buffer (match-string 1 line))))
           (unless (eq buf (current-buffer))
+            (when (eq tmux-control--session-display buf)
+              (setq tmux-control--session-display (current-buffer)))
             (dolist (win (get-buffer-window-list buf nil t))
               (set-window-buffer win (current-buffer)))
             (let ((kill-buffer-query-functions nil))
@@ -3831,11 +3842,15 @@ Must run in the controller buffer."
 
 (defun tmux-control--session-display-buffer (&optional ctrl)
   "Return the buffer currently representing CTRL's session on screen.
-That is the current window's render buffer when per-window buffers are
-on and one exists, else the controller itself."
+Prefers the controller's explicit display pointer (set by every swap, so
+it is correct even mid-burst when the cached window index lags); falls
+back to the current window's render buffer, then the controller itself."
   (let ((ctrl (or ctrl (tmux-control--wb-controller))))
     (with-current-buffer ctrl
       (or (and tmux-control-window-buffers
+               (buffer-live-p tmux-control--session-display)
+               tmux-control--session-display)
+          (and tmux-control-window-buffers
                tmux-control--current-window
                (tmux-control--window-buffer
                 (tmux-control--window-id-for-index
@@ -3892,6 +3907,12 @@ it asynchronously over the control connection."
         (setq eat-terminal tmux-control--terminal)
         (when size
           (eat-term-resize tmux-control--terminal (car size) (cdr size)))
+        ;; A first visit takes two control-connection round trips to paint
+        ;; (noticeable over SSH); show a notice instead of a silent blank.
+        ;; The seed's screen-clear replaces it.
+        (tmux-control--feed-terminal
+         "\033[2m[tmux-control] loading window…\033[0m")
+        (tmux-control--flush-display nil)
         (eat-semi-char-mode)
         (setf (eat-term-parameter tmux-control--terminal 'input-function)
               #'tmux-control--send-input)
@@ -3932,46 +3953,45 @@ it asynchronously over the control connection."
 
 (defun tmux-control--seed-window-buffer (buffer window-id)
   "Resolve WINDOW-ID's active pane and seed BUFFER from it, asynchronously.
-A closure-query chain over the control connection: find the window's
-active pane, fetch its cursor, capture its screen -- never blocking
-Emacs, and ordered by tmux itself."
+A closure-query chain over the control connection -- never blocking
+Emacs, and ordered by tmux itself.  Two round trips, not three: the
+active pane and its cursor come back in one list-panes reply (this is
+the first-visit latency a remote user sees as a blank window, so every
+round trip counts), then the capture paints the screen."
   (let ((ctrl (tmux-control--wb-controller)))
     (with-current-buffer ctrl
       (tmux-control--query
-       (format "list-panes -t %s -F \"#{pane_active}\t#{pane_id}\""
+       (format "list-panes -t %s -F \"#{pane_active}\t#{pane_id}\t#{cursor_x},#{cursor_y},#{cursor_flag}\""
                window-id)
        (lambda (lines)
-         (let ((pane (cl-loop for l in (or lines '())
-                              when (string-match "\\`1\t\\(%[0-9]+\\)\\'" l)
-                              return (match-string 1 l))))
+         (let (pane cur vis)
+           (cl-loop for l in (or lines '())
+                    when (string-match
+                          "\\`1\t\\(%[0-9]+\\)\t\\(.*\\)\\'" l)
+                    do (setq pane (match-string 1 l))
+                       (let ((cline (list (match-string 2 l))))
+                         (setq cur (tmux-control--parse-cursor-pos cline)
+                               vis (tmux-control--parse-cursor-visible cline)))
+                    and return nil)
            (when (and pane (buffer-live-p buffer))
              (with-current-buffer buffer
                (setq tmux-control--active-pane pane))
              (with-current-buffer ctrl
                (tmux-control--query
-                (format "display-message -p -t %s \"#{cursor_x},#{cursor_y},#{cursor_flag}\"" pane)
-                (lambda (cursor-lines)
-                  (let ((cur (and cursor-lines
-                                  (tmux-control--parse-cursor-pos cursor-lines)))
-                        (vis (if cursor-lines
-                                 (tmux-control--parse-cursor-visible cursor-lines)
-                               :unknown)))
-                    (with-current-buffer ctrl
-                      (tmux-control--query
-                       (format "capture-pane -p -e%s -t %s"
-                               (if (buffer-local-value
-                                    'tmux-control--capture-trailing-p buffer)
-                                   " -N" "")
-                               pane)
-                       (lambda (cap-lines)
-                         (when (and cap-lines (buffer-live-p buffer))
-                           (with-current-buffer buffer
-                             (tmux-control--write-terminal
-                              (tmux-control--screen-seed-sequence
-                               (string-join cap-lines "\n")
-                               cur vis))
-                             (tmux-control--flush-display
-                              (tmux-control--current-sync-windows))))))))))))))))))
+                (format "capture-pane -p -e%s -t %s"
+                        (if (buffer-local-value
+                             'tmux-control--capture-trailing-p buffer)
+                            " -N" "")
+                        pane)
+                (lambda (cap-lines)
+                  (when (and cap-lines (buffer-live-p buffer))
+                    (with-current-buffer buffer
+                      (tmux-control--write-terminal
+                       (tmux-control--screen-seed-sequence
+                        (string-join cap-lines "\n")
+                        cur (or vis :unknown)))
+                      (tmux-control--flush-display
+                       (tmux-control--current-sync-windows))))))))))))))
 
 (defun tmux-control--flush-window-buffers ()
   "Flush each sibling window render buffer's batched output and redisplay.
@@ -4012,6 +4032,11 @@ display buffer (or the controller) over to the new one."
         (with-current-buffer new
           (when (get-buffer-window new t)
             (tmux-control--resize-to-window)))))
+    ;; Record the swap unconditionally: this pointer is what the NEXT swap
+    ;; (and flock/switcher) read, and it must track the session's current
+    ;; window even when no Emacs window was showing the live view.
+    (with-current-buffer ctrl
+      (setq tmux-control--session-display new))
     new))
 
 ;;;; Multi-pane tiling (experimental)


### PR DESCRIPTION
Field report from the per-window-buffers feature: "two windows, two buffers — select the other in the menu and the same buffer remains", plus possible flicker, on a remote session.

**Root cause (deterministic):** the swap derived its notion of "the displayed buffer" from `--current-window`, which updates via a separate, slower `:windows` reply. Rapid switches (exactly what the preview menu generates) interleave: the second `%session-window-changed` computes "old" from the stale index, finds no Emacs window showing that buffer, and silently no-ops. View stranded.

**Fix:** the controller records every swap in an explicit `tmux-control--session-display` pointer; swaps (and flock / session switcher / strip clicks) read it instead of re-deriving. Plus first-visit polish: the seed chain is 2 round trips instead of 3, and a new window buffer shows a dim *loading* notice instead of a silent blank (the flicker suspect over SSH RTT).

**Validation:**
- unit regression encoding the stale-index race (fails on previous code)
- live integration test: back-to-back switch burst, no waits — in CI on both tmux versions
- 50-iteration randomized soak (1–3-switch bursts under two streaming windows): zero stranded views, zero render-oracle diffs
- the inline preview menu (rapid previews → commit ×3) and the default two-pane chooser, driven end-to-end against a live session

115 unit + 14 integration green; strict byte-compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)