### PR TITLE
Forward wheel-down to mouse/full-screen apps in the live view

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -3018,5 +3018,43 @@ output), :calls (side-effect invocations in order), :active-pane,
                                        tmux-control--window-buffers)))
             (when (buffer-live-p new) (kill-buffer new))))))))
 
+(ert-deftest tmux-control-test-wheel-down-forwards-to-mouse-app ()
+  ;; Symmetry with wheel-up: a full-screen or mouse-tracking app must get
+  ;; wheel-DOWN forwarded to it, not have it fall through to ordinary
+  ;; scrolling.  Found in a config-loaded buffer: wheel-up scrolled vim
+  ;; but wheel-down hit pixel-scroll-precision and scrolled the Emacs
+  ;; buffer instead (vim never moved).  Bound in the high-precedence
+  ;; maps so it beats a global wheel minor mode (pixel-scroll).
+  (should (eq (lookup-key tmux-control--override-map [wheel-down])
+              #'tmux-control-wheel-down))
+  (should (eq (lookup-key tmux-control--char-mode-map [wheel-down])
+              #'tmux-control-wheel-down))
+  (let ((forwarded 0) (scrolled 0)
+        (event (list 'wheel-down (list (selected-window) 1 '(0 . 0) 0))))
+    (cl-letf (((symbol-function 'eat-self-input)
+               (lambda (&rest _) (cl-incf forwarded)))
+              ((symbol-function 'tmux-control--dispatch-wheel)
+               (lambda (_) (cl-incf scrolled)))
+              ((symbol-function 'posn-window) (lambda (_) (selected-window))))
+      (with-temp-buffer
+        (tmux-control-mode)
+        (set-window-buffer (selected-window) (current-buffer))
+        ;; Mouse-grabbing (or alt-screen) app: forward to the app.
+        (cl-letf (((symbol-function 'tmux-control--alt-screen-p)
+                   (lambda () nil))
+                  ((symbol-function 'tmux-control--pane-grabs-mouse-p)
+                   (lambda () t)))
+          (tmux-control-wheel-down event)
+          (should (= forwarded 1))
+          (should (= scrolled 0)))
+        ;; Plain normal-screen pane: ordinary scrolling, not forwarded.
+        (cl-letf (((symbol-function 'tmux-control--alt-screen-p)
+                   (lambda () nil))
+                  ((symbol-function 'tmux-control--pane-grabs-mouse-p)
+                   (lambda () nil)))
+          (tmux-control-wheel-down event)
+          (should (= forwarded 1))
+          (should (= scrolled 1)))))))
+
 (provide 'tmux-control-test)
 ;;; tmux-control-test.el ends here

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -495,6 +495,7 @@ kills, which are deliberate.")
     ;; mode map (low precedence) so a modal package's own ESC binding
     ;; wins -- see `tmux-control-mode-map'.
     (define-key map [wheel-up] #'tmux-control-wheel-scroll)
+    (define-key map [wheel-down] #'tmux-control-wheel-down)
     map)
   "High-precedence keymap for tmux-control buffers.
 Active in semi-char mode (`tmux-control--keys-active').  In char mode it
@@ -504,6 +505,7 @@ shadowing the pane's own C-c.")
 (defvar tmux-control--char-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map [wheel-up] #'tmux-control-wheel-scroll)
+    (define-key map [wheel-down] #'tmux-control-wheel-down)
     map)
   "High-precedence keymap for tmux-control buffers in char mode.
 Char mode exists to send EVERY key to the pane -- C-c above all, the
@@ -2261,9 +2263,9 @@ Emacs-side analog of tmux's default wheel-up binding, which opens
 copy-mode scrollback for normal-screen panes.
 
 In every other case -- a genuine full-screen (alternate-screen)
-application, a mouse-aware application, or wheel-down -- the event is
-forwarded to the terminal unchanged so the application keeps its own
-handling.
+application or a mouse-aware application -- the event is forwarded to the
+terminal unchanged so the application keeps its own handling.  Wheel-down
+is handled by `tmux-control-wheel-down'.
 
 The scrollback interception is only active when Eat's screen state can
 be read, so the live behavior is otherwise unchanged."
@@ -2286,6 +2288,28 @@ be read, so the live behavior is otherwise unchanged."
             (with-selected-window window
               (eat-self-input 1 event)))))
       (eat-self-input 1 event))))
+
+(defun tmux-control-wheel-down (event)
+  "Handle a wheel-down EVENT in a live tmux-control buffer.
+A full-screen (alternate-screen) or mouse-tracking application owns the
+wheel, so forward the event to it -- the symmetric partner of
+`tmux-control-wheel-scroll', which forwards wheel-up to such an app.
+Without this, wheel-UP reached a mouse application (e.g. a TUI scrolled
+with the mouse) but wheel-DOWN did not: nothing bound it, so it fell
+through to the user's ordinary scrolling, and under
+`pixel-scroll-precision-mode' that visibly scrolled the Emacs buffer
+instead of the application.  On a normal-screen pane the wheel keeps the
+user's ordinary downward scrolling."
+  (interactive "e")
+  (let ((window (posn-window (event-start event))))
+    (if (and (window-live-p window)
+             (with-current-buffer (window-buffer window)
+               (and (derived-mode-p 'tmux-control-mode)
+                    (or (tmux-control--alt-screen-p)
+                        (tmux-control--pane-grabs-mouse-p)))))
+        (with-selected-window window
+          (eat-self-input 1 event))
+      (tmux-control--dispatch-wheel event))))
 
 (defun tmux-control--disable-line-numbers ()
   "Disable line numbers in tmux-control buffers."


### PR DESCRIPTION
## Found by config-loaded testing

This is the first bug from the new methodology shift: testing tmux-control in a daemon loaded with the user's **real config** (xah-fly-keys, pixel-scroll-precision-mode, vertico/consult, modus-vivendi) instead of `-Q` — the composition class that `-Q` structurally cannot see, and where the ESC regression also lived.

## The bug

A mouse-tracking or alternate-screen application (vim+mouse, htop, less, an agent TUI) got **wheel-up** forwarded to it — `tmux-control-wheel-scroll` handles that — but **nothing bound wheel-down**. It fell through to the user's ordinary scrolling, and under `pixel-scroll-precision-mode` that scrolled the *Emacs buffer* instead of the app. You could wheel a TUI up but not down.

Verified live in a config-loaded buffer with vim+mouse:
- wheel-up → vim scrolled (line 45 → 42) ✓
- wheel-down → vim stuck (line 1, unmoved); the Emacs buffer scrolled instead ✗

`tmux-control-wheel-scroll`'s own docstring *claimed* wheel-down was forwarded — it just was never bound to anything.

## The fix

New `tmux-control-wheel-down`, the symmetric partner: forward to the app when it owns the wheel (alternate-screen or mouse-grabbing pane), otherwise do the user's ordinary downward scrolling (normal-screen panes unchanged). Bound alongside wheel-up in the override and char-mode emulation maps so it beats a global wheel minor mode like pixel-scroll.

Post-fix, in the same config-loaded buffer, vim scrolled **down** (45 → 48) on a real wheel-down. Both directions now reach the app.

## Validation

1 unit test (forward-to-app vs normal-scroll, plus binding presence); **149 green**; strict byte-compile clean. Verified live with real wheel events in the user's real config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)