### PR TITLE
Foreign-pane events, seed drift, homeless controller: chaos-soak finds

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -511,3 +511,17 @@ Emacs while exercising tiling by hand:
 (load-file "test/tmux-control-live-oracle.el")
 (tmux-control-live-compare-all "main")  ;; MATCH/DIFF per tiled pane
 ```
+
+A **chaos soak** (`test/tmux-control-chaos.el`) drives a live GUI session
+through a reproducible random stream of realistic operations — window
+switches, the pager, typing, pastes, floods, frame resizes, char-mode
+round trips, reconnects, window/pane churn — checking after every step
+that the displayed screen matches `capture-pane`, the command queue
+drains, no view is stranded, and buffers stay bounded.  Run it against a
+throwaway `tmux -L tc-chaos` server (see the file's commentary); the
+same seed replays the same sequence:
+
+```elisp
+(load-file "test/tmux-control-chaos.el")
+(tmux-control-chaos-run 120 1234)   ;; STEPS SEED; nil = clean
+```

--- a/test/tmux-control-chaos.el
+++ b/test/tmux-control-chaos.el
@@ -1,0 +1,384 @@
+;;; tmux-control-chaos.el --- Randomized live soak harness -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; A chaos soak for a LIVE, GUI tmux-control session: drive a random but
+;; reproducible stream of realistic operations -- window switches, the
+;; scrollback pager, typing, pastes, output floods, frame resizes,
+;; char-mode round trips, reconnects, window and pane churn -- and check
+;; invariants after every step:
+;;
+;;   - the displayed buffer's Eat screen matches tmux `capture-pane'
+;;     (with one settle retry for in-flight output)
+;;   - the command queue drains
+;;   - the displayed buffer is a tmux-control buffer (no stranded view)
+;;   - render buffers stay bounded (Eat's scrollback trim is working)
+;;   - the timer list does not grow without bound
+;;
+;; This is a MANUAL tool, not part of `make test': it needs a GUI frame
+;; (frame resizing is one of the ops) and minutes of wall clock.  It has
+;; caught real bugs the scripted suites missed: a foreign-window
+;; %window-pane-changed retargeting the controller onto a pane that
+;; later died, and a one-row screen drift from %output interleaving a
+;; seed's cursor and capture replies.
+;;
+;; Usage, from a GUI Emacs with tmux-control loaded:
+;;
+;;   (load "test/tmux-control-chaos.el")
+;;   ;; throwaway server: tmux -L tc-chaos new-session -d -s chaos -x 120 -y 30
+;;   ;; (plus a couple of extra windows), then connect tmux-control to it
+;;   ;; and display the live buffer in the selected window.
+;;   (tmux-control-chaos-run 120 1234)   ; STEPS SEED
+;;
+;; The same SEED replays the same operation sequence (an LCG; Emacs's
+;; seeded `random' is not stable across builds).  A non-nil result lists
+;; (STEP OP PROBLEMS) triples.  `tmux-control-chaos-run-until-failure'
+;; stops at the first failure, leaving the live state frozen for
+;; inspection.
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'tmux-control)
+
+(defvar tmux-control-chaos-socket "tc-chaos"
+  "tmux -L socket name the chaos ops drive out-of-band.")
+(defvar tmux-control-chaos-session "chaos"
+  "tmux session name the chaos ops target.")
+(defvar tmux-control-chaos-windows 3
+  "How many windows the soak assumes exist (switch targets 0..N-1).")
+
+(defvar tmux-control-chaos--seed 1)
+(defvar tmux-control-chaos--trace nil)
+(defvar tmux-control-chaos--failures nil)
+
+(defun tmux-control-chaos--rand (n)
+  (setq tmux-control-chaos--seed
+        (mod (+ (* tmux-control-chaos--seed 1103515245) 12345) 2147483648))
+  (mod (/ tmux-control-chaos--seed 65536) n))
+
+(defun tmux-control-chaos--gui-frame ()
+  (or (cl-find-if (lambda (f) (frame-parameter f 'window-system))
+                  (frame-list))
+      (error "tmux-control-chaos needs a GUI frame")))
+
+(defun tmux-control-chaos--ctrl ()
+  (or (cl-find-if (lambda (b)
+                    (with-current-buffer b
+                      (and (derived-mode-p 'tmux-control-mode)
+                           (not tmux-control--controller)
+                           (process-live-p tmux-control--process))))
+                  (buffer-list))
+      (error "No live tmux-control controller buffer")))
+
+(defun tmux-control-chaos--win ()
+  (frame-selected-window (tmux-control-chaos--gui-frame)))
+(defun tmux-control-chaos--displayed ()
+  (window-buffer (tmux-control-chaos--win)))
+(defun tmux-control-chaos--in-displayed (fn)
+  (with-selected-frame (tmux-control-chaos--gui-frame)
+    (with-selected-window (tmux-control-chaos--win) (funcall fn))))
+
+(defun tmux-control-chaos--screen-text (buf)
+  "BUF's visible Eat screen, invisible padding stripped, tabs expanded."
+  (with-current-buffer buf
+    (let* ((term tmux-control--terminal)
+           (raw (buffer-substring (eat-term-display-beginning term)
+                                  (eat-term-end term)))
+           (out ""))
+      (let ((i 0) (n (length raw)))
+        (while (< i n)
+          (let ((next (or (next-single-property-change i 'invisible raw) n)))
+            (unless (get-text-property i 'invisible raw)
+              (setq out (concat out (substring raw i next))))
+            (setq i next))))
+      (with-temp-buffer (insert out) (untabify (point-min) (point-max))
+                        (buffer-string)))))
+
+(defun tmux-control-chaos--tmux (&rest args)
+  (apply #'call-process "tmux" nil nil nil
+         "-L" tmux-control-chaos-socket args))
+(defun tmux-control-chaos--tmux-out (&rest args)
+  (with-output-to-string
+    (with-current-buffer standard-output
+      (apply #'call-process "tmux" nil t nil
+             "-L" tmux-control-chaos-socket args))))
+
+(defun tmux-control-chaos--pump (secs)
+  (let ((t0 (float-time)))
+    (while (< (- (float-time) t0) secs)
+      (accept-process-output nil 0.03))))
+
+(defun tmux-control-chaos--settle (&optional secs)
+  "Pump process output until the command queue drains (timeout SECS)."
+  (let ((t0 (float-time)) (limit (or secs 8)))
+    (while (and (< (- (float-time) t0) limit)
+                (with-current-buffer (tmux-control-chaos--ctrl)
+                  (or tmux-control--command-queue
+                      tmux-control--collecting-command)))
+      (accept-process-output nil 0.03))
+    (tmux-control-chaos--pump 0.25)))
+
+;;;; Operations
+
+(defmacro tmux-control-chaos--defop (name weight &rest body)
+  "Define chaos op NAME with selection WEIGHT and BODY."
+  (declare (indent 2))
+  `(progn
+     (defun ,name () ,@body)
+     (push (cons ',name ,weight) tmux-control-chaos--ops)))
+
+(defvar tmux-control-chaos--ops nil)
+(setq tmux-control-chaos--ops nil)
+
+(tmux-control-chaos--defop tmux-control-chaos--op-switch-window 14
+  (let ((idx (number-to-string
+              (tmux-control-chaos--rand tmux-control-chaos-windows))))
+    (tmux-control-chaos--in-displayed
+     (lambda () (tmux-control-select-window idx)))
+    (tmux-control-chaos--settle)))
+
+(tmux-control-chaos--defop tmux-control-chaos--op-next-window 8
+  (tmux-control-chaos--in-displayed #'tmux-control-next-window)
+  (tmux-control-chaos--settle))
+
+(tmux-control-chaos--defop tmux-control-chaos--op-prev-window 6
+  (tmux-control-chaos--in-displayed #'tmux-control-previous-window)
+  (tmux-control-chaos--settle))
+
+(tmux-control-chaos--defop tmux-control-chaos--op-pager-roundtrip 10
+  (when (with-current-buffer (tmux-control-chaos--displayed)
+          (derived-mode-p 'tmux-control-mode))
+    (tmux-control-chaos--in-displayed #'tmux-control-scrollback)
+    (tmux-control-chaos--settle)
+    (when (with-current-buffer (tmux-control-chaos--displayed)
+            (derived-mode-p 'tmux-control-scrollback-mode))
+      (tmux-control-chaos--in-displayed #'tmux-control-live))
+    (tmux-control-chaos--settle)))
+
+(tmux-control-chaos--defop tmux-control-chaos--op-wheel-exit 6
+  (when (with-current-buffer (tmux-control-chaos--displayed)
+          (derived-mode-p 'tmux-control-mode))
+    (tmux-control-chaos--in-displayed #'tmux-control-scrollback)
+    (tmux-control-chaos--settle)
+    (let ((w (tmux-control-chaos--win)))
+      (when (with-current-buffer (window-buffer w)
+              (derived-mode-p 'tmux-control-scrollback-mode))
+        (with-selected-window w
+          (with-current-buffer (window-buffer w)
+            (goto-char (point-max))
+            (funcall (key-binding [wheel-down])
+                     (list 'wheel-down (list w)))))))
+    (tmux-control-chaos--settle)))
+
+(tmux-control-chaos--defop tmux-control-chaos--op-type 14
+  (with-current-buffer (tmux-control-chaos--displayed)
+    (when (derived-mode-p 'tmux-control-mode)
+      (tmux-control--send-input tmux-control--terminal "\C-u")
+      (tmux-control--send-input
+       tmux-control--terminal
+       (format " echo c%d" (tmux-control-chaos--rand 1000)))))
+  (tmux-control-chaos--settle))
+
+(tmux-control-chaos--defop tmux-control-chaos--op-clear-line 6
+  (with-current-buffer (tmux-control-chaos--displayed)
+    (when (derived-mode-p 'tmux-control-mode)
+      (tmux-control--send-input tmux-control--terminal "\C-u")))
+  (tmux-control-chaos--settle))
+
+(tmux-control-chaos--defop tmux-control-chaos--op-paste 8
+  (when (with-current-buffer (tmux-control-chaos--displayed)
+          (derived-mode-p 'tmux-control-mode))
+    (kill-new (format "p%d one\np%d two"
+                      (tmux-control-chaos--rand 100)
+                      (tmux-control-chaos--rand 100)))
+    (tmux-control-chaos--in-displayed #'tmux-control-yank)
+    (tmux-control-chaos--settle)
+    (with-current-buffer (tmux-control-chaos--displayed)
+      (when (derived-mode-p 'tmux-control-mode)
+        (tmux-control--send-input tmux-control--terminal "\C-c")))
+    (tmux-control-chaos--settle)))
+
+(tmux-control-chaos--defop tmux-control-chaos--op-flood-burst 8
+  (tmux-control-chaos--tmux
+   "send-keys" "-t"
+   (format "%s:%d" tmux-control-chaos-session
+           (tmux-control-chaos--rand tmux-control-chaos-windows))
+   (format "seq 1 %d" (+ 2000 (tmux-control-chaos--rand 4000)))
+   "Enter")
+  (tmux-control-chaos--settle 12))
+
+(tmux-control-chaos--defop tmux-control-chaos--op-resize 6
+  (set-frame-size (tmux-control-chaos--gui-frame)
+                  (+ 90 (tmux-control-chaos--rand 40))
+                  (+ 24 (tmux-control-chaos--rand 14)))
+  (tmux-control-chaos--settle 10))
+
+(tmux-control-chaos--defop tmux-control-chaos--op-char-mode-roundtrip 5
+  (with-current-buffer (tmux-control-chaos--displayed)
+    (when (derived-mode-p 'tmux-control-mode)
+      (eat-char-mode)
+      (eat-semi-char-mode)))
+  (tmux-control-chaos--settle))
+
+(tmux-control-chaos--defop tmux-control-chaos--op-clear-repaint 4
+  (when (with-current-buffer (tmux-control-chaos--displayed)
+          (derived-mode-p 'tmux-control-mode))
+    (tmux-control-chaos--in-displayed #'tmux-control-clear-and-repaint)
+    (tmux-control-chaos--settle)))
+
+(tmux-control-chaos--defop tmux-control-chaos--op-new-then-kill-window 3
+  (tmux-control-chaos--in-displayed
+   (lambda () (tmux-control-new-window "tmp")))
+  (tmux-control-chaos--settle)
+  (dolist (line (split-string
+                 (tmux-control-chaos--tmux-out
+                  "list-windows" "-t" tmux-control-chaos-session
+                  "-F" "#{window_index}\t#{window_name}")
+                 "\n" t))
+    (let ((cells (split-string line "\t")))
+      (when (equal (cadr cells) "tmp")
+        (tmux-control-chaos--tmux
+         "kill-window" "-t" (format "%s:%s" tmux-control-chaos-session
+                                    (car cells))))))
+  (tmux-control-chaos--settle))
+
+(tmux-control-chaos--defop tmux-control-chaos--op-split-then-kill-pane 4
+  (let ((cur (string-trim
+              (tmux-control-chaos--tmux-out
+               "display-message" "-p" "-t" tmux-control-chaos-session
+               "#{window_index}"))))
+    (tmux-control-chaos--tmux
+     "split-window" "-t" (format "%s:%s" tmux-control-chaos-session cur))
+    (tmux-control-chaos--settle 10)
+    (tmux-control-chaos--tmux
+     "send-keys" "-t" (format "%s:%s" tmux-control-chaos-session cur)
+     "seq 1 500" "Enter")
+    (tmux-control-chaos--settle)
+    (tmux-control-chaos--tmux
+     "kill-pane" "-t" (format "%s:%s" tmux-control-chaos-session cur))
+    (tmux-control-chaos--settle 10)))
+
+(tmux-control-chaos--defop tmux-control-chaos--op-kill-controller-window 2
+  (let ((wid (buffer-local-value 'tmux-control--window-id
+                                 (tmux-control-chaos--ctrl))))
+    (when wid
+      ;; Replacement first: killing the session's last window would end
+      ;; the session (and the soak) rather than exercise the close path.
+      (tmux-control-chaos--tmux
+       "new-window" "-d" "-t" (concat tmux-control-chaos-session ":"))
+      (tmux-control-chaos--tmux "kill-window" "-t" wid)
+      (tmux-control-chaos--settle 10))))
+
+(tmux-control-chaos--defop tmux-control-chaos--op-reconnect 2
+  (tmux-control-chaos--in-displayed #'tmux-control-reconnect)
+  (tmux-control-chaos--settle 15))
+
+(defun tmux-control-chaos--pick-op ()
+  (let* ((total (apply #'+ (mapcar #'cdr tmux-control-chaos--ops)))
+         (r (tmux-control-chaos--rand total)))
+    (catch 'pick
+      (dolist (entry tmux-control-chaos--ops)
+        (when (< r (cdr entry)) (throw 'pick (car entry)))
+        (setq r (- r (cdr entry)))))))
+
+;;;; Invariants
+
+(defun tmux-control-chaos--screen-tail (buf n)
+  (last (mapcar #'string-trim-right
+                (split-string
+                 (string-trim-right (tmux-control-chaos--screen-text buf))
+                 "\n"))
+        n))
+
+(defun tmux-control-chaos--capture-tail (pane n)
+  (last (mapcar #'string-trim-right
+                (split-string
+                 (string-trim-right
+                  (tmux-control-chaos--tmux-out "capture-pane" "-p" "-t" pane))
+                 "\n"))
+        n))
+
+(defun tmux-control-chaos--check (step op)
+  (let ((problems nil))
+    ;; Stranded view?
+    (let ((b (tmux-control-chaos--displayed)))
+      (unless (with-current-buffer b
+                (or (derived-mode-p 'tmux-control-mode)
+                    (derived-mode-p 'tmux-control-scrollback-mode)))
+        (push (format "stranded view: %s" (buffer-name b)) problems)))
+    (let ((ctrl (ignore-errors (tmux-control-chaos--ctrl))))
+      (if (not ctrl)
+          (push "no live controller" problems)
+        ;; Queue drained?
+        (when (buffer-local-value 'tmux-control--command-queue ctrl)
+          (push "queue not drained" problems))
+        ;; Render oracle on the displayed live buffer.
+        (let ((b (tmux-control-chaos--displayed)))
+          (when (with-current-buffer b (derived-mode-p 'tmux-control-mode))
+            (let ((pane (buffer-local-value 'tmux-control--active-pane b)))
+              (when (and pane
+                         (not (equal (tmux-control-chaos--screen-tail b 2)
+                                     (tmux-control-chaos--capture-tail pane 2))))
+                ;; one settle retry: in-flight output is not a failure
+                (tmux-control-chaos--pump 1.0)
+                (let ((eat-tail (tmux-control-chaos--screen-tail b 2))
+                      (cap-tail (tmux-control-chaos--capture-tail pane 2)))
+                  (unless (equal eat-tail cap-tail)
+                    (push (format "oracle diff: eat=%S cap=%S"
+                                  (mapcar #'substring-no-properties eat-tail)
+                                  cap-tail)
+                          problems)))))))
+        ;; Buffers bounded (Eat's scrollback trim at work).
+        (dolist (b (buffer-list))
+          (when (with-current-buffer b (derived-mode-p 'tmux-control-mode))
+            (when (> (buffer-size b) 400000)
+              (push (format "buffer %s grew to %d chars"
+                            (buffer-name b) (buffer-size b))
+                    problems))))
+        ;; Timer sanity.
+        (when (> (length timer-list) 25)
+          (push (format "timer-list grew to %d" (length timer-list))
+                problems))))
+    (when problems
+      (push (list step op problems) tmux-control-chaos--failures))
+    problems))
+
+;;;; Runners
+
+(defun tmux-control-chaos-run (steps seed)
+  "Run STEPS random ops from SEED; return the failure list (nil = clean)."
+  (setq tmux-control-chaos--seed seed
+        tmux-control-chaos--trace nil
+        tmux-control-chaos--failures nil)
+  (dotimes (i steps)
+    (let ((op (tmux-control-chaos--pick-op)))
+      (push (cons i op) tmux-control-chaos--trace)
+      (condition-case err
+          (funcall op)
+        (error (push (list i op (list (format "OP ERROR: %S" err)))
+                     tmux-control-chaos--failures)))
+      (tmux-control-chaos--check i op)))
+  (reverse tmux-control-chaos--failures))
+
+(defun tmux-control-chaos-run-until-failure (steps seed)
+  "Like `tmux-control-chaos-run' but stop at the first failure.
+The live state is left frozen for inspection; `tmux-control-chaos--trace'
+holds the operations that led there."
+  (setq tmux-control-chaos--seed seed
+        tmux-control-chaos--trace nil
+        tmux-control-chaos--failures nil)
+  (catch 'stop
+    (dotimes (i steps)
+      (let ((op (tmux-control-chaos--pick-op)))
+        (push (cons i op) tmux-control-chaos--trace)
+        (condition-case err
+            (funcall op)
+          (error (push (list i op (list (format "OP ERROR: %S" err)))
+                       tmux-control-chaos--failures)))
+        (when (tmux-control-chaos--check i op)
+          (throw 'stop (car tmux-control-chaos--failures)))))
+    :clean))
+
+(provide 'tmux-control-chaos)
+;;; tmux-control-chaos.el ends here

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -2909,7 +2909,46 @@ output), :calls (side-effect invocations in order), :active-pane,
         ;; split-brain twice, through two different re-homing paths).
         (tmux-control--update-windows '("5\tlive\t1\t0\t@9"))
         (should-not tmux-control--window-id)
-        (should-not (assoc "@9" tmux-control--window-buffers))))))
+        (should-not (assoc "@9" tmux-control--window-buffers))
+        ;; Nor may the first arriving %output bootstrap a pane into it
+        ;; (that exists for connect time, before :pane-id lands)...
+        (tmux-control--batch-pane-output "%9" "stray")
+        (should-not tmux-control--active-pane)
+        (should-not tmux-control--output-batch)
+        ;; ...nor a %window-pane-changed re-aim it -- every window's
+        ;; pane event is foreign to a buffer that owns no window.
+        (cl-letf (((symbol-function 'tmux-control--seed-screen)
+                   (lambda () (error "homeless controller reseeded")))
+                  ((symbol-function 'tmux-control--refresh-pane-window-map)
+                   #'ignore))
+          (tmux-control--handle-line "%window-pane-changed @9 %9"))
+        (should-not tmux-control--active-pane)))))
+
+(ert-deftest tmux-control-test-homeless-controller-drops-input-fallback ()
+  ;; With the active pane nil, input and paste normally fall back to the
+  ;; session target -- a connect-time affordance.  A HOMELESS controller
+  ;; must not: it would silently drive the session's current pane (which
+  ;; the user watches through a DIFFERENT buffer) from a frozen view.
+  (let ((sent '()))
+    (cl-letf (((symbol-function 'tmux-control--send-command)
+               (lambda (cmd &optional _kind) (push cmd sent)))
+              ((symbol-function 'tmux-control--message) #'ignore)
+              ((symbol-function 'process-live-p) (lambda (_) t)))
+      (with-temp-buffer
+        (tmux-control-mode)
+        (setq-local tmux-control--session "s"
+                    tmux-control--process (make-symbol "proc")
+                    tmux-control--active-pane nil
+                    tmux-control--fallback-target "s:"
+                    tmux-control--homeless t)
+        (tmux-control--send-input nil "x")
+        (tmux-control--paste-to-pane "clip")
+        (should (null sent))
+        ;; The connect-time fallback (NOT homeless) still works.
+        (setq tmux-control--homeless nil)
+        (tmux-control--send-input nil "x")
+        (should (cl-some (lambda (c) (string-match-p "send-keys -t s:" c))
+                         sent))))))
 
 (ert-deftest tmux-control-test-homeless-controller-stays-out-of-routing ()
   ;; A homeless controller does NOT adopt windows: a first cut that

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -2706,5 +2706,242 @@ output), :calls (side-effect invocations in order), :active-pane,
         (should offered)
         (should reconnected)))))
 
+(ert-deftest tmux-control-test-pane-changed-foreign-window-leaves-buffer-alone ()
+  ;; %window-pane-changed for an UNVISITED other window (no render buffer
+  ;; yet) must not retarget this buffer.  tmux-control-new-window emits
+  ;; this for the created window BEFORE the %session-window-changed that
+  ;; builds its buffer; adopting that pane aimed the controller at a
+  ;; foreign pane, and when the window later closed (an agent's task
+  ;; window) the controller was stranded on a DEAD pane -- empty screen,
+  ;; keystrokes into "can't find pane" -- and window switches did not
+  ;; heal it (chaos-soak find).
+  (let ((seeded 0) (map-refreshed 0))
+    (cl-letf (((symbol-function 'tmux-control--seed-screen)
+               (lambda () (cl-incf seeded)))
+              ((symbol-function 'tmux-control--refresh-alt-screen-option)
+               #'ignore)
+              ((symbol-function 'tmux-control--refresh-pane-size) #'ignore)
+              ((symbol-function 'tmux-control--refresh-pane-window-map)
+               (lambda () (cl-incf map-refreshed))))
+      (with-temp-buffer
+        (tmux-control-mode)
+        (let ((tmux-control-window-buffers t))
+          (setq-local tmux-control--window-id "@2"
+                      tmux-control--active-pane "%2"
+                      tmux-control--window-buffers nil
+                      tmux-control--collecting-command nil)
+          ;; Foreign window @7: pane stays ours, map refreshed, no reseed.
+          (tmux-control--handle-line "%window-pane-changed @7 %9")
+          (should (equal tmux-control--active-pane "%2"))
+          (should (= seeded 0))
+          (should (= map-refreshed 1))
+          ;; Our own window @2: follow the pane change.
+          (tmux-control--handle-line "%window-pane-changed @2 %5")
+          (should (equal tmux-control--active-pane "%5"))
+          (should (= seeded 1)))))))
+
+(ert-deftest tmux-control-test-pane-changed-legacy-mode-follows-unconditionally ()
+  ;; With per-window buffers OFF the single view mirrors the session and
+  ;; has always followed %window-pane-changed unconditionally -- a
+  ;; load-bearing affordance (it is how cross-window select-pane jumps
+  ;; worked); the foreign-window guard must not change it.
+  (let ((seeded 0))
+    (cl-letf (((symbol-function 'tmux-control--seed-screen)
+               (lambda () (cl-incf seeded)))
+              ((symbol-function 'tmux-control--refresh-alt-screen-option)
+               #'ignore)
+              ((symbol-function 'tmux-control--refresh-pane-size) #'ignore))
+      (with-temp-buffer
+        (tmux-control-mode)
+        (let ((tmux-control-window-buffers nil))
+          (setq-local tmux-control--window-id "@2"
+                      tmux-control--active-pane "%2"
+                      tmux-control--collecting-command nil)
+          (tmux-control--handle-line "%window-pane-changed @7 %9")
+          (should (equal tmux-control--active-pane "%9"))
+          (should (= seeded 1)))))))
+
+(ert-deftest tmux-control-test-new-and-kill-window-skip-pane-requery-when-gated ()
+  ;; With per-window buffers the echoed %session-window-changed swaps the
+  ;; display; re-querying the active pane would aim THIS buffer at the
+  ;; new window's pane while it still renders its own window -- the same
+  ;; foreign-pane corruption, through the :pane-id reply.  The window
+  ;; switch commands already gate this; new-window and kill-window must
+  ;; too.
+  (let ((requeried 0) (quieted 0) (sent '()))
+    (cl-letf (((symbol-function 'tmux-control--refresh-active-pane)
+               (lambda (&optional _self) (cl-incf requeried)))
+              ((symbol-function 'tmux-control--quiet-activity)
+               (lambda (&optional _secs) (cl-incf quieted)))
+              ((symbol-function 'tmux-control--ensure-live) #'ignore)
+              ((symbol-function 'tmux-control--send-command)
+               (lambda (cmd &optional _kind) (push cmd sent)))
+              ((symbol-function 'yes-or-no-p) (lambda (_) t)))
+      (with-temp-buffer
+        (tmux-control-mode)
+        (setq-local tmux-control--session "s")
+        (let ((tmux-control-window-buffers t))
+          (tmux-control-new-window "agent")
+          (tmux-control-kill-window "3")
+          (should (= requeried 0))
+          (should (= quieted 2)))
+        (let ((tmux-control-window-buffers nil))
+          (tmux-control-new-window "agent")
+          (tmux-control-kill-window "3")
+          (should (= requeried 2)))
+        (should (cl-some (lambda (c) (string-prefix-p "new-window" c)) sent))
+        (should (cl-some (lambda (c) (string-prefix-p "kill-window" c)) sent))))))
+
+(ert-deftest tmux-control-test-eat-cursor-xy-reads-terminal-cursor ()
+  ;; The drift detector compares tmux's 0-indexed #{cursor_x},#{cursor_y}
+  ;; with Eat's own cursor; the accessor must convert Eat's 1-indexed
+  ;; coordinates.
+  (with-temp-buffer
+    (tmux-control-mode)
+    (setq tmux-control--terminal (eat-term-make (current-buffer) (point-min)))
+    (eat-term-resize tmux-control--terminal 40 10)
+    (let ((inhibit-read-only t))
+      (eat-term-process-output tmux-control--terminal "ab")
+      (eat-term-redisplay tmux-control--terminal))
+    (should (equal (tmux-control--eat-cursor-xy) '(2 . 0)))
+    (let ((inhibit-read-only t))
+      (eat-term-process-output tmux-control--terminal "\r\ncd")
+      (eat-term-redisplay tmux-control--terminal))
+    (should (equal (tmux-control--eat-cursor-xy) '(2 . 1)))
+    (eat-term-delete tmux-control--terminal)))
+
+(ert-deftest tmux-control-test-verify-seed-reseeds-on-drift-bounded ()
+  ;; A seed's cursor query and capture are separate reply blocks; %output
+  ;; interleaved between them leaves the seeded baseline shifted -- one
+  ;; row off, FOREVER, since deltas preserve relative consistency (chaos
+  ;; soak find: a screen identical to the pane's but shifted one row,
+  ;; stable for minutes).  After each seed the verifier compares tmux's
+  ;; cursor with Eat's; drift triggers a bounded reseed, agreement resets
+  ;; the budget.
+  (let ((reseeds 0) (queries '()) (fresh "5,3") (mine '(5 . 3)))
+    (cl-letf (((symbol-function 'tmux-control--query)
+               (lambda (cmd cb) (push cmd queries) (funcall cb (list fresh))))
+              ((symbol-function 'tmux-control--eat-cursor-xy)
+               (lambda () mine)))
+      (with-temp-buffer
+        (tmux-control-mode)
+        (setq-local tmux-control--active-pane "%7"
+                    tmux-control--seed-verify-retries 0)
+        ;; Agreement: no reseed, budget reset.
+        (tmux-control--verify-seed (current-buffer)
+                                   (lambda () (cl-incf reseeds)))
+        (should (= reseeds 0))
+        (should (= tmux-control--seed-verify-retries 0))
+        (should (string-match-p "cursor_x.*cursor_y" (car queries)))
+        ;; Drift: reseed, budget consumed.
+        (setq mine '(5 . 2))
+        (tmux-control--verify-seed (current-buffer)
+                                   (lambda () (cl-incf reseeds)))
+        (should (= reseeds 1))
+        (should (= tmux-control--seed-verify-retries 1))
+        ;; Drift persists: second (last) retry...
+        (tmux-control--verify-seed (current-buffer)
+                                   (lambda () (cl-incf reseeds)))
+        (should (= reseeds 2))
+        ;; ...then the budget is exhausted: no further reseed, reset.
+        (tmux-control--verify-seed (current-buffer)
+                                   (lambda () (cl-incf reseeds)))
+        (should (= reseeds 2))
+        (should (= tmux-control--seed-verify-retries 0))
+        ;; Pane switched between issue and reply: not judged.  Defer the
+        ;; reply so the switch can happen in between, as it would live.
+        (let ((pending nil))
+          (cl-letf (((symbol-function 'tmux-control--query)
+                     (lambda (_cmd cb) (setq pending cb))))
+            (tmux-control--verify-seed (current-buffer)
+                                       (lambda () (cl-incf reseeds))))
+          (setq tmux-control--active-pane "%9")
+          (funcall pending (list fresh))
+          (should (= reseeds 2)))))))
+
+(ert-deftest tmux-control-test-seed-screen-issues-verification ()
+  ;; Every controller seed is followed by the drift-check query.
+  (let ((sent '()) (verified '()))
+    (cl-letf (((symbol-function 'tmux-control--send-command)
+               (lambda (cmd &optional kind) (push (cons kind cmd) sent)))
+              ((symbol-function 'tmux-control--verify-seed)
+               (lambda (buf _reseed) (push buf verified))))
+      (with-temp-buffer
+        (tmux-control-mode)
+        (setq-local tmux-control--active-pane "%3")
+        (tmux-control--seed-screen)
+        (should (equal (mapcar #'car (nreverse sent))
+                       '(:cursor-pos :capture)))
+        (should (equal verified (list (current-buffer))))))))
+
+(ert-deftest tmux-control-test-controller-window-close-goes-homeless ()
+  ;; When the CONTROLLER's own window closes (an agent's task window it
+  ;; was homed on), the buffer survives -- it owns the process -- but its
+  ;; window id and active pane are dead.  It must mark itself homeless
+  ;; (id and pane nil, registry entry gone) instead of rendering a frozen
+  ;; screen and sending keystrokes into "can't find pane" forever.
+  (cl-letf (((symbol-function 'tmux-control--refresh-windows) #'ignore)
+            ((symbol-function 'tmux-control--refresh-pane-window-map)
+             #'ignore))
+    (with-temp-buffer
+      (tmux-control-mode)
+      (let ((tmux-control-window-buffers t))
+        (setq-local tmux-control--window-id "@2"
+                    tmux-control--active-pane "%2"
+                    tmux-control--collecting-command nil
+                    tmux-control--window-buffers
+                    (list (cons "@2" (current-buffer))))
+        ;; Another window closing leaves the controller homed.
+        (tmux-control--handle-line "%window-close @7")
+        (should (equal tmux-control--window-id "@2"))
+        ;; Its own window closing makes it homeless.
+        (tmux-control--handle-line "%window-close @2")
+        (should-not tmux-control--window-id)
+        (should-not tmux-control--active-pane)
+        (should tmux-control--homeless)
+        (should-not (assoc "@2" tmux-control--window-buffers))
+        ;; CRITICAL: the window-list refresh must NOT re-claim the
+        ;; session's current window for a homeless controller.  That
+        ;; binding exists for connect time only -- re-firing it here
+        ;; orphaned the current window's render buffer from the
+        ;; registry, routed its output to the hidden controller, and
+        ;; froze the visible buffer (chaos-soak find: the same
+        ;; split-brain twice, through two different re-homing paths).
+        (tmux-control--update-windows '("5\tlive\t1\t0\t@9"))
+        (should-not tmux-control--window-id)
+        (should-not (assoc "@9" tmux-control--window-buffers))))))
+
+(ert-deftest tmux-control-test-homeless-controller-stays-out-of-routing ()
+  ;; A homeless controller does NOT adopt windows: a first cut that
+  ;; re-registered the controller under the next displayed window id
+  ;; created a SPLIT-BRAIN under churn -- two buffers claiming one
+  ;; window, output routed to the hidden one, the displayed one frozen
+  ;; (chaos-soak find).  The invariant is one window, one buffer: a
+  ;; switch while the controller is homeless builds an ordinary render
+  ;; buffer, and the controller keeps owning only the process.
+  (let ((made 0))
+    (cl-letf (((symbol-function 'tmux-control--make-window-buffer)
+               (lambda (&rest _) (cl-incf made)
+                 (generate-new-buffer " *tc-made*")))
+              ((symbol-function 'tmux-control--seed-window-buffer) #'ignore)
+              ((symbol-function 'tmux-control--resize-to-window) #'ignore))
+      (with-temp-buffer
+        (tmux-control-mode)
+        (setq-local tmux-control--window-id nil
+                    tmux-control--active-pane nil
+                    tmux-control--window-buffers nil
+                    tmux-control--session-display nil)
+        (let ((new (tmux-control--display-window-buffer "@9")))
+          (unwind-protect
+              (progn
+                ;; A fresh render buffer, not the controller.
+                (should-not (eq new (current-buffer)))
+                (should (= made 1))
+                ;; The controller stays homeless and unregistered.
+                (should-not tmux-control--window-id)
+                (should-not (cl-rassoc (current-buffer)
+                                       tmux-control--window-buffers)))
+            (when (buffer-live-p new) (kill-buffer new))))))))
+
 (provide 'tmux-control-test)
 ;;; tmux-control-test.el ends here

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -365,6 +365,15 @@ the block early.")
   "Non-nil after the watchdog has warned about the current stuck episode.
 Cleared when a reply arrives or the queue drains, so one wedge produces
 one warning rather than one per check interval.")
+(defvar-local tmux-control--homeless nil
+  "Non-nil in a controller buffer whose own tmux window has closed.
+The buffer keeps owning the process and the session state, but it no
+longer renders any window: its window id and active pane are nil, and
+this flag keeps the window-list refresh from re-claiming the session's
+current window for it (that window has -- or will get -- its own render
+buffer; two buffers claiming one window routes output to the hidden one
+and freezes the visible one).  Cleared by a (re)connect.")
+
 (defvar-local tmux-control--disconnecting nil
   "Non-nil while this session's control process is being shut down on purpose.
 Set by `tmux-control-disconnect' right before deleting the process and
@@ -1408,7 +1417,14 @@ With a NAME, give the new window that name."
    (concat (format "new-window -t %s:" tmux-control--session)
            (when (and name (not (string-empty-p name)))
              (concat " -n " (tmux-control--quote-tmux-arg name)))))
-  (tmux-control--refresh-active-pane t))
+  ;; Per-window buffers: the echoed %session-window-changed creates and
+  ;; displays the new window's buffer; re-querying the active pane here
+  ;; would aim THIS buffer at the new window's pane while it still renders
+  ;; its own window -- the foreign-pane corruption the window-switch
+  ;; commands already guard against (see `tmux-control--do-select-window').
+  (if tmux-control-window-buffers
+      (tmux-control--quiet-activity)
+    (tmux-control--refresh-active-pane t)))
 
 (defun tmux-control-kill-window (&optional index)
   "Kill window INDEX in the current tmux-control session.
@@ -1424,7 +1440,11 @@ window in the session ends the session and disconnects this client."
   (setq index (tmux-control--normalize-window-index index))
   (tmux-control--send-command
    (format "kill-window -t %s:%s" tmux-control--session index))
-  (tmux-control--refresh-active-pane t))
+  ;; Mirror tmux-control-new-window: with per-window buffers the
+  ;; %window-close/%session-window-changed echoes do all the work.
+  (if tmux-control-window-buffers
+      (tmux-control--quiet-activity)
+    (tmux-control--refresh-active-pane t)))
 
 (defun tmux-control-rename-window (&optional index name)
   "Rename window INDEX in the current tmux-control session to NAME.
@@ -1503,11 +1523,18 @@ the controller renders its own window, so a switch back to it swaps here."
       (when (hash-table-p tmux-control--activity)
         (remhash active tmux-control--activity)))
     ;; The controller doubles as the render buffer for the window it was
-    ;; connected on; bind it to that window's id once known.
+    ;; connected on; bind it to that window's id once known.  ONLY that
+    ;; once: a controller whose own window later closed has a nil id too,
+    ;; and re-binding it here -- this runs on every window-list refresh --
+    ;; silently re-homed it onto the session's current window, ORPHANING
+    ;; that window's render buffer from the registry: output then routed
+    ;; to the hidden controller while the user watched the orphan freeze
+    ;; (chaos-soak find; `tmux-control--homeless' marks the difference).
     (when (and tmux-control-window-buffers
                active-id
                (null tmux-control--controller)   ; we are the controller
-               (null tmux-control--window-id))
+               (null tmux-control--window-id)
+               (not tmux-control--homeless))
       (setq tmux-control--window-id active-id)
       (tmux-control--register-window-buffer active-id (current-buffer)))
     (force-mode-line-update)))
@@ -2379,6 +2406,7 @@ so the tmux-control keys get out of the way; the mode line shows
               (kill-buffer buf))))))
     (setq tmux-control--window-buffers nil)
     (setq tmux-control--window-id nil)
+    (setq tmux-control--homeless nil)
     (setq tmux-control--session-display nil)
     (setq tmux-control--seed-cursor nil)
     (setq tmux-control--seed-cursor-visible :unknown)
@@ -3369,7 +3397,27 @@ the matching pane's render buffer instead, so every pane updates at once."
           (with-current-buffer wbuf
             (setq tmux-control--active-pane pane))
           (tmux-control--seed-window-buffer wbuf win-id))
+         ((and tmux-control-window-buffers
+               (not tmux-control--tiled)
+               tmux-control--window-id
+               (not (equal win-id tmux-control--window-id)))
+          ;; Per-window buffers: the event names some OTHER window with no
+          ;; render buffer (brand-new -- tmux-control-new-window emits
+          ;; %window-pane-changed for the created window BEFORE the
+          ;; %session-window-changed that builds its buffer -- or simply
+          ;; never visited).  It is not this buffer's pane: adopting it
+          ;; retargeted the controller onto a foreign pane, and when that
+          ;; window later closed (an agent's task window, say) the
+          ;; controller was left aimed at a DEAD pane -- empty screen,
+          ;; keystrokes to "can't find pane", even window switches did not
+          ;; heal it (chaos-soak find).  Just refresh the pane->window map
+          ;; (a pane appeared or moved) for the activity machinery.
+          (tmux-control--refresh-pane-window-map))
          (t
+          ;; Our own window's pane changed (a split, select-pane, closed
+          ;; pane) -- or the legacy single-buffer mode, whose view follows
+          ;; the event unconditionally (pre-window-buffers semantics, a
+          ;; load-bearing affordance).  Follow it.
           (setq tmux-control--active-pane pane)
           (unless tmux-control--tiled
             (tmux-control--seed-screen)
@@ -3436,6 +3484,24 @@ the matching pane's render buffer instead, so every pane updates at once."
       (when (and tmux-control-window-buffers
                  (string-match "\\`%\\(?:unlinked-\\)?window-close \\(@[0-9]+\\)\\'"
                                line))
+        ;; The CONTROLLER's own window can close too (an agent's task
+        ;; window the controller happened to be homed on).  The buffer
+        ;; must survive -- it owns the process -- but its window id and
+        ;; active pane are now dead: left as they were, it would render
+        ;; a frozen screen and send keystrokes into "can't find pane" if
+        ;; it ever reached a window again (C-x b always can).  Mark it
+        ;; homeless instead: id and pane nil (typing then says "No
+        ;; active tmux pane yet" -- honest, recoverable), registry entry
+        ;; gone.  The session's view continues through the per-window
+        ;; render buffers; the homeless controller keeps owning the
+        ;; process and the session state, just no window of its own.
+        (when (equal (match-string 1 line) tmux-control--window-id)
+          (setq tmux-control--window-buffers
+                (cl-remove-if (lambda (e) (eq (cdr e) (current-buffer)))
+                              tmux-control--window-buffers))
+          (setq tmux-control--window-id nil)
+          (setq tmux-control--active-pane nil)
+          (setq tmux-control--homeless t))
         (when-let* ((buf (tmux-control--window-buffer (match-string 1 line))))
           (unless (eq buf (current-buffer))
             (when (eq tmux-control--session-display buf)
@@ -3577,7 +3643,86 @@ the `:capture' reply that paints the screen and consumes it."
              ;; -N keeps trailing background cells so full-width fills survive.
              (if tmux-control--capture-trailing-p " -N" "")
              tmux-control--active-pane)
-     :capture)))
+     :capture)
+    (tmux-control--verify-seed (current-buffer)
+                               #'tmux-control--seed-screen)))
+
+(defconst tmux-control--seed-verify-max-retries 2
+  "How many times a drift-detected seed is retried before giving up.
+A pane that streams continuously can race every retry; the cap keeps
+the worst case bounded, and the next seed (a resize, a window visit, a
+pause) gets a fresh budget.")
+
+(defvar-local tmux-control--seed-verify-retries 0
+  "Consecutive seed retries triggered by cursor-drift detection.
+Reset to zero whenever a verification passes.")
+
+(defun tmux-control--eat-cursor-xy ()
+  "Return the current buffer's terminal cursor as 0-indexed (X . Y).
+Reads Eat's own cursor bookkeeping (the same coordinates tmux reports
+as #{cursor_x},#{cursor_y}); nil when the terminal is gone or Eat's
+internals are unavailable, in which case seed verification quietly
+disables itself."
+  (when (and tmux-control--terminal
+             (eat-term-live-p tmux-control--terminal)
+             (fboundp 'eat--t-term-display)
+             (fboundp 'eat--t-disp-cursor)
+             (fboundp 'eat--t-cur-x)
+             (fboundp 'eat--t-cur-y))
+    (let* ((disp (eat--t-term-display tmux-control--terminal))
+           (cur (and disp (eat--t-disp-cursor disp))))
+      (when cur
+        ;; Eat's cursor is 1-indexed; tmux's is 0-indexed.
+        (cons (1- (eat--t-cur-x cur)) (1- (eat--t-cur-y cur)))))))
+
+(defun tmux-control--verify-seed (buffer reseed)
+  "Verify BUFFER's freshly seeded screen against tmux; RESEED on drift.
+
+The seed's cursor query and screen capture are two reply blocks, and
+tmux may interleave %output between them -- a prompt redraw scrolling
+the pane one row right there leaves the seeded baseline one row off,
+after which every cursor-relative repaint applies one row off, FOREVER
+\(deltas preserve relative consistency; nothing repaints).  The chaos
+soak caught exactly this: a screen identical to the pane's but shifted
+one row, stable for minutes.
+
+So after each seed, ask tmux for the pane's cursor once more and
+compare it with Eat's own cursor.  Stream ordering makes the comparison
+exact: any output that moved tmux's cursor before this reply was
+generated has already been fed to Eat by the time the reply dispatches
+\(the filter flushes pending output before every control line), so on
+an aligned screen the two agree even mid-stream.  Disagreement means
+the baseline drifted: run RESEED (bounded by
+`tmux-control--seed-verify-max-retries').  This also heals any
+historical drift at the next natural seed, whatever its cause."
+  (when (buffer-live-p buffer)
+    (let ((pane (buffer-local-value 'tmux-control--active-pane buffer))
+          (ctrl (with-current-buffer buffer (tmux-control--wb-controller))))
+      (when (and pane (buffer-live-p ctrl))
+        (with-current-buffer ctrl
+          (tmux-control--query
+           (format "display-message -p -t %s \"#{cursor_x},#{cursor_y}\""
+                   pane)
+           (lambda (lines)
+             (when (and lines (buffer-live-p buffer))
+               (with-current-buffer buffer
+                 ;; Only judge the pane this verification was issued for:
+                 ;; a pane switch between issue and reply would compare
+                 ;; apples to oranges.
+                 (when (equal pane tmux-control--active-pane)
+                   (let ((fresh (tmux-control--parse-cursor-pos lines))
+                         (mine (tmux-control--eat-cursor-xy)))
+                     (cond
+                      ((or (null fresh) (null mine))
+                       (setq tmux-control--seed-verify-retries 0))
+                      ((equal fresh mine)
+                       (setq tmux-control--seed-verify-retries 0))
+                      ((< tmux-control--seed-verify-retries
+                          tmux-control--seed-verify-max-retries)
+                       (cl-incf tmux-control--seed-verify-retries)
+                       (funcall reseed))
+                      (t
+                       (setq tmux-control--seed-verify-retries 0))))))))))))))
 
 (defun tmux-control--handle-pause (pane)
   "Resync after tmux paused PANE for lagging, then resume streaming it.
@@ -4616,7 +4761,15 @@ round trip counts), then the capture paints the screen."
                         (string-join cap-lines "\n")
                         cur (or vis :unknown)))
                       (tmux-control--flush-display
-                       (tmux-control--current-sync-windows))))))))))))))
+                       (tmux-control--current-sync-windows)))
+                    ;; Same drift detection as the controller seed: output
+                    ;; interleaved between the cursor and capture replies
+                    ;; leaves the baseline shifted; verify and re-seed.
+                    (tmux-control--verify-seed
+                     buffer
+                     (lambda ()
+                       (tmux-control--seed-window-buffer
+                        buffer window-id))))))))))))))
 
 (defun tmux-control--flush-window-buffers ()
   "Flush each sibling window render buffer's batched output and redisplay.

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -3298,9 +3298,15 @@ the matching pane's render buffer instead, so every pane updates at once."
             (with-current-buffer wbuf
               (push decoded tmux-control--output-batch)))))
        (t
-        (unless tmux-control--active-pane
+        ;; Bootstrapping the active pane from the first output exists for
+        ;; connect time, before the :pane-id reply lands.  A HOMELESS
+        ;; controller has a nil pane too, but for it this would adopt
+        ;; whatever unbuffered pane speaks first -- re-aiming a buffer
+        ;; that must stay out of rendering (Copilot review).
+        (unless (or tmux-control--active-pane tmux-control--homeless)
           (setq tmux-control--active-pane pane))
-        (when (equal pane tmux-control--active-pane)
+        (when (and tmux-control--active-pane
+                   (equal pane tmux-control--active-pane))
           (push (tmux-control--decode-output payload)
                 tmux-control--output-batch)))))))
 
@@ -3399,8 +3405,13 @@ the matching pane's render buffer instead, so every pane updates at once."
           (tmux-control--seed-window-buffer wbuf win-id))
          ((and tmux-control-window-buffers
                (not tmux-control--tiled)
-               tmux-control--window-id
-               (not (equal win-id tmux-control--window-id)))
+               ;; A HOMELESS controller owns no window at all, so every
+               ;; window's pane event is foreign to it -- without this it
+               ;; fell through to the follow branch and re-aimed itself
+               ;; (Copilot review).
+               (or tmux-control--homeless
+                   (and tmux-control--window-id
+                        (not (equal win-id tmux-control--window-id)))))
           ;; Per-window buffers: the event names some OTHER window with no
           ;; render buffer (brand-new -- tmux-control-new-window emits
           ;; %window-pane-changed for the created window BEFORE the
@@ -4099,7 +4110,14 @@ terminal, so make them the recovery path instead of a silent no-op."
   (when (and (process-live-p tmux-control--process)
              (> (length string) 0)
              (not tmux-control--suppress-responses))
-    (let ((target (or tmux-control--active-pane tmux-control--fallback-target)))
+    ;; The session-target fallback exists for connect time, before the
+    ;; active pane is known.  A HOMELESS controller (own window closed)
+    ;; must NOT fall back: it would silently drive the session's current
+    ;; pane -- which the user is watching through a DIFFERENT buffer --
+    ;; from a frozen view (Copilot review).
+    (let ((target (or tmux-control--active-pane
+                      (and (not tmux-control--homeless)
+                           tmux-control--fallback-target))))
       (if target
           (let* ((bytes (encode-coding-string string 'utf-8-unix))
                  (n (length bytes))
@@ -4182,7 +4200,11 @@ pane like any terminal paste.  This is how iTerm2's tmux integration
 pastes, and the reason is the same: the client cannot know the pane's
 bracketed-paste state, but tmux does."
   (when (> (length text) 0)
-    (let ((target (or tmux-control--active-pane tmux-control--fallback-target)))
+    ;; Same homeless gating as `tmux-control--send-input': never drive
+    ;; the session's current pane from a buffer that renders nothing.
+    (let ((target (or tmux-control--active-pane
+                      (and (not tmux-control--homeless)
+                           tmux-control--fallback-target))))
       (if (not target)
           (tmux-control--message "No active tmux pane yet")
         (let* ((bytes (encode-coding-string text 'utf-8-unix))


### PR DESCRIPTION
## A chaos soak, and what it caught

This PR ships a randomized soak harness (`test/tmux-control-chaos.el`) that drives a **live GUI session** through reproducible random operation streams — window switches, the pager, typing, pastes, floods, frame resizes, char-mode round trips, reconnects, window/pane churn — checking after every step that the displayed screen matches `capture-pane`, the queue drains, no view is stranded, and buffers stay bounded. Same seed ⇒ same sequence (own LCG; seeded `random` isn't stable across builds).

It found **four real bugs** no scripted suite could see, all fixed here:

### 1. Foreign `%window-pane-changed` retargeted the controller
The handler's no-render-buffer fallthrough adopted the event's pane into the *current* buffer for any window without a buffer — including the window `tmux-control-new-window` itself just created (tmux announces its pane **before** the `%session-window-changed` that builds its buffer). The controller ended up aimed at a foreign pane; when that window later closed (an agent's task window), it was stranded on a **dead** pane: empty screen, keystrokes into `can't find pane`, and window switches did not heal it. The fallthrough now follows only the buffer's **own** window when per-window buffers are on (legacy single-buffer mode keeps its load-bearing unconditional follow). `new-window`/`kill-window` also stop re-querying the active pane under the gate — the `:pane-id` reply was a second path to the same corruption.

### 2. Seed cursor/capture race left a permanent one-row drift
A seed's cursor query and screen capture are separate reply blocks; `%output` interleaved between them shifts the seeded baseline — and every later delta applies relative to it, **forever** (the soak caught a screen identical to the pane's but one row off, stable for minutes). Every seed now ends with a drift check (`tmux-control--verify-seed`): one cursor re-query compared against Eat's own cursor. Stream ordering makes the comparison exact — the filter flushes pending output before each control line, so output that moved tmux's cursor has already reached Eat when the reply dispatches. Disagreement ⇒ bounded reseed; also heals any historical drift at the next natural seed.

### 3. Homeless controller
When the controller's **own** window closed, the buffer survived (it owns the process) but kept a dead window id and pane — a frozen view with dead keystrokes if it ever reached a window again (`C-x b` always can). It now marks itself homeless: id and pane nil (typing then says "No active tmux pane yet" — honest, recoverable), registry entry gone.

### 4. The window-list refresh re-homed homeless controllers
The connect-time "claim the active window once its id is learned" binding keyed on a **nil window-id** — which a homeless controller has too. The next `list-windows` refresh silently re-claimed the session's current window for it, **orphaning that window's render buffer from the registry**: output routed to the hidden controller while the user watched the orphan freeze. (An explicit re-homing "adoption" variant was tried during development and reverted for exactly this split-brain; the soak then exposed the same brain hiding in the connect path.) A new `tmux-control--homeless` flag distinguishes *never homed* from *went homeless*. The invariant: **one window, one buffer**.

## Soak evidence

| build | seed 42 | seed 1234 | seed 777 | seed 31337 |
|---|---|---|---|---|
| pre-fix | ~25 fails / 60 steps | 87 / 120 (stuck views) | — | — |
| post-fix | clean | **0** / 120 | 2 / 100 (one transient, self-healed) | **0** / 100 |

Also confirmed along the way: Eat's 128K scrollback trim bounds every render buffer (pinned at exactly 131072 chars under a 10MB flood); scrollback-region markers and `filter-buffer-substring` stay stable under live floods; and `pause-after` flow control fired `%pause` **live for the first time**, over a deliberately bandwidth-starved SSH link (ProxyCommand throttle).

## Validation

10 new unit tests; **146 green**; strict byte-compile clean (harness too). Guide: chaos soak documented under Development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)