### PR TITLE
Anchor flushes to the screen top only in tiled panes

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -2220,5 +2220,48 @@ output), :calls (side-effect invocations in order), :active-pane,
         (should-not window-selected)
         (should (equal (car sent) "select-pane -t %0"))))))
 
+(ert-deftest tmux-control-test-flush-anchors-only-tiled-panes ()
+  ;; The screen-top anchor exists for TILED panes.  It counts buffer lines
+  ;; back from point-max, which lands above eat's display-beginning whenever
+  ;; a screen row is a wrapped continuation -- so in a per-window render
+  ;; buffer (which also sets `tmux-control--controller') every output flush
+  ;; re-anchored the view away from where eat's keystroke-time scroll sync
+  ;; had just put it, and typing into a TUI bounced the screen up and down
+  ;; once per character (field report).  The anchor must run only when the
+  ;; buffer's controller is actually tiling.
+  (let ((anchored 0)
+        (eat--synchronize-scroll-function #'ignore))
+    (cl-letf (((symbol-function 'tmux-control--anchor-windows-to-screen-top)
+               (lambda (_) (cl-incf anchored)))
+              ((symbol-function 'eat-term-redisplay) #'ignore)
+              ((symbol-function 'eat-term-live-p) (lambda (_) t))
+              ((symbol-function 'tmux-control--keep-cursor-visible) #'ignore))
+      (let ((ctrl (generate-new-buffer " *tc-anchor-ctrl*")))
+        (unwind-protect
+            (progn
+              ;; Per-window render buffer: controller NOT tiled -> no anchor.
+              (with-temp-buffer
+                (setq-local tmux-control--terminal t
+                            tmux-control--display-dirty t
+                            tmux-control--controller ctrl)
+                (tmux-control--flush-display (list (selected-window))))
+              (should (= anchored 0))
+              ;; The controller buffer itself (no --controller): no anchor.
+              (with-temp-buffer
+                (setq-local tmux-control--terminal t
+                            tmux-control--display-dirty t)
+                (tmux-control--flush-display (list (selected-window))))
+              (should (= anchored 0))
+              ;; Tiled pane buffer: controller tiling -> anchored.
+              (with-current-buffer ctrl
+                (setq-local tmux-control--tiled t))
+              (with-temp-buffer
+                (setq-local tmux-control--terminal t
+                            tmux-control--display-dirty t
+                            tmux-control--controller ctrl)
+                (tmux-control--flush-display (list (selected-window))))
+              (should (= anchored 1)))
+          (kill-buffer ctrl))))))
+
 (provide 'tmux-control-test)
 ;;; tmux-control-test.el ends here

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -2261,7 +2261,8 @@ output), :calls (side-effect invocations in order), :active-pane,
                             tmux-control--controller ctrl)
                 (tmux-control--flush-display (list (selected-window))))
               (should (= anchored 1)))
-          (kill-buffer ctrl))))))
+          (when (buffer-live-p ctrl)
+            (kill-buffer ctrl)))))))
 
 (provide 'tmux-control-test)
 ;;; tmux-control-test.el ends here

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -3517,11 +3517,21 @@ cursor position and their cursor line is kept visible."
       (when (and sync-windows
                  (boundp 'eat--synchronize-scroll-function))
         (funcall eat--synchronize-scroll-function sync-windows)
-        ;; In a tiled pane, anchor to the top of the current terminal screen
-        ;; so a full-screen TUI (e.g. a Claude Code panel) shows from its top
-        ;; instead of being scrolled with its top cut off when tall
+        ;; In a TILED pane only, anchor to the top of the current terminal
+        ;; screen so a full-screen TUI (e.g. a Claude Code panel) shows from
+        ;; its top instead of being scrolled with its top cut off when tall
         ;; box-drawing glyphs make the rows overflow the body in pixels.
-        (when tmux-control--controller
+        ;; Only there: the anchor counts buffer LINES back from point-max,
+        ;; which lands above eat's display-beginning whenever a screen row
+        ;; is a wrapped continuation.  A per-window render buffer sets
+        ;; `tmux-control--controller' too, and inheriting the anchor made
+        ;; every output flush fight eat's keystroke-time scroll sync -- the
+        ;; view bounced between the two notions of "screen top" on each
+        ;; typed character.
+        (when (and tmux-control--controller
+                   (buffer-live-p tmux-control--controller)
+                   (buffer-local-value 'tmux-control--tiled
+                                       tmux-control--controller))
           (tmux-control--anchor-windows-to-screen-top sync-windows))
         (tmux-control--keep-cursor-visible sync-windows))
       (run-hooks 'eat-update-hook))))


### PR DESCRIPTION
## The report

Typing into a full-screen TUI (a Claude Code panel on `nebius-0`) shown in a per-window render buffer made the screen bounce up and down a little on every character.

## Diagnosis (instrumented live)

A 20ms `window-start` trace during real keystrokes showed the view alternating between two positions at typing frequency, 185 chars apart:

- Each keystroke: `eat-self-input` runs eat's own scroll sync → `window-start := eat-term-display-beginning` (**65676**).
- Each echo (~250ms later): the output flush ran `tmux-control--anchor-windows-to-screen-top` → `window-start :=` *(point-max minus height−1 buffer lines)* (**65491**).

The two notions of "top of screen" differ whenever any screen row is a **wrapped continuation** of a long line — here a 185-char `Run dir: /mnt/...` row occupying two screen rows as one buffer line. Counting buffer lines back from `point-max` then overshoots eat's `display-beginning` and pulls a scrollback row into view (which also pixel-clips the bottom status row at rest). Every keystroke snapped the view to eat's notion; every echo snapped it back. Visible bounce.

## Why it regressed

The anchor was built for **tiled panes** (e9c1a79), when "has a `tmux-control--controller`" uniquely identified them. Per-window render buffers (e6b2db6) set `tmux-control--controller` too and inherited the anchor by aliasing. The controller buffer itself never runs it — which is why window 0's view (the base buffer) never bounced while window 1's did.

## The fix

Scope the anchor to buffers whose controller is actually tiling (`tmux-control--tiled`). Per-window buffers now follow eat's own sync plus `tmux-control--keep-cursor-visible` — exactly the controller buffer's proven behavior. Tiled behavior is unchanged.

## Validation

- New unit test pinning the guard (per-window flush and controller flush never anchor; tiled-pane flush does) — **fails on main, passes here**.
- 120 unit + 15 integration green, source and byte-compiled; clean strict compile.
- **Live before/after** on the reporting session, same 12-keystroke experiment:
  - before: 25 window-start transitions in 4s (65491 ↔ 65676 on every key and echo)
  - after: a single transition at the first keystroke (the one-time correction onto the true screen top), then flat for all subsequent keys and echoes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)