### PR TITLE
Key display swaps off frame reality, not the display pointer

### DIFF
--- a/test/tmux-control-integration.el
+++ b/test/tmux-control-integration.el
@@ -561,5 +561,57 @@ window's pane -- the view must not stay on the old window."
         (kill-buffer buf))
       (tmux-control-it--tmux-ok "kill-server"))))
 
+(ert-deftest tmux-control-it-select-pane-recovers-desynced-view ()
+  "Selecting a pane converges the view even when the session is ALREADY
+current on the pane's window while the frame shows another window's buffer.
+The desync is one hand-display away (`switch-to-buffer' on a render buffer,
+a window-configuration restore); from it, the bare select-pane changes
+nothing tmux notifies about, so nothing visibly happened -- the live field
+report, reproduced end to end: jump to w1, display w0's buffer by hand,
+select w1's pane again, and the view must come back to w1."
+  (skip-unless (tmux-control-it--available-p))
+  (tmux-control-it--tmux-ok "kill-server")
+  (tmux-control-it--tmux "new-session" "-d" "-s" "t" "-n" "w0" "-x" "80" "-y" "24")
+  (tmux-control-it--tmux "new-window" "-t" "t:" "-n" "w1")
+  (tmux-control-it--tmux "select-window" "-t" "t:0")
+  (tmux-control-it--tmux "send-keys" "-t" "t:0" "echo PANE_OF_W0" "Enter")
+  (tmux-control-it--tmux "send-keys" "-t" "t:1" "echo PANE_OF_W1" "Enter")
+  (let* ((tmux-control-window-buffers t)
+         (buf (tmux-control-connect nil tmux-control-it--socket "t")))
+    (cl-flet ((shows-w1 ()
+                (tmux-control-it--pump-until
+                 8 (lambda ()
+                     (let ((shown (window-buffer (selected-window))))
+                       (and (not (eq shown buf))
+                            (with-current-buffer shown
+                              (string-match-p
+                               "PANE_OF_W1"
+                               (buffer-substring-no-properties
+                                (point-min) (point-max))))))))))
+      (unwind-protect
+          (progn
+            (tmux-control-it--pump 1.5)
+            (let ((target (string-trim
+                           (tmux-control-it--tmux
+                            "list-panes" "-t" "t:1" "-F" "#{pane_id}"))))
+              ;; A legitimate jump first: view, pointer, and tmux all on w1.
+              (with-current-buffer buf
+                (tmux-control-select-pane target))
+              (should (shows-w1))
+              ;; Out-of-band: the user displays w0's render buffer by hand.
+              ;; tmux still says current window 1; the display pointer still
+              ;; says w1's buffer.
+              (set-window-buffer (selected-window) buf)
+              ;; Select w1's pane again.  tmux is already there -- no
+              ;; notification will come -- so the command itself must bring
+              ;; the view back.
+              (with-current-buffer buf
+                (tmux-control-select-pane target))
+              (should (shows-w1))))
+        (when (buffer-live-p buf)
+          (with-current-buffer buf (ignore-errors (tmux-control-disconnect)))
+          (kill-buffer buf))
+        (tmux-control-it--tmux-ok "kill-server")))))
+
 (provide 'tmux-control-integration)
 ;;; tmux-control-integration.el ends here

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -2143,5 +2143,82 @@ output), :calls (side-effect invocations in order), :active-pane,
         (should (equal window-selected "1"))
         (should (equal (car sent) "select-pane -t %5"))))))
 
+(ert-deftest tmux-control-test-display-swap-recovers-desynced-pointer ()
+  ;; The swap keys off the windows REALLY showing session buffers, not the
+  ;; display pointer.  Displaying a render buffer by hand (`switch-to-buffer',
+  ;; a window-config restore) desyncs the pointer from the frame; a
+  ;; pointer-keyed swap then either hunted for an "old" buffer no window was
+  ;; showing, or -- when the pointer already claimed the target -- declined
+  ;; to swap at all.  Field report: with the pointer stuck on the other
+  ;; window's buffer, every switch toward it was a silent no-op.
+  (with-temp-buffer
+    (let* ((tmux-control-window-buffers t)
+           (ctrl (current-buffer))
+           (buf-b (generate-new-buffer " *tc-desync-b*"))
+           (win (selected-window))
+           (orig (window-buffer win)))
+      (unwind-protect
+          (progn
+            (setq-local tmux-control--window-id "@1")
+            (setq-local tmux-control--windows
+                        '((:index "0" :name "a" :id "@1")
+                          (:index "1" :name "b" :active t :id "@2")))
+            (tmux-control--register-window-buffer "@1" ctrl)
+            (with-current-buffer buf-b
+              (setq-local tmux-control--window-id "@2"
+                          tmux-control--controller ctrl))
+            (tmux-control--register-window-buffer "@2" buf-b)
+            ;; Out-of-band display: the frame shows the controller while the
+            ;; pointer still claims B is on screen.
+            (set-window-buffer win ctrl)
+            (setq-local tmux-control--session-display buf-b)
+            ;; Swapping "to" B -- which the pointer believes needs nothing --
+            ;; must still converge the frame on B.
+            (tmux-control--display-window-buffer "@2")
+            (should (eq (window-buffer win) buf-b))
+            (should (eq (tmux-control--session-display-buffer ctrl) buf-b))
+            ;; And the view keeps following normal swaps afterwards.
+            (tmux-control--display-window-buffer "@1")
+            (should (eq (window-buffer win) ctrl)))
+        (set-window-buffer win orig)
+        (kill-buffer buf-b)))))
+
+(ert-deftest tmux-control-test-select-pane-jumps-from-viewed-window ()
+  ;; The cross-window jump triggers off the window the invoking buffer
+  ;; renders, not only off tmux's current window.  With the session already
+  ;; current on the pane's window but the frame showing another window's
+  ;; buffer (an out-of-band display), the bare select-pane changes nothing
+  ;; tmux would notify about -- the command itself must route through the
+  ;; window switch so the view converges.
+  (with-temp-buffer
+    (let ((sent '()) (window-selected nil))
+      (cl-letf (((symbol-function 'tmux-control--ensure-live) #'ignore)
+                ((symbol-function 'tmux-control--do-select-window)
+                 (lambda (idx) (setq window-selected idx)))
+                ((symbol-function 'tmux-control--send-command)
+                 (lambda (cmd &optional _kind) (push cmd sent))))
+        (setq-local tmux-control--session "s"
+                    tmux-control--window-id "@1" ; this buffer renders w0
+                    tmux-control--current-window "1" ; tmux sits on w1
+                    tmux-control--pane-window (make-hash-table :test 'equal))
+        (puthash "%0" (cons "0" "@1") tmux-control--pane-window)
+        (puthash "%5" (cons "1" "@2") tmux-control--pane-window)
+        ;; Pane of the session's current window but NOT of the rendered one:
+        ;; the regression -- must jump, not send a bare invisible select-pane.
+        (tmux-control-select-pane "%5")
+        (should (equal window-selected "1"))
+        (should (equal (car sent) "select-pane -t %5"))
+        ;; Pane of the rendered window while the session is current
+        ;; elsewhere: still a jump (the current-window clause).
+        (setq window-selected nil)
+        (tmux-control-select-pane "%0")
+        (should (equal window-selected "0"))
+        ;; Pane of the window both rendered and current: plain select-pane.
+        (setq-local tmux-control--current-window "0")
+        (setq window-selected nil)
+        (tmux-control-select-pane "%0")
+        (should-not window-selected)
+        (should (equal (car sent) "select-pane -t %0"))))))
+
 (provide 'tmux-control-test)
 ;;; tmux-control-test.el ends here

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -392,12 +392,15 @@ itself under its own window id once that id is known.")
   "The tmux @window-id this buffer renders, or nil before it is known.")
 (defvar-local tmux-control--session-display nil
   "On the controller: the render buffer the live view last swapped to.
-The authoritative \"what is the session showing\" pointer.  It must NOT
-be derived from `tmux-control--current-window' at swap time: that index
-updates via a separate, slower :windows reply, so during rapid switches
-\(the window preview menu, two fast `C-c C-n') the next swap would look
-for a buffer that is no longer on screen, find no window, and silently
-strand the view on the previous window.")
+What `tmux-control--session-display-buffer' readers (the session
+switcher, `tmux-control--connect-or-switch') treat as the session's
+on-screen buffer.  It tracks swaps, not the frame: a render buffer
+displayed by hand leaves it stale until the next swap.  The swap itself
+\(`tmux-control--display-window-buffer') therefore keys off the windows
+really showing the session's buffers -- never off this pointer, nor off
+`tmux-control--current-window', whose index updates via a separate,
+slower :windows reply and lags rapid switches (the window preview menu,
+two fast `C-c C-n').")
 
 ;; Multi-pane tiling (experimental).  In tiling mode the controller buffer
 ;; (the process buffer) stops rendering and instead fans the session's
@@ -1615,10 +1618,16 @@ to it directly.
 
 A pane in another window is a real jump: tmux's `select-pane' alone
 sets that window's active pane WITHOUT switching the session's current
-window, so the session is switched to the pane's window first (the tab
-bar, other clients, and the per-window view all follow), then the pane
-is focused within it.  A pane of the current window just becomes the
-active pane, and the view repaints on it.
+window -- and when the session is already current there, it produces no
+notification a display swap could follow -- so the session is switched
+to the pane's window first (the tab bar, other clients, and the
+per-window view all follow), then the pane is focused within it.  The
+jump triggers when the pane's window differs from the window of the
+buffer the command ran in OR from the session's current window: the two
+disagree after a render buffer is displayed by hand, and either
+mismatch makes the bare command invisible.  A pane of the window that
+is both on screen and current just becomes the active pane, and the
+view repaints on it.
 
 The window hop relies on the pane->window map, which is fetched
 asynchronously at connect; in the brief moment before it arrives (or
@@ -1628,12 +1637,17 @@ unmapped pane falls back to the bare `select-pane'."
   (interactive (list nil))
   (tmux-control--ensure-live)
   (let* ((pane (or pane (tmux-control--read-pane)))
+         (viewed tmux-control--window-id)
          (ctrl (tmux-control--wb-controller))
-         (idx (with-current-buffer ctrl
-                (and (hash-table-p tmux-control--pane-window)
-                     (car-safe (gethash pane tmux-control--pane-window)))))
+         (entry (with-current-buffer ctrl
+                  (and (hash-table-p tmux-control--pane-window)
+                       (gethash pane tmux-control--pane-window))))
+         (idx (car-safe entry))
+         (wid (cdr-safe entry))
          (current (buffer-local-value 'tmux-control--current-window ctrl)))
-    (when (and idx current (not (equal idx current)))
+    (when (and idx
+               (or (and current (not (equal idx current)))
+                   (and wid viewed (not (equal wid viewed)))))
       (tmux-control--do-select-window idx))
     (tmux-control--send-command (format "select-pane -t %s" pane))))
 
@@ -4052,10 +4066,16 @@ flushed by the regular single-pane path."
 (defun tmux-control--display-window-buffer (window-id)
   "Show WINDOW-ID's render buffer in place of the session's current view.
 Creates and seeds the buffer on first visit.  Runs in any buffer of the
-session; swaps every Emacs window currently showing the session's
-display buffer (or the controller) over to the new one."
+session; swaps every Emacs window currently showing ANY of the session's
+render buffers (or the controller) over to the new one.  The swap is
+keyed off what is really on screen, never off the display pointer: the
+two disagree once a render buffer is displayed by hand (a plain
+`switch-to-buffer', `winner-undo', a window-configuration restore), and
+a pointer-keyed swap then either hunted for an \"old\" buffer no window
+was showing, or believed the target already on screen -- both silent
+no-ops that strand the view until something happens to resync them."
   (let* ((ctrl (tmux-control--wb-controller))
-         (old (tmux-control--session-display-buffer ctrl))
+         (prior (buffer-local-value 'tmux-control--session-display ctrl))
          (new (or (with-current-buffer ctrl
                     (tmux-control--window-buffer window-id))
                   ;; The controller renders its own window.
@@ -4065,17 +4085,27 @@ display buffer (or the controller) over to the new one."
                        ctrl)
                   (let ((b (tmux-control--make-window-buffer window-id ctrl)))
                     (tmux-control--seed-window-buffer b window-id)
-                    b))))
-    (unless (eq old new)
-      (dolist (win (get-buffer-window-list old nil t))
-        (set-window-buffer win new))
-      (when (buffer-live-p new)
-        (with-current-buffer new
-          (when (get-buffer-window new t)
-            (tmux-control--resize-to-window)))))
-    ;; Record the swap unconditionally: this pointer is what the NEXT swap
-    ;; (and flock/switcher) read, and it must track the session's current
-    ;; window even when no Emacs window was showing the live view.
+                    b)))
+         (swapped nil))
+    (dolist (buf (cons ctrl (mapcar #'cdr (buffer-local-value
+                                           'tmux-control--window-buffers
+                                           ctrl))))
+      (when (and (buffer-live-p buf) (not (eq buf new)))
+        (dolist (win (get-buffer-window-list buf nil t))
+          ;; `set-window-buffer' rejects strongly dedicated windows (side
+          ;; windows, previews); they opted out of buffer reuse.
+          (unless (eq (window-dedicated-p win) t)
+            (set-window-buffer win new)
+            (setq swapped t)))))
+    (when (and (buffer-live-p new)
+               (or swapped (not (eq prior new)))
+               (get-buffer-window new t))
+      (with-current-buffer new
+        (tmux-control--resize-to-window)))
+    ;; Record the swap unconditionally: `tmux-control--session-display-buffer'
+    ;; readers (the flock switcher, connect-or-switch) find the session's
+    ;; on-screen buffer through this pointer, and it must track the session's
+    ;; current window even when no Emacs window was showing the live view.
     (with-current-buffer ctrl
       (setq tmux-control--session-display new))
     new))


### PR DESCRIPTION
## The report

Diagnosed live on a real session (`nebius-0`): with the session current on window 1 but the frame showing window 0's buffer, picking window 1's pane changed nothing — the exact symptom #33 and #34 fixed, **on a build containing both fixes**.

The state behind it: `tmux-control--session-display` (what the swap machinery believes is on screen) said window 1's buffer while the frame really showed window 0's. One hand-display creates that state — `switch-to-buffer` on a render buffer, `winner-undo`, a saved window configuration — and from it every swap dead-ends:

- The optimistic swap (#33) and the echo swap both compute "old" from the pointer, then either hunt for a buffer no window is showing, or conclude there is nothing to do at all (`old eq new`) — silent no-ops, view stranded.
- `select-pane`'s window hop (#34) compares the pane's window to **tmux's** current window, sees them equal, and sends a bare `select-pane` that tmux — already on that window — answers with no notification whatsoever. Nothing visibly happens.

Confirmed by prediction in the live session: selecting the *visible* window's pane accidentally resyncs the pointer, after which the previously dead selection works instantly.

## The fix

1. **`tmux-control--display-window-buffer`** now swaps every Emacs window showing *any* of the session's render buffers over to the target, deriving nothing from the pointer (nor from the lagging `current-window` index — the #32 lesson; its regression tests still pass). Whatever session buffer is really on screen gets converged, and an out-of-band display heals on the next swap instead of poisoning all of them. The pointer remains as the read-side hint for `connect-or-switch` and the flock switcher, recorded on every swap as before.
2. **`tmux-control-select-pane`** hops windows when the pane's window differs from the window of the buffer the command ran in **or** from the session's current window — either mismatch means a bare `select-pane` would be invisible; both views then converge on the pane's window.

## Validation

- New unit tests: swap converges when the pointer already claims the target is shown; select-pane jumps when tmux is already on the pane's window but the invoking buffer renders another. Both **fail on main, pass here**.
- New integration test replaying the reported sequence end to end (jump to w1 → display w0's buffer by hand → select w1's pane again → view must come back). **Fails on main, passes here.**
- 119 unit + 15 integration green, against both source and byte-compiled loads; clean strict byte-compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)