### PR TITLE
ESC defers to modal packages (xah-fly-keys/evil/viper command mode)

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -268,15 +268,16 @@ Line numbers are disabled locally in live and scrollback buffers.
 
 ## Keys, raw mode, and paste
 
-**ESC reaches the pane the moment you press it.**  Leaving vim's insert
-mode, closing a TUI menu, interrupting an agent — none of it waits for a
-second key.  (Stock GUI Emacs turns an unbound escape into a pending meta
-prefix, so a bare ESC sent nothing until your next keystroke.)  This is a
-low-precedence default: a modal package that binds ESC to leave insert
-mode — xah-fly-keys, evil, viper — keeps it, because those bindings sit
-in a minor-mode map that outranks tmux-control's major-mode map.  Such
-users switch modes with ESC as usual and reach the pane's own ESC through
-their config (or char mode below).
+**By default, ESC reaches the pane the moment you press it** — leaving
+vim's insert mode, closing a TUI menu, interrupting an agent, with no
+wait for a second key.  (Stock GUI Emacs turns an unbound escape into a
+pending meta prefix, so a bare ESC sent nothing until your next
+keystroke.)  This is a low-precedence default: a modal package that binds
+ESC to leave insert mode — xah-fly-keys, evil, viper — keeps it, because
+those bindings sit in a minor-mode map that outranks tmux-control's
+major-mode map.  For those users the ESC key switches modes as usual; to
+send ESC to the pane they bind `tmux-control-send-escape` to a free key,
+or use char mode (below), where every key goes to the pane.
 
 **Sending C-c and friends.**  In the default semi-char mode, `C-c` is the
 Emacs prefix, so interrupting the pane's process is `C-c C-c` — the comint

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -271,7 +271,12 @@ Line numbers are disabled locally in live and scrollback buffers.
 **ESC reaches the pane the moment you press it.**  Leaving vim's insert
 mode, closing a TUI menu, interrupting an agent — none of it waits for a
 second key.  (Stock GUI Emacs turns an unbound escape into a pending meta
-prefix, so a bare ESC sent nothing until your next keystroke.)
+prefix, so a bare ESC sent nothing until your next keystroke.)  This is a
+low-precedence default: a modal package that binds ESC to leave insert
+mode — xah-fly-keys, evil, viper — keeps it, because those bindings sit
+in a minor-mode map that outranks tmux-control's major-mode map.  Such
+users switch modes with ESC as usual and reach the pane's own ESC through
+their config (or char mode below).
 
 **Sending C-c and friends.**  In the default semi-char mode, `C-c` is the
 Emacs prefix, so interrupting the pane's process is `C-c C-c` — the comint

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -2395,6 +2395,39 @@ output), :calls (side-effect invocations in order), :active-pane,
       (tmux-control-send-escape)
       (should (equal sent '(?\e))))))
 
+(defvar tmux-control-test--fake-modal nil
+  "Stands in for a modal minor mode in the ESC precedence test.")
+
+(ert-deftest tmux-control-test-escape-yields-to-minor-mode-map ()
+  ;; The regression was about keymap PRECEDENCE, not which map names the
+  ;; binding: ESC lived in an emulation map, which outranks minor-mode
+  ;; maps, so a modal package's ESC binding lost.  Exercise the live
+  ;; `key-binding' resolution through the full stack a real buffer has --
+  ;; emulation override (active in semi-char mode) over minor-mode maps
+  ;; over the major mode map -- so reintroducing ESC into the override
+  ;; map fails here even though the static binding would still "look"
+  ;; right.
+  (let* ((sentinel (lambda () (interactive) 'modal-switch))
+         (modal-map (let ((m (make-sparse-keymap)))
+                      (define-key m [escape] sentinel)
+                      m)))
+    (with-temp-buffer
+      (tmux-control-mode)
+      ;; Reproduce a live buffer: the override emulation map is active.
+      (setq-local emulation-mode-map-alists
+                  (cons tmux-control--emulation-mode-map-alist
+                        emulation-mode-map-alists))
+      (setq tmux-control--keys-active t)
+      (let ((minor-mode-map-alist
+             (cons (cons 'tmux-control-test--fake-modal modal-map)
+                   minor-mode-map-alist)))
+        ;; Modal package active: its minor-mode ESC wins.
+        (setq tmux-control-test--fake-modal t)
+        (should (eq (key-binding [escape]) sentinel))
+        ;; No modal package: ESC falls through to the pane.
+        (setq tmux-control-test--fake-modal nil)
+        (should (eq (key-binding [escape]) #'tmux-control-send-escape))))))
+
 (ert-deftest tmux-control-test-quote-tmux-data-octal-escapes ()
   ;; Newlines (and every non-alphanumeric byte) ride control commands as
   ;; octal escapes inside double quotes -- the one representation tmux's

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -2378,14 +2378,17 @@ output), :calls (side-effect invocations in order), :active-pane,
         (should-not tmux-control--size-pin-warned)))))
 
 (ert-deftest tmux-control-test-escape-sends-escape-immediately ()
-  ;; A bare ESC press must reach the pane the moment it is pressed.  In
+  ;; A bare ESC press should reach the pane the moment it is pressed.  In
   ;; GUI Emacs the unbound `escape' event decays into the meta prefix and
   ;; waits indefinitely for a second key -- vim's mode switch and an
-  ;; agent TUI's interrupt did nothing until the NEXT keystroke.
+  ;; agent TUI's interrupt did nothing until the NEXT keystroke.  It is
+  ;; bound in the major mode map ONLY: a modal package's ESC binding
+  ;; (xah-fly-keys/evil/viper, in a minor-mode map) must keep winning, so
+  ;; ESC must NOT sit in the high-precedence emulation override map (a
+  ;; regression that swallowed xah-fly-keys' command-mode-activate).
   (should (eq (lookup-key tmux-control-mode-map [escape])
               #'tmux-control-send-escape))
-  (should (eq (lookup-key tmux-control--override-map [escape])
-              #'tmux-control-send-escape))
+  (should-not (lookup-key tmux-control--override-map [escape]))
   (let ((sent '()))
     (cl-letf (((symbol-function 'eat-self-input)
                (lambda (_n event) (push event sent))))

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -491,7 +491,9 @@ kills, which are deliberate.")
     (define-key map (kbd "C-c C-r") #'tmux-control-reconnect)
     (define-key map (kbd "C-c C-s") #'tmux-control-select-session)
     (define-key map (kbd "C-c C-f") #'tmux-control-toggle-flock)
-    (define-key map [escape] #'tmux-control-send-escape)
+    ;; NB: ESC is deliberately NOT bound here.  It belongs in the major
+    ;; mode map (low precedence) so a modal package's own ESC binding
+    ;; wins -- see `tmux-control-mode-map'.
     (define-key map [wheel-up] #'tmux-control-wheel-scroll)
     map)
   "High-precedence keymap for tmux-control buffers.
@@ -560,10 +562,15 @@ the cross-session activity strip (see `tmux-control-session-activity').")
     (define-key map (kbd "C-c C-r") #'tmux-control-reconnect)
     (define-key map (kbd "C-c C-s") #'tmux-control-select-session)
     (define-key map (kbd "C-c C-f") #'tmux-control-toggle-flock)
-    ;; A bare ESC press must reach the pane immediately; see
-    ;; `tmux-control-send-escape'.  Bound here as well as in the override
-    ;; map so it holds in char mode (override map swapped out) and under
-    ;; modal packages whose minor-mode maps would beat the major mode.
+    ;; A bare ESC press should reach the pane immediately; see
+    ;; `tmux-control-send-escape'.  Bound ONLY here, in the major mode
+    ;; map, on purpose: a modal package (xah-fly-keys, evil, viper) that
+    ;; binds ESC to leave insert mode installs it in a minor-mode map,
+    ;; which outranks the major mode map -- so for those users ESC keeps
+    ;; switching modes (the regression this placement fixes), while for
+    ;; everyone else, where nothing else claims ESC, it sends to the pane.
+    ;; It must NOT go in `tmux-control--override-map' (an emulation map):
+    ;; that beats minor-mode maps and would swallow the modal binding.
     (define-key map [escape] #'tmux-control-send-escape)
     ;; Route every "paste" gesture through tmux's own paste buffer.  Eat's
     ;; map covers C-y, M-y, S-insert and mouse yank, but a GUI/macOS
@@ -4157,7 +4164,13 @@ most reflexive key a terminal has after C-c: it leaves vim's insert
 mode, cancels a TUI's menu, interrupts an agent.  Send it the moment
 it is pressed, like any terminal would.  (In a tty Emacs the escape
 key never generates this `escape' event, so terminal Meta sequences
-are unaffected.)"
+are unaffected.)
+
+Bound only in `tmux-control-mode-map', the major mode map, so a modal
+package that binds ESC to leave insert mode (xah-fly-keys, evil, viper)
+keeps it: those bindings live in a minor-mode map, which outranks the
+major mode map.  Such users send ESC to the pane through their own
+config (e.g. an insert-mode keymap entry) rather than this command."
   (interactive)
   (eat-self-input 1 ?\e))
 

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -4169,8 +4169,9 @@ are unaffected.)
 Bound only in `tmux-control-mode-map', the major mode map, so a modal
 package that binds ESC to leave insert mode (xah-fly-keys, evil, viper)
 keeps it: those bindings live in a minor-mode map, which outranks the
-major mode map.  Such users send ESC to the pane through their own
-config (e.g. an insert-mode keymap entry) rather than this command."
+major mode map.  For such users the ESC key switches modes rather than
+reaching the pane; to send ESC to the pane they bind this command to a
+free key, or use char mode (where every key goes to the pane)."
   (interactive)
   (eat-self-input 1 ?\e))
 


### PR DESCRIPTION
## Regression

From the input-fidelity work (#41): `tmux-control-send-escape` was bound in `tmux-control--override-map`, an **emulation** map. Emulation maps outrank minor-mode maps — so tmux-control's ESC swallowed **xah-fly-keys' `<escape>` → `xah-fly-command-mode-activate`** binding (which lives in `xah-fly-insert-map`, a minor-mode map). A modal user could no longer switch into command mode from a tmux-control buffer.

Reported: *"i can't switch into command mode now."* The reporter's init binds `<escape>`/`ESC`/`C-[` in `xah-fly-insert-map` — all shadowed by the emulation entry.

## Fix

ESC is now bound **only in `tmux-control-mode-map`** (the major mode map). A modal package installs its ESC binding in a minor-mode map, which beats the major mode map — so those users keep command mode, while everyone else (nothing else claims ESC) still sends it straight to the pane. The terminal-ESC feature becomes a low-precedence *default* that any modal config naturally overrides, which is the correct relationship.

Precedence chain for `<escape>` in a tmux-control buffer:
| layer | before | after |
|---|---|---|
| emulation (`tmux-control--override-map`) | **send-escape** ← stole it | — |
| minor-mode (`xah-fly-insert-map`) | command-mode-activate (lost) | **command-mode-activate** ✓ |
| major mode (`tmux-control-mode-map`) | send-escape | send-escape (non-modal fallthrough) ✓ |

## Verified live

In an isolated daemon with **xah-fly-keys actually loaded** and the reporter's exact init bindings, in a live tmux-control buffer (emulation map active, `keys-active` t):
- insert state → `(key-binding [escape])` = **`xah-fly-command-mode-activate`** (regression gone)
- with xah-fly-keys disabled → **`tmux-control-send-escape`** (terminal ESC preserved)

The override map's other entries (the `C-c` command chords, the wheel) are untouched.

Test flipped to assert ESC is **absent** from the override map and present in the major mode map; **147 green**; strict byte-compile clean. Guide notes the modal deference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)