### PR TITLE
Detect and resolve a window whose size tmux won't let us drive

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -373,6 +373,35 @@ backlog.  It engages only on a genuinely **low-bandwidth** link — Emacs reads
 the socket eagerly, so a fast client (even a high-latency-but-fat-pipe SSH one)
 keeps up and never triggers it.  Off by default; needs tmux 3.2+.
 
+## Window sizing, and sharing a session with another client
+
+tmux sizes each window from its attached clients according to the
+`window-size` option (default **latest**: the most recently active client
+wins).  tmux-control asks for the size of your Emacs window on every layout
+change, so normally the pane follows Emacs exactly.  Two situations break
+that, and both used to fail *silently*:
+
+- **A pinned window.**  Any `resize-window` — yours, a script's, another
+  tool's — sets that window's `window-size` to `manual` as a side effect,
+  after which tmux ignores every client size request.  The view then keeps
+  reconciling to a grid that never matches your Emacs window (content
+  wrapped for a different width reads as mangled).
+- **A competing client.**  With the session also attached in another
+  terminal (iTerm2, say), `latest` means whichever client acted last sizes
+  the window — every hand-off makes the TUI reflow and repaint.
+
+tmux-control now notices when tmux did not follow a size request, probes the
+window's `window-size` in-band, and tells you which case you are in — once,
+in the session buffer and the echo area.  **`M-x
+tmux-control-adopt-window-size`** resolves either: it sets the rendered
+window's `window-size` back to `latest` and resizes it to your Emacs window
+on the spot.
+
+When you *want* long-term cohabitation with another client, consider
+`set-option -g window-size smallest` on that server (both clients see the
+same content, letterboxed to the smaller one) — or keep the other client
+detached while working from Emacs.
+
 ## A connection that stops replying
 
 Replies on the control connection are matched to commands strictly in order,

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -378,8 +378,10 @@ keeps up and never triggers it.  Off by default; needs tmux 3.2+.
 tmux sizes each window from its attached clients according to the
 `window-size` option (default **latest**: the most recently active client
 wins).  tmux-control asks for the size of your Emacs window on every layout
-change, so normally the pane follows Emacs exactly.  Two situations break
-that, and both used to fail *silently*:
+change, so normally the tmux *window* follows Emacs exactly (in a split
+window the active pane is its share of that — the renderer always matches
+the pane).  Two situations break the following, and both used to fail
+*silently*:
 
 - **A pinned window.**  Any `resize-window` — yours, a script's, another
   tool's — sets that window's `window-size` to `manual` as a side effect,

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -2330,13 +2330,16 @@ output), :calls (side-effect invocations in order), :active-pane,
                 ((symbol-function 'message) #'ignore))
         (setq-local tmux-control--session "s"
                     tmux-control--current-window "0"
+                    tmux-control--window-id "@7" ; the displayed window
                     tmux-control--requested-client-size (cons 124 37)
                     tmux-control--size-pin-warned nil)
-        ;; Mismatched width: probe fires, names the pin, warns in-buffer.
+        ;; Mismatched WINDOW width: probe fires -- targeting the displayed
+        ;; window by stable @id, as a -w window option -- and the warning
+        ;; names the pin in-buffer.
         (tmux-control--maybe-warn-pinned-size (cons 100 20))
         (should tmux-control--size-pin-warned)
         (should (= 1 (length queries)))
-        (should (string-match-p "show-options -qv -t s:0 window-size"
+        (should (string-match-p "show-options -wqv -t @7 window-size"
                                 (car queries)))
         (should (string-match-p "window-size manual" (buffer-string)))
         ;; Still mismatched: no second probe, no second warning.

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -2319,5 +2319,56 @@ output), :calls (side-effect invocations in order), :active-pane,
           (kill-buffer sb)
           (kill-buffer live))))))
 
