### PR TITLE
Reconnect: sweep stale render buffers by name, not the registry

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -3117,5 +3117,31 @@ output), :calls (side-effect invocations in order), :active-pane,
           (let ((escape2 (assoc "<escape>" (tmux-control--audit-rows))))
             (should (eq (nth 3 escape2) 'overridden))))))))
 
+(ert-deftest tmux-control-test-kill-render-buffers-by-name ()
+  ;; A reconnect must sweep stale render buffers even when the registry
+  ;; has drifted out of sync -- so the sweep is by NAME, not the
+  ;; registry.  Chaos-soak find: after visiting a window then
+  ;; reconnecting, that window's render buffer survived holding the dead
+  ;; process, and every key on it errored "process is not live".
+  (let* ((ctrl (generate-new-buffer "*tmux-control:local:cs*"))
+         (r0 (generate-new-buffer "*tmux-control:local:cs:@0*"))
+         (r7 (generate-new-buffer "*tmux-control:local:cs:@7*"))
+         ;; A pane (tiling) buffer uses ":%", and another session's
+         ;; render buffer has a different controller name -- neither is
+         ;; ours; both must survive.
+         (pane (generate-new-buffer "*tmux-control:local:cs:%2*"))
+         (other (generate-new-buffer "*tmux-control:local:other:@0*")))
+    (unwind-protect
+        (progn
+          (tmux-control--kill-render-buffers ctrl)
+          (should (buffer-live-p ctrl))      ; never kills the controller
+          (should-not (buffer-live-p r0))    ; @-render buffers swept
+          (should-not (buffer-live-p r7))
+          (should (buffer-live-p pane))      ; :% pane buffer untouched
+          (should (buffer-live-p other)))    ; other session untouched
+      (dolist (b (list ctrl r0 r7 pane other))
+        (when (buffer-live-p b)
+          (let ((kill-buffer-query-functions nil)) (kill-buffer b)))))))
+
 (provide 'tmux-control-test)
 ;;; tmux-control-test.el ends here

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -2588,14 +2588,8 @@ so the tmux-control keys get out of the way; the mode line shows
     (setq tmux-control--command-watchdog-timer nil)
     (setq tmux-control--command-watchdog-warned nil)
     ;; A (re)connect starts the per-window buffer registry fresh; stale
-    ;; sibling buffers from a previous connection eat output for window ids
-    ;; that may no longer exist.
-    (let ((self (current-buffer)))
-      (dolist (entry tmux-control--window-buffers)
-        (let ((buf (cdr entry)))
-          (when (and (buffer-live-p buf) (not (eq buf self)))
-            (let ((kill-buffer-query-functions nil))
-              (kill-buffer buf))))))
+    ;; sibling render buffers from the previous connection must go.
+    (tmux-control--kill-render-buffers (current-buffer))
     (setq tmux-control--window-buffers nil)
     (setq tmux-control--window-id nil)
     (setq tmux-control--homeless nil)
@@ -4825,6 +4819,26 @@ Must run in the controller buffer."
   (setq tmux-control--window-buffers
         (cons (cons window-id buffer)
               (assoc-delete-all window-id tmux-control--window-buffers))))
+
+(defun tmux-control--kill-render-buffers (controller)
+  "Kill every per-window render buffer belonging to CONTROLLER.
+A render buffer is named \"*<CONTROLLER-name>:@ID*\", so CONTROLLER's
+own name with the closing star replaced by \":@\" is the exact prefix.
+
+Sweeps by NAME rather than the `tmux-control--window-buffers' registry
+on purpose: the registry can drift out of sync with the live buffers (a
+visited window deregistered without its buffer killed), and a
+registry-only sweep then leaves the orphan behind.  On a reconnect that
+orphan keeps the now-dead process, so reaching it (`C-x b', a later
+window event) hits \"process is not live\" with no recovery -- the
+chaos-soak find this guards against.  CONTROLLER itself is never killed."
+  (let ((prefix (concat (substring (buffer-name controller) 0 -1) ":@")))
+    (dolist (buf (buffer-list))
+      (when (and (buffer-live-p buf)
+                 (not (eq buf controller))
+                 (string-prefix-p prefix (buffer-name buf)))
+        (let ((kill-buffer-query-functions nil))
+          (kill-buffer buf))))))
 
 (defun tmux-control--session-display-buffer (&optional ctrl)
   "Return the buffer currently representing CTRL's session on screen.


### PR DESCRIPTION
## The bug (found by the transient-probing chaos soak)

Visit a tmux window — creating its per-window render buffer — then `tmux-control-reconnect`. The render buffer **survives holding the old, now-dead process**. Reach it afterward (`C-x b`, a later window event) and every keystroke errors "tmux-control process is not live," with no recovery — even though the session reconnected fine and the displayed view is live.

Clean deterministic repro: controller on `@1`, visit window 0 → `@0` render buffer created and live; after reconnect, `@0` is still alive with a **dead** process.

## Root cause

`--reset-buffer` killed sibling render buffers by walking the `tmux-control--window-buffers` **registry** — but the registry can drift out of sync with the live buffers (a visited window deregistered without its buffer killed). A registry-only sweep then leaves that orphan behind, pointing at the process the reconnect just deleted.

## Fix

`tmux-control--kill-render-buffers` sweeps by **name**: every render buffer is `*<controller-name>:@ID*`, so the controller's own name with the closing `*` replaced by `:@` is the exact, drift-proof prefix. The controller itself, tiling `:%` pane buffers, and other sessions' buffers are all spared.

## Validation

- Clean repro verified fixed: the visited window's `@`-buffer is **gone** after reconnect, displayed buffer live.
- 1 unit test (`@`-render buffers swept; `%`-pane buffer, another session's buffer, and the controller all untouched).
- **151 unit green**; strict byte-compile clean.

Found via the transient-probing extension to the chaos soak (separate PR for the harness) — the kind of reconnect-plus-window-churn interaction that only surfaces when you drive input through async state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)