### PR TITLE
Scrollback: don't bounce out of the pager before you've read history

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -2582,8 +2582,11 @@ output), :calls (side-effect invocations in order), :active-pane,
 (ert-deftest tmux-control-test-scrollback-wheel-down-exits-at-bottom ()
   ;; tmux copy-mode parity: scrolling back down to the bottom of the
   ;; pager leaves scrollback -- the gesture that took you in takes you
-  ;; back out.  Above the bottom the event re-dispatches to the user's
-  ;; normal scrolling.
+  ;; back out.  But ONLY after the user has scrolled up into history: you
+  ;; enter by scrolling up, so the pager opens at the bottom, and a
+  ;; wheel-down right then (the up-flick's momentum tail, or one arriving
+  ;; while the "capturing…" placeholder makes the bottom trivially
+  ;; visible) must NOT bounce straight back out (field report: a loop).
   (let ((lived 0) (dispatched 0) (at-bottom t))
     (cl-letf (((symbol-function 'tmux-control-live)
                (lambda () (cl-incf lived)))
@@ -2598,18 +2601,28 @@ output), :calls (side-effect invocations in order), :active-pane,
         (with-temp-buffer
           (tmux-control-scrollback-mode)
           (let ((inhibit-read-only t)) (insert "history line\n"))
+          (setq-local tmux-control--scrollback-left-bottom nil)
           (set-window-buffer (selected-window) (current-buffer))
-          ;; Bottom visible: return to live.
+          ;; Fresh pager, at the bottom, never scrolled up: a wheel-down
+          ;; does NOT leave -- it scrolls (a no-op on a short buffer).
           (tmux-control-scrollback-wheel-down
            (list 'wheel-down (list (selected-window))))
-          (should (= lived 1))
-          (should (= dispatched 0))
-          ;; Bottom out of view: normal scroll.
+          (should (= lived 0))
+          (should (= dispatched 1))
+          ;; Scroll up off the bottom: normal scroll, and now the pager
+          ;; remembers it has left the bottom.
           (setq at-bottom nil)
           (tmux-control-scrollback-wheel-down
            (list 'wheel-down (list (selected-window))))
+          (should (= lived 0))
+          (should (= dispatched 2))
+          (should tmux-control--scrollback-left-bottom)
+          ;; Back down to the bottom after viewing history: NOW it leaves.
+          (setq at-bottom t)
+          (tmux-control-scrollback-wheel-down
+           (list 'wheel-down (list (selected-window))))
           (should (= lived 1))
-          (should (= dispatched 1)))))))
+          (should (= dispatched 2)))))))
 
 (ert-deftest tmux-control-test-window-buffer-mode-line-drops-process-status ()
   ;; A per-window render buffer owns no process (the controller does);

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -345,6 +345,15 @@ is treated as stale and cleared, so a self-initiated reseed that produced no
   "(WIDTH . HEIGHT) the scrollback view was last captured for, or nil.")
 (defvar-local tmux-control--scrollback-resize-timer nil
   "Debounce timer for re-capturing scrollback after a window resize.")
+(defvar-local tmux-control--scrollback-left-bottom nil
+  "Non-nil once the scrollback pager has been scrolled up off the bottom.
+You enter the pager by scrolling UP, so it opens at the bottom; the
+wheel-down-leaves-to-live rule must not fire until you have actually
+moved up into history and are scrolling back down -- otherwise a
+wheel-down right after entering (or while the capture is still pending,
+when the one-line \"capturing…\" placeholder makes the bottom trivially
+visible) bounces you straight back to the live view.  Reset when the
+pager opens.")
 (defvar-local tmux-control--command-queue nil
   "Pending control-mode command entries, oldest first.
 Each entry is a cons (KIND . SEND-TIME): the reply-handler kind enqueued
@@ -2150,6 +2159,9 @@ the live interactive pane."
         (setq-local tmux-control--scrollback-target target)
         (setq-local tmux-control--capture-trailing-p trailing)
         (setq-local tmux-control--live-buffer live-buffer)
+        ;; Fresh pager: not yet scrolled up into history, so a wheel-down
+        ;; cannot leave to live yet (see `tmux-control-scrollback-wheel-down').
+        (setq-local tmux-control--scrollback-left-bottom nil)
         ;; Keep the window tabs visible.  Hide the text cursor in this read-only
         ;; history pager: point pins at the bottom and, under pixel-scroll
         ;; (point does not move on wheel), the cursor scrolls off-screen and
@@ -2305,24 +2317,43 @@ user's configured wheel behavior; route the event back to it."
 
 (defun tmux-control-scrollback-wheel-down (event)
   "Scroll the pager down; from the bottom, return to the live view.
-This is tmux's own copy-mode rule: scrolling back down to the bottom
-of history leaves scrollback and you are live again -- no key to
-remember, the gesture that took you in takes you back out.  Above the
-bottom, the wheel scrolls as it always did (EVENT is re-dispatched to
-the user's configured scrolling, pixel-precision included)."
+This is tmux's own copy-mode rule: scrolling back down to the bottom of
+history leaves scrollback and you are live again -- no key to remember,
+the gesture that took you in takes you back out.
+
+But you ENTER the pager by scrolling up, so it opens at the bottom; the
+leave-to-live step only fires once you have actually scrolled up into
+history and are scrolling back down (`tmux-control--scrollback-left-bottom').
+Otherwise a wheel-down right after entering -- the momentum tail of the
+up-flick, a stray tick, or one arriving while the capture is still
+pending and the one-line \"capturing…\" placeholder makes the bottom
+trivially visible -- would bounce you straight back out, repeatedly
+\(field report: an apparent loop).
+
+Above the bottom, the wheel scrolls as it always did (EVENT is
+re-dispatched to the user's configured scrolling, pixel-precision
+included)."
   (interactive "e")
   (let ((window (posn-window (event-start event))))
-    (if (and (window-live-p window)
-             (with-current-buffer (window-buffer window)
-               (and (derived-mode-p 'tmux-control-scrollback-mode)
-                    ;; "At the bottom" must count a PARTIALLY visible last
-                    ;; line: pixel-precision scrolling routinely parks the
-                    ;; window with the final line a few pixels clipped, and
-                    ;; `pos-visible-in-window-p' answers nil there forever.
-                    (>= (window-end window t) (point-max)))))
+    (if (window-live-p window)
         (with-selected-window window
           (with-current-buffer (window-buffer window)
-            (tmux-control-live)))
+            ;; "At the bottom" must count a PARTIALLY visible last line:
+            ;; pixel-precision scrolling routinely parks the window with the
+            ;; final line a few pixels clipped, and `pos-visible-in-window-p'
+            ;; answers nil there forever.
+            (if (and (derived-mode-p 'tmux-control-scrollback-mode)
+                     (>= (window-end window t) (point-max)))
+                (if tmux-control--scrollback-left-bottom
+                    (tmux-control-live)
+                  ;; At the bottom but never left it: do not leave; let the
+                  ;; wheel scroll (a no-op on a buffer this short).
+                  (tmux-control--dispatch-wheel event))
+              ;; Above the bottom -- viewing history.  Remember it, so a
+              ;; later wheel-down that reaches the bottom leaves.
+              (when (derived-mode-p 'tmux-control-scrollback-mode)
+                (setq tmux-control--scrollback-left-bottom t))
+              (tmux-control--dispatch-wheel event))))
       (tmux-control--dispatch-wheel event))))
 
 (defun tmux-control--alt-screen-effective-p (honored eat-alt-display-p)


### PR DESCRIPTION
## Field report

Latest build, pixel-scroll-precision-mode: scrolling up into a large scrollback shows `capturing 10000 lines…` then jumps straight back to the live view, repeatedly — an apparent loop, no errors.

## Root cause

The wheel-down-leaves-to-live rule (from the viewport-continuity work) fired too eagerly. It leaves when the pager is "at the bottom" — but you **enter** the pager by scrolling up, so it opens at the bottom, and while the async capture is pending the one-line `capturing…` placeholder makes the bottom *trivially* visible. So a wheel-down arriving right then — the momentum tail of the up-flick, a stray tick, pixel-scroll interpolation — hit the leave path before the capture even landed. Repeating the scroll-up reproduced it as a loop.

Reproduced deterministically in a config-loaded daemon: pager opens showing the 38-byte `capturing…` placeholder, `(>= (window-end w t) (point-max))` is `t`, and a wheel-down there returns to `tmux-control-mode` (live).

## Fix

Leave only once the user has actually scrolled up off the bottom into history — `tmux-control--scrollback-left-bottom`, reset when the pager opens, set when a wheel-down is seen above the bottom. Entering then cannot bounce: you must have viewed history and be scrolling back *down* to the bottom, which is the rule's real intent ("the gesture that took you in takes you back out"). This structurally fixes both the capturing-placeholder bounce and the just-entered-momentum bounce.

## Verified live (reporter's real config)

- The deterministic repro (wheel-down while the placeholder shows) now **stays in the pager** and the capture lands normally.
- Full round trip with real wheel events: scroll up into history → scroll back down to the bottom → one nudge → leaves to live as intended.

(The "one nudge at the bottom" is the pre-existing pixel-scroll coalescing behavior — a flick's events are consumed internally, so reaching the bottom mid-flick doesn't fire the leave; a separate tick does. Unchanged by this PR.)

Unit test updated to the new semantic (at bottom + not-yet-left = scroll, not leave; left then back to bottom = leave); **150 green**; strict compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)