+(ert-deftest tmux-control-test-pinned-size-warns-once-and-recovers ()
+  ;; tmux silently refusing our size requests (window-size manual after any
+  ;; resize-window, or a competing client) must be surfaced: one probe+warn
+  ;; per episode, episode cleared when a reconciliation matches again.
+  (with-temp-buffer
+    (let ((queries '()))
+      (cl-letf (((symbol-function 'tmux-control--query)
+                 (lambda (cmd cb) (push cmd queries) (funcall cb '("manual"))))
+                ((symbol-function 'message) #'ignore))
+        (setq-local tmux-control--session "s"
+                    tmux-control--current-window "0"
+                    tmux-control--requested-client-size (cons 124 37)
+                    tmux-control--size-pin-warned nil)
+        ;; Mismatched width: probe fires, names the pin, warns in-buffer.
+        (tmux-control--maybe-warn-pinned-size (cons 100 20))
+        (should tmux-control--size-pin-warned)
+        (should (= 1 (length queries)))
+        (should (string-match-p "show-options -qv -t s:0 window-size"
+                                (car queries)))
+        (should (string-match-p "window-size manual" (buffer-string)))
+        ;; Still mismatched: no second probe, no second warning.
+        (tmux-control--maybe-warn-pinned-size (cons 100 20))
+        (should (= 1 (length queries)))
+        ;; tmux follows again: the episode ends.
+        (tmux-control--maybe-warn-pinned-size (cons 124 36))
+        (should-not tmux-control--size-pin-warned)))))
+
+(ert-deftest tmux-control-test-adopt-window-size-unpins ()
+  ;; The recovery command unpins the rendered window and resizes to the
+  ;; Emacs window, clearing the warning episode.
+  (with-temp-buffer
+    (let ((sent '()) (resized nil))
+      (cl-letf (((symbol-function 'tmux-control--ensure-live) #'ignore)
+                ((symbol-function 'tmux-control--resize-to-window)
+                 (lambda () (setq resized t)))
+                ((symbol-function 'tmux-control--send-command)
+                 (lambda (cmd &optional _kind) (push cmd sent)))
+                ((symbol-function 'message) #'ignore))
+        (setq-local tmux-control--session "s"
+                    tmux-control--window-id "@2"
+                    tmux-control--current-window "0"
+                    tmux-control--windows
+                    '((:index "0" :name "a" :id "@1")
+                      (:index "1" :name "b" :id "@2"))
+                    tmux-control--size-pin-warned t)
+        (tmux-control-adopt-window-size)
+        ;; Targets the window THIS buffer renders (@2 -> index 1).
+        (should (equal (car sent) "set-option -w -t s:1 window-size latest"))
+        (should resized)
+        (should-not tmux-control--size-pin-warned)))))
+
 (provide 'tmux-control-test)
 ;;; tmux-control-test.el ends here

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -3299,21 +3299,33 @@ swallowed as content and the reply queue would desynchronize."
            (tmux-control--refresh-alt-screen-option)
            (tmux-control--refresh-pane-size))))
       (:pane-size
-       (let ((size (tmux-control--parse-pane-size output)))
+       ;; The reply carries "PANExSIZE\tWINDOWxSIZE": the PANE size drives
+       ;; the renderer (in a split window the active pane is narrower than
+       ;; the window, and the grid must match the pane); the WINDOW size is
+       ;; what refresh-client actually negotiates, so the pin detection
+       ;; compares THAT against what we asked for -- comparing the pane
+       ;; would cry wolf on every split layout.
+       (let* ((val (car (cl-remove-if #'string-empty-p
+                                      (mapcar #'string-trim output))))
+              (parts (and val (split-string val "\t")))
+              (size (tmux-control--parse-pane-size
+                     (list (or (car parts) ""))))
+              (win-size (and (cadr parts)
+                             (tmux-control--parse-pane-size
+                              (list (cadr parts))))))
          (when (and size
                     (tmux-control--apply-eat-size (car size) (cdr size)))
            ;; The grid changed under already-rendered output, so repaint
            ;; the visible screen at the corrected width.
            (tmux-control--seed-screen))
-         ;; A pane that stays at another size than the one we just asked
-         ;; tmux for usually means the window's size is PINNED
-         ;; (window-size manual -- e.g. after any `resize-window', which
-         ;; tmux pins as a side effect) or owned by another attached
-         ;; client.  That failure is otherwise silent: the view keeps
-         ;; reconciling to a grid that never matches the Emacs window.
-         ;; Probe and say so, once per episode.
-         (when size
-           (tmux-control--maybe-warn-pinned-size size))))
+         ;; A WINDOW that stays at another size than the one we just asked
+         ;; tmux for means its size is PINNED (window-size manual -- e.g.
+         ;; after any `resize-window', which tmux pins as a side effect) or
+         ;; owned by another attached client.  That failure is otherwise
+         ;; silent: the view keeps reconciling to a grid that never matches
+         ;; the Emacs window.  Probe and say so, once per episode.
+         (when win-size
+           (tmux-control--maybe-warn-pinned-size win-size))))
       (:windows
        (tmux-control--update-windows output))
       (:pane-window
@@ -3937,17 +3949,19 @@ by the `:pane-size' branch of `tmux-control--finish-command-output'."
   (when (and tmux-control--active-pane
              (process-live-p tmux-control--process))
     (tmux-control--send-command
-     (format "display-message -p -t %s \"#{pane_width}x#{pane_height}\""
+     (format "display-message -p -t %s \"#{pane_width}x#{pane_height}\t#{window_width}x#{window_height}\""
              tmux-control--active-pane)
      :pane-size)))
 
 (defun tmux-control--maybe-warn-pinned-size (actual)
-  "Warn once when tmux keeps the pane at ACTUAL despite our size requests.
-Runs in the controller from the :pane-size reconciliation.  Compares
-widths only (heights legitimately differ by a status line), and probes
-the window's `window-size' option in-band before saying anything, so
-the warning names the actual cause: a pinned window (\"manual\" -- the
-side effect of any `resize-window') or a competing attached client.
+  "Warn once when tmux keeps the WINDOW at ACTUAL despite our size requests.
+ACTUAL is the window size from the :pane-size reconciliation reply (the
+window, not the pane: a split window's active pane is legitimately
+narrower than what refresh-client negotiates).  Compares widths only
+\(heights legitimately differ by a status line), and probes the
+displayed window's `window-size' option in-band before saying anything,
+so the warning names the actual cause: a pinned window (\"manual\" --
+the side effect of any `resize-window') or a competing attached client.
 Resolving it is one command: `tmux-control-adopt-window-size'."
   (let ((requested tmux-control--requested-client-size))
     (cond
@@ -3957,11 +3971,18 @@ Resolving it is one command: `tmux-control-adopt-window-size'."
       (setq tmux-control--size-pin-warned nil))
      ((not tmux-control--size-pin-warned)
       (setq tmux-control--size-pin-warned t)
-      (let ((buffer (current-buffer))
-            (target (format "%s:%s" tmux-control--session
-                            (or tmux-control--current-window ""))))
+      (let* ((buffer (current-buffer))
+             ;; Probe the window actually on screen, by stable @id when
+             ;; known -- the cached current-window INDEX can lag rapid
+             ;; switches and would misattribute the diagnosis.
+             (display-id (buffer-local-value
+                          'tmux-control--window-id
+                          (tmux-control--session-display-buffer buffer)))
+             (target (or display-id
+                         (format "%s:%s" tmux-control--session
+                                 (or tmux-control--current-window "")))))
         (tmux-control--query
-         (format "show-options -qv -t %s window-size" target)
+         (format "show-options -wqv -t %s window-size" target)
          (lambda (lines)
            (when (buffer-live-p buffer)
              (with-current-buffer buffer

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -402,6 +402,13 @@ WINDOW-ID is tmux's stable @id string.  Includes the connect buffer
 itself under its own window id once that id is known.")
 (defvar-local tmux-control--window-id nil
   "The tmux @window-id this buffer renders, or nil before it is known.")
+(defvar-local tmux-control--requested-client-size nil
+  "On the controller: the (WIDTH . HEIGHT) last asked of refresh-client.
+Compared against the :pane-size reconciliation reply to notice a window
+whose size tmux is not letting this client drive.")
+(defvar-local tmux-control--size-pin-warned nil
+  "Non-nil after warning that tmux is not following our size requests.
+One warning per episode; cleared when a reconciliation matches again.")
 (defvar-local tmux-control--session-display nil
   "On the controller: the render buffer the live view last swapped to.
 What `tmux-control--session-display-buffer' readers (the session
@@ -3297,7 +3304,16 @@ swallowed as content and the reply queue would desynchronize."
                     (tmux-control--apply-eat-size (car size) (cdr size)))
            ;; The grid changed under already-rendered output, so repaint
            ;; the visible screen at the corrected width.
-           (tmux-control--seed-screen))))
+           (tmux-control--seed-screen))
+         ;; A pane that stays at another size than the one we just asked
+         ;; tmux for usually means the window's size is PINNED
+         ;; (window-size manual -- e.g. after any `resize-window', which
+         ;; tmux pins as a side effect) or owned by another attached
+         ;; client.  That failure is otherwise silent: the view keeps
+         ;; reconciling to a grid that never matches the Emacs window.
+         ;; Probe and say so, once per episode.
+         (when size
+           (tmux-control--maybe-warn-pinned-size size))))
       (:windows
        (tmux-control--update-windows output))
       (:pane-window
@@ -3824,6 +3840,11 @@ redraws stay aligned."
         (tmux-control--keep-cursor-visible
          (eat--synchronize-scroll-windows)))))
   (tmux-control--send-command (format "refresh-client -C %dx%d" width height))
+  ;; Remember what we asked for, so the :pane-size reconciliation can
+  ;; notice tmux NOT following (a pinned window-size, a competing client)
+  ;; and say so instead of silently snapping the grid back.
+  (with-current-buffer (tmux-control--wb-controller)
+    (setq tmux-control--requested-client-size (cons width height)))
   ;; refresh-client sizes the CLIENT, so tmux resizes every window to it;
   ;; keep the sibling window render buffers' grids in step so background
   ;; output renders at the size tmux is actually emitting for.
@@ -3919,6 +3940,70 @@ by the `:pane-size' branch of `tmux-control--finish-command-output'."
      (format "display-message -p -t %s \"#{pane_width}x#{pane_height}\""
              tmux-control--active-pane)
      :pane-size)))
+
+(defun tmux-control--maybe-warn-pinned-size (actual)
+  "Warn once when tmux keeps the pane at ACTUAL despite our size requests.
+Runs in the controller from the :pane-size reconciliation.  Compares
+widths only (heights legitimately differ by a status line), and probes
+the window's `window-size' option in-band before saying anything, so
+the warning names the actual cause: a pinned window (\"manual\" -- the
+side effect of any `resize-window') or a competing attached client.
+Resolving it is one command: `tmux-control-adopt-window-size'."
+  (let ((requested tmux-control--requested-client-size))
+    (cond
+     ((null requested) nil)
+     ((= (car requested) (car actual))
+      ;; tmux followed us; any earlier episode is over.
+      (setq tmux-control--size-pin-warned nil))
+     ((not tmux-control--size-pin-warned)
+      (setq tmux-control--size-pin-warned t)
+      (let ((buffer (current-buffer))
+            (target (format "%s:%s" tmux-control--session
+                            (or tmux-control--current-window ""))))
+        (tmux-control--query
+         (format "show-options -qv -t %s window-size" target)
+         (lambda (lines)
+           (when (buffer-live-p buffer)
+             (with-current-buffer buffer
+               (let* ((value (and lines
+                                  (car (cl-remove-if #'string-empty-p
+                                                     (mapcar #'string-trim
+                                                             lines)))))
+                      (text (if (equal value "manual")
+                                (format "tmux window size is pinned (window-size manual), so the view cannot follow this Emacs window (stuck at %dx%d); M-x tmux-control-adopt-window-size to unpin"
+                                        (car actual) (cdr actual))
+                              (format "tmux kept the window at %dx%d (asked %dx%d): window-size is %s -- another attached client may be sizing it; M-x tmux-control-adopt-window-size to take over"
+                                      (car actual) (cdr actual)
+                                      (car requested) (cdr requested)
+                                      (or value "default")))))
+                 (tmux-control--message text)
+                 (message "tmux-control: %s" text)))))))))))
+
+(defun tmux-control-adopt-window-size ()
+  "Make the current tmux window's size follow this Emacs window.
+Sets the window's `window-size' option to latest (undoing the manual pin
+tmux applies as a side effect of any `resize-window', or wresting the
+size from another attached client's stale claim) and immediately resizes
+to this Emacs window.  See the guide on sharing a session with another
+client (e.g. iTerm2) for the trade-offs."
+  (interactive)
+  (tmux-control--ensure-live)
+  (let* ((ctrl (tmux-control--wb-controller))
+         (idx (or (and tmux-control--window-id
+                       (with-current-buffer ctrl
+                         (cl-loop for w in tmux-control--windows
+                                  when (equal (plist-get w :id)
+                                              tmux-control--window-id)
+                                  return (plist-get w :index))))
+                  (buffer-local-value 'tmux-control--current-window ctrl))))
+    (tmux-control--send-command
+     (format "set-option -w -t %s%s window-size latest"
+             tmux-control--session
+             (if idx (concat ":" idx) ":")))
+    (with-current-buffer ctrl
+      (setq tmux-control--size-pin-warned nil))
+    (tmux-control--resize-to-window)
+    (message "tmux-control: window now follows this Emacs window")))
 
 (defun tmux-control--sentinel (process message)
   "Handle PROCESS exit with MESSAGE."


### PR DESCRIPTION
Evaluation of the field report "copilot TUI gets mangled when I change the window size", against real copilot with a render oracle at every step:

**The resize pipeline is faithful** — every size, idle and mid-stream, converges cell-for-cell. The mangling comes from two environmental states that failed *silently*:

1. **A pinned window**: any `resize-window` sets `window-size manual` as a side effect; tmux then ignores all client size requests, and the view reconciles forever to a grid that never matches the Emacs window (content wrapped for another width = "mangled").
2. **A competing client**: a second attached client (iTerm2) under default `window-size latest` re-sizes the window on every hand-off — constant TUI reflow.

Now the `:pane-size` reconciliation compares tmux's answer to what we requested; on mismatch it probes `window-size` in-band and names the case — once per episode, buffer + echo area. **`M-x tmux-control-adopt-window-size`** resolves either: window back to `latest`, resized to the Emacs window on the spot.

Live-validated end to end (pin → refused resize → correct warning → adopt → unpinned + resized + oracle MATCH). Guide gains a sharing-with-iTerm section. 2 new unit tests; 123 green; strict compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)