### PR TITLE
Swap the display immediately on menu/tab window selection (zero-RTT)

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -2072,5 +2072,44 @@ output), :calls (side-effect invocations in order), :active-pane,
         (kill-buffer buf-b)
         (kill-buffer buf-c)))))
 
+(ert-deftest tmux-control-test-do-select-window-swaps-optimistically ()
+  ;; A menu/tab selection knows its target window, so the display swaps
+  ;; IMMEDIATELY -- zero round trips, no dependence on tmux echoing
+  ;; %session-window-changed.  (The echo re-runs the swap idempotently.)
+  (with-temp-buffer
+    (let* ((tmux-control-window-buffers t)
+           (ctrl (current-buffer))
+           (buf-b (generate-new-buffer " *tc-opt-b*"))
+           (win (selected-window))
+           (orig (window-buffer win))
+           (sent nil))
+      (unwind-protect
+          (cl-letf (((symbol-function 'tmux-control--ensure-live) #'ignore)
+                    ((symbol-function 'tmux-control--send-command)
+                     (lambda (cmd &optional _kind) (push cmd sent))))
+            (setq-local tmux-control--session "s"
+                        tmux-control--window-id "@1"
+                        tmux-control--current-window "0"
+                        tmux-control--windows
+                        '((:index "0" :name "a" :active t :id "@1")
+                          (:index "1" :name "b" :id "@2")))
+            (tmux-control--register-window-buffer "@1" ctrl)
+            (with-current-buffer buf-b
+              (setq-local tmux-control--window-id "@2"
+                          tmux-control--controller ctrl))
+            (tmux-control--register-window-buffer "@2" buf-b)
+            (set-window-buffer win ctrl)
+            ;; Select window 1: the swap happens NOW, before any reply.
+            (tmux-control--do-select-window "1")
+            (should (eq (window-buffer win) buf-b))
+            (should (cl-some (lambda (c) (string-match-p "select-window" c))
+                             sent))
+            ;; Unknown index (no id cached): no swap, no error; the echo
+            ;; will handle it.
+            (tmux-control--do-select-window "7")
+            (should (eq (window-buffer win) buf-b)))
+        (set-window-buffer win orig)
+        (kill-buffer buf-b)))))
+
 (provide 'tmux-control-test)
 ;;; tmux-control-test.el ends here

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -1185,10 +1185,24 @@ to the new window's panes, so only the single-pane view reseeds here."
     (tmux-control--send-command
      (format "select-window -t %s:%s" tmux-control--session index))
     (unless ctrl
-      ;; With per-window buffers the echoed %session-window-changed swaps
-      ;; the displayed buffer; repainting in place would be wasted work.
       (if tmux-control-window-buffers
-          (tmux-control--quiet-activity)
+          (progn
+            (tmux-control--quiet-activity)
+            ;; The target is KNOWN here (menu pick, tab click, chooser), so
+            ;; swap the display NOW -- zero round trips -- instead of
+            ;; waiting for tmux to echo %session-window-changed.  The echo
+            ;; still arrives and re-runs the swap idempotently, and remains
+            ;; the only driver for switches we did not initiate.  Falls
+            ;; through quietly when the window list has not delivered an id
+            ;; for INDEX yet; the echo then does the swap as before.
+            (when-let* ((idx (if (integerp index)
+                                 (number-to-string index)
+                               index))
+                        (id (and (stringp idx)
+                                 (with-current-buffer
+                                     (tmux-control--wb-controller)
+                                   (tmux-control--window-id-for-index idx)))))
+              (tmux-control--display-window-buffer id)))
         (tmux-control--refresh-active-pane t)))))
 
 (defun tmux-control--switch-window (verb)


### PR DESCRIPTION
Follow-up to #32 for the field report "the issue persists": menu/tab/chooser selections — where the target window is already known client-side — no longer wait for tmux to echo `%session-window-changed` before swapping the displayed buffer. The swap happens **immediately, zero round trips**; the echo re-runs it idempotently, and remains the sole driver for switches initiated by other clients (and for next/previous/last, whose targets tmux resolves).

Two wins:
- **Latency**: menu selection feels instant on remote sessions instead of paying a full RTT
- **Robustness**: the selection path no longer depends on echo timing at all — whatever notification weirdness a link has, the pick lands

Validated: unit test asserting the swap precedes any reply (and that an uncached index is a safe no-op deferring to the echo); a 30-round randomized burst soak under streaming load (zero stranded views; revisits preserve buffer identity, pane, and accumulated scrollback); the inline preview menu and the default two-pane chooser driven end-to-end against a live session.

116 unit + 13 integration green; strict byte-compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)