### PR TITLE
select-pane: make choosing a pane in another window a real jump

### DIFF
--- a/test/tmux-control-integration.el
+++ b/test/tmux-control-integration.el
@@ -522,9 +522,10 @@ view and stranded the display on the previous window."
       (tmux-control-it--tmux-ok "kill-server"))))
 
 (ert-deftest tmux-control-it-select-pane-jumps-to-other-window ()
-  "Choosing a pane that lives in ANOTHER window via the pane picker is a real
+  "`tmux-control-select-pane' given a pane id from ANOTHER window is a real
 jump: the session switches to that window, and the view shows the pane.
-The field-reported topology: two windows, one pane each, pick the other
+\(Non-interactive here; the interactive picker resolves to the same call.)
+The field-reported topology: two windows, one pane each, target the other
 window's pane -- the view must not stay on the old window."
   (skip-unless (tmux-control-it--available-p))
   (tmux-control-it--tmux-ok "kill-server")

--- a/test/tmux-control-integration.el
+++ b/test/tmux-control-integration.el
@@ -521,5 +521,44 @@ view and stranded the display on the previous window."
         (kill-buffer buf))
       (tmux-control-it--tmux-ok "kill-server"))))
 
+(ert-deftest tmux-control-it-select-pane-jumps-to-other-window ()
+  "Choosing a pane that lives in ANOTHER window via the pane picker is a real
+jump: the session switches to that window, and the view shows the pane.
+The field-reported topology: two windows, one pane each, pick the other
+window's pane -- the view must not stay on the old window."
+  (skip-unless (tmux-control-it--available-p))
+  (tmux-control-it--tmux-ok "kill-server")
+  (tmux-control-it--tmux "new-session" "-d" "-s" "t" "-n" "w0" "-x" "80" "-y" "24")
+  (tmux-control-it--tmux "new-window" "-t" "t:" "-n" "w1")
+  (tmux-control-it--tmux "select-window" "-t" "t:0")
+  (tmux-control-it--tmux "send-keys" "-t" "t:0" "echo PANE_OF_W0" "Enter")
+  (tmux-control-it--tmux "send-keys" "-t" "t:1" "echo PANE_OF_W1" "Enter")
+  (let* ((tmux-control-window-buffers t)
+         (buf (tmux-control-connect nil tmux-control-it--socket "t")))
+    (unwind-protect
+        (progn
+          (tmux-control-it--pump 1.5)
+          ;; Resolve window 1's pane id from tmux itself.
+          (let ((target
+                 (string-trim
+                  (tmux-control-it--tmux
+                   "list-panes" "-t" "t:1" "-F" "#{pane_id}"))))
+            (with-current-buffer buf
+              (tmux-control-select-pane target))
+            ;; The view converges on window 1's buffer showing its pane.
+            (should (tmux-control-it--pump-until
+                     8 (lambda ()
+                         (let ((shown (window-buffer (selected-window))))
+                           (and (not (eq shown buf))
+                                (with-current-buffer shown
+                                  (string-match-p
+                                   "PANE_OF_W1"
+                                   (buffer-substring-no-properties
+                                    (point-min) (point-max)))))))))))
+      (when (buffer-live-p buf)
+        (with-current-buffer buf (ignore-errors (tmux-control-disconnect)))
+        (kill-buffer buf))
+      (tmux-control-it--tmux-ok "kill-server"))))
+
 (provide 'tmux-control-integration)
 ;;; tmux-control-integration.el ends here

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -829,18 +829,21 @@ each wrapped in an evolving prompt line and a status bar.")
                      ("2" . "2: editor pane"))))))
 
 (ert-deftest tmux-control-test-list-panes-parses ()
+  ;; Session-wide listing: pane id, window index+name, pane index, pane
+  ;; active, window active, command, title.
   (cl-letf (((symbol-function 'tmux-control--call)
              (lambda (&rest _)
-               (concat "%0\t0\t1\tbash\tclays-mbp\n"
-                       "%3\t1\t0\tnode\tcoder\n"
-                       "%2\t2\t0\tnode\tnode\n"
+               (concat "%0\t0\tcode\t0\t1\t1\tbash\tclays-mbp\n"
+                       ;; active pane of an INACTIVE window: not "[active]"
+                       "%3\t1\tagents\t0\t1\t0\tnode\tcoder\n"
+                       "%2\t1\tagents\t1\t0\t0\tnode\tnode\n"
                        "garbage-line"))))
     (should (equal (tmux-control--list-panes nil "main" "emacs")
-                   ;; index: command (title-when-distinct) [active]
-                   '(("%0" . "0: bash (clays-mbp) [active]")
-                     ("%3" . "1: node (coder)")
+                   ;; window:name.pane command (title-when-distinct) [active]
+                   '(("%0" . "0:code.0 bash (clays-mbp) [active]")
+                     ("%3" . "1:agents.0 node (coder)")
                      ;; title == command -> no redundant "(node)"
-                     ("%2" . "2: node"))))))
+                     ("%2" . "1:agents.1 node"))))))
 
 ;;; Window-management command construction.
 
