### PR TITLE
Wrap the wheel-down test's window mutation in save-window-excursion

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -3036,25 +3036,26 @@ output), :calls (side-effect invocations in order), :active-pane,
               ((symbol-function 'tmux-control--dispatch-wheel)
                (lambda (_) (cl-incf scrolled)))
               ((symbol-function 'posn-window) (lambda (_) (selected-window))))
-      (with-temp-buffer
-        (tmux-control-mode)
-        (set-window-buffer (selected-window) (current-buffer))
-        ;; Mouse-grabbing (or alt-screen) app: forward to the app.
-        (cl-letf (((symbol-function 'tmux-control--alt-screen-p)
-                   (lambda () nil))
-                  ((symbol-function 'tmux-control--pane-grabs-mouse-p)
-                   (lambda () t)))
-          (tmux-control-wheel-down event)
-          (should (= forwarded 1))
-          (should (= scrolled 0)))
-        ;; Plain normal-screen pane: ordinary scrolling, not forwarded.
-        (cl-letf (((symbol-function 'tmux-control--alt-screen-p)
-                   (lambda () nil))
-                  ((symbol-function 'tmux-control--pane-grabs-mouse-p)
-                   (lambda () nil)))
-          (tmux-control-wheel-down event)
-          (should (= forwarded 1))
-          (should (= scrolled 1)))))))
+      (save-window-excursion
+        (with-temp-buffer
+          (tmux-control-mode)
+          (set-window-buffer (selected-window) (current-buffer))
+          ;; Mouse-grabbing (or alt-screen) app: forward to the app.
+          (cl-letf (((symbol-function 'tmux-control--alt-screen-p)
+                     (lambda () nil))
+                    ((symbol-function 'tmux-control--pane-grabs-mouse-p)
+                     (lambda () t)))
+            (tmux-control-wheel-down event)
+            (should (= forwarded 1))
+            (should (= scrolled 0)))
+          ;; Plain normal-screen pane: ordinary scrolling, not forwarded.
+          (cl-letf (((symbol-function 'tmux-control--alt-screen-p)
+                     (lambda () nil))
+                    ((symbol-function 'tmux-control--pane-grabs-mouse-p)
+                     (lambda () nil)))
+            (tmux-control-wheel-down event)
+            (should (= forwarded 1))
+            (should (= scrolled 1))))))))
 
 (provide 'tmux-control-test)
 ;;; tmux-control-test.el ends here


### PR DESCRIPTION
Follow-up to #45 — Copilot flagged that `tmux-control-test-wheel-down-forwards-to-mouse-app` set the selected window's buffer without restoring it (unlike the neighboring window-touching tests), a potential source of order-dependent ERT leakage. Wrap it in `save-window-excursion`. Pure test hygiene; 149 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)