@@ -2112,10 +2115,10 @@ output), :calls (side-effect invocations in order), :active-pane,
         (kill-buffer buf-b)))))
 
 (ert-deftest tmux-control-test-select-pane-crosses-windows ()
-  ;; The pane picker lists the whole session's panes, but tmux's bare
-  ;; `select-pane' cannot move the session to another window -- so choosing
-  ;; a pane that lives elsewhere must switch the window first, then focus
-  ;; the pane.  (Regression: the old single-buffer client followed
+  ;; `tmux-control-select-pane' can be handed (or complete to) a pane in
+  ;; another window, but tmux's bare `select-pane' cannot move the session
+  ;; there -- so the command must switch the window first, then focus the
+  ;; pane.  (Regression: the old single-buffer client followed
   ;; %window-pane-changed unconditionally, which made the bare command
   ;; LOOK like a cross-window jump; per-window buffers routed the change
   ;; to the other window's buffer and the view stayed put.)

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -2111,5 +2111,34 @@ output), :calls (side-effect invocations in order), :active-pane,
         (set-window-buffer win orig)
         (kill-buffer buf-b)))))
 
+(ert-deftest tmux-control-test-select-pane-crosses-windows ()
+  ;; The pane picker lists the whole session's panes, but tmux's bare
+  ;; `select-pane' cannot move the session to another window -- so choosing
+  ;; a pane that lives elsewhere must switch the window first, then focus
+  ;; the pane.  (Regression: the old single-buffer client followed
+  ;; %window-pane-changed unconditionally, which made the bare command
+  ;; LOOK like a cross-window jump; per-window buffers routed the change
+  ;; to the other window's buffer and the view stayed put.)
+  (with-temp-buffer
+    (let ((sent '()) (window-selected nil))
+      (cl-letf (((symbol-function 'tmux-control--ensure-live) #'ignore)
+                ((symbol-function 'tmux-control--do-select-window)
+                 (lambda (idx) (setq window-selected idx)))
+                ((symbol-function 'tmux-control--send-command)
+                 (lambda (cmd &optional _kind) (push cmd sent))))
+        (setq-local tmux-control--session "s"
+                    tmux-control--current-window "0"
+                    tmux-control--pane-window (make-hash-table :test 'equal))
+        (puthash "%0" (cons "0" "@1") tmux-control--pane-window)
+        (puthash "%5" (cons "1" "@2") tmux-control--pane-window)
+        ;; Same-window pane: no window switch, just select-pane.
+        (tmux-control-select-pane "%0")
+        (should-not window-selected)
+        (should (equal (car sent) "select-pane -t %0"))
+        ;; Cross-window pane: switch the window, then focus the pane.
+        (tmux-control-select-pane "%5")
+        (should (equal window-selected "1"))
+        (should (equal (car sent) "select-pane -t %5"))))))
+
 (provide 'tmux-control-test)
 ;;; tmux-control-test.el ends here

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -980,12 +980,14 @@ Queries tmux on HOST using SOCKET-NAME."
            (split-string (string-trim text) "\n" t)))))
 
 (defun tmux-control--list-panes (host socket-name target)
-  "Return an alist of (PANE-ID . LABEL) for the active window of TARGET.
-Queries tmux on HOST using SOCKET-NAME.  LABEL shows the pane index, its
-running command, its title when that differs, and whether it is active."
-  (let* ((fmt "#{pane_id}\t#{pane_index}\t#{pane_active}\t#{pane_current_command}\t#{pane_title}")
+  "Return an alist of (PANE-ID . LABEL) for every pane in session TARGET.
+Queries tmux on HOST using SOCKET-NAME, across ALL of the session's
+windows (an agent fleet shows every agent, whichever window it lives
+in).  LABEL shows the pane's window and index, its running command, its
+title when that differs, and whether it is the session's active pane."
+  (let* ((fmt "#{pane_id}\t#{window_index}\t#{window_name}\t#{pane_index}\t#{pane_active}\t#{window_active}\t#{pane_current_command}\t#{pane_title}")
          (args (append (when socket-name (list "-L" socket-name))
-                       (list "list-panes" "-t" target "-F" fmt)))
+                       (list "list-panes" "-s" "-t" target "-F" fmt)))
          (text (if (and host (not (string-empty-p host)))
                    (tmux-control--call
                     "ssh"
@@ -998,20 +1000,24 @@ running command, its title when that differs, and whether it is active."
           (mapcar
            (lambda (line)
              (when (string-match
-                    "\\`\\(%[0-9]+\\)\t\\([0-9]+\\)\t\\([01]\\)\t\\([^\t]*\\)\t\\(.*\\)\\'"
+                    "\\`\\(%[0-9]+\\)\t\\([0-9]+\\)\t\\([^\t]*\\)\t\\([0-9]+\\)\t\\([01]\\)\t\\([01]\\)\t\\([^\t]*\\)\t\\(.*\\)\\'"
                     line)
                (let* ((pane (match-string 1 line))
-                      (index (match-string 2 line))
-                      (active (string= (match-string 3 line) "1"))
-                      (cmd (match-string 4 line))
-                      (title (match-string 5 line))
-                      (label (format "%s: %s%s%s"
-                                     index cmd
+                      (widx (match-string 2 line))
+                      (wname (match-string 3 line))
+                      (pidx (match-string 4 line))
+                      (pane-active (string= (match-string 5 line) "1"))
+                      (win-active (string= (match-string 6 line) "1"))
+                      (cmd (match-string 7 line))
+                      (title (match-string 8 line))
+                      (label (format "%s:%s.%s %s%s%s"
+                                     widx wname pidx cmd
                                      (if (and (not (string-empty-p title))
                                               (not (equal title cmd)))
                                          (format " (%s)" title)
                                        "")
-                                     (if active " [active]" ""))))
+                                     (if (and pane-active win-active)
+                                         " [active]" ""))))
                  (cons pane label))))
            (split-string (string-trim text) "\n" t)))))
 
@@ -1588,7 +1594,9 @@ See `tmux-control-select-pane' to jump to a pane by name."
   (tmux-control--send-command "select-pane -t :.+"))
 
 (defun tmux-control--read-pane ()
-  "Read a pane id of the current window using completion over its panes."
+  "Read a pane id with completion over ALL of the session's panes.
+Each candidate is labelled with its window and index, so an agent
+fleet's panes are distinguishable across windows."
   (let* ((panes (tmux-control--list-panes tmux-control--host
                                           tmux-control--socket-name
                                           tmux-control--session))
@@ -1610,7 +1618,13 @@ sets that window's active pane WITHOUT switching the session's current
 window, so the session is switched to the pane's window first (the tab
 bar, other clients, and the per-window view all follow), then the pane
 is focused within it.  A pane of the current window just becomes the
-active pane, and the view repaints on it."
+active pane, and the view repaints on it.
+
+The window hop relies on the pane->window map, which is fetched
+asynchronously at connect; in the brief moment before it arrives (or
+with both `tmux-control-window-tab-bar' and
+`tmux-control-window-buffers' disabled, which leave it unfetched) an
+unmapped pane falls back to the bare `select-pane'."
   (interactive (list nil))
   (tmux-control--ensure-live)
   (let* ((pane (or pane (tmux-control--read-pane)))

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -1599,15 +1599,28 @@ See `tmux-control-select-pane' to jump to a pane by name."
         (user-error "No such pane"))))
 
 (defun tmux-control-select-pane (&optional pane)
-  "Switch the live view to another pane in the current window.
-Interactively, complete over the window's panes -- a Claude Code agent
-team shows each teammate as a pane, labelled by its command and title --
-and focus the chosen one.  With PANE (a pane id) given non-interactively,
-switch to it directly.  Switching sets the window's active pane, which
-tmux reports so the view repaints on it."
+  "Switch the live view to another pane, by name.
+Interactively, complete over the SESSION's panes -- an agent team shows
+each teammate as a pane, labelled by its command and title -- and focus
+the chosen one.  With PANE (a pane id) given non-interactively, switch
+to it directly.
+
+A pane in another window is a real jump: tmux's `select-pane' alone
+sets that window's active pane WITHOUT switching the session's current
+window, so the session is switched to the pane's window first (the tab
+bar, other clients, and the per-window view all follow), then the pane
+is focused within it.  A pane of the current window just becomes the
+active pane, and the view repaints on it."
   (interactive (list nil))
   (tmux-control--ensure-live)
-  (let ((pane (or pane (tmux-control--read-pane))))
+  (let* ((pane (or pane (tmux-control--read-pane)))
+         (ctrl (tmux-control--wb-controller))
+         (idx (with-current-buffer ctrl
+                (and (hash-table-p tmux-control--pane-window)
+                     (car-safe (gethash pane tmux-control--pane-window)))))
+         (current (buffer-local-value 'tmux-control--current-window ctrl)))
+    (when (and idx current (not (equal idx current)))
+      (tmux-control--do-select-window idx))
     (tmux-control--send-command (format "select-pane -t %s" pane))))
 
 (defun tmux-control--remote-file-method (host)


### PR DESCRIPTION
Resolves the persisting field report — finally pinned by asking the right questions: **two windows (one pane each), `tmux-control-select-pane`, content stays the same.**

The pane picker lists the whole session's panes, but sent a bare `select-pane` — which tmux defines as setting that window's active pane **without switching the session's current window**. The old single-buffer client followed `%window-pane-changed` unconditionally, so this accidentally worked as a cross-window jump. Per-window buffers (#29) route that notification to the other window's own buffer — correct per-window semantics — so the displayed view legitimately stayed put. A behavior regression of an undocumented affordance.

Now: a pane in another window switches the session to that window first (tab bar, other clients, and the zero-RTT display swap from #33 all follow), then focuses the pane. Same-window picks unchanged; unmapped panes fall back to the bare command.

Unit test for the dispatch + a live integration test of the literal reported topology, now in CI. 117 unit + 14 integration green; strict byte-compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)