### PR TITLE
Scrollback: hold extension off until the initial chunk lands

### DIFF
--- a/test/tmux-control-integration.el
+++ b/test/tmux-control-integration.el
@@ -776,5 +776,50 @@ requested depth instead of the received depth would risk a seam error."
                  (buffer-local-value 'tmux-control--process live)))
               (kill-buffer live))))))))
 
+(ert-deftest tmux-control-it-scrollback-lazy-open-no-spurious-extend ()
+  "Opening the pager loads ONLY the initial chunk -- it does not balloon into
+a second chunk because the brief \"capturing…\" placeholder makes the top
+trivially visible.  Unlike the other lazy tests this does NOT stub the scroll
+watcher: it drives the real one, because the watcher firing during the
+placeholder is exactly the regression being guarded (a fresh open settling at
+initial+extend instead of initial)."
+  (skip-unless (tmux-control-it--available-p))
+  (let ((tmux-control-scrollback-initial-lines 50)
+        (tmux-control-scrollback-extend-lines 100)
+        (tmux-control-scrollback-lines 5000)
+        (tmux-control-compact-scrollback nil)
+        (content (mapconcat (lambda (i) (format "L%04d" i))
+                            (number-sequence 1 600) "\n")))
+    (tmux-control-it--with-pane (concat content "\n") 100 24
+      (let ((live (tmux-control-connect nil tmux-control-it--socket "t")))
+        (unwind-protect
+            (progn
+              (tmux-control-it--pump-until
+               5 (lambda () (with-current-buffer live tmux-control--active-pane)))
+              (let* ((sbname (format "*%s-scrollback*" (buffer-name live)))
+                     (sb nil))
+                (with-current-buffer live (tmux-control-scrollback))
+                (setq sb (get-buffer sbname))
+                (tmux-control-it--pump-until
+                 10 (lambda () (with-current-buffer sb
+                                 (not (string-match-p "capturing"
+                                                      (buffer-string))))))
+                ;; Give any extend timer that should have been suppressed an
+                ;; ample chance to (not) fire.
+                (tmux-control-it--pump 0.5)
+                ;; Still just the initial chunk -- not initial + extend.
+                (should (= (buffer-local-value
+                            'tmux-control--scrollback-depth sb)
+                           50))
+                (should (< (with-current-buffer sb
+                             (count-lines (point-min) (point-max)))
+                           120))
+                (when (buffer-live-p sb) (kill-buffer sb))))
+          (when (buffer-live-p live)
+            (when (process-live-p
+                   (buffer-local-value 'tmux-control--process live))
+              (delete-process (buffer-local-value 'tmux-control--process live)))
+            (kill-buffer live)))))))
+
 (provide 'tmux-control-integration)
 ;;; tmux-control-integration.el ends here

--- a/test/tmux-control-integration.el
+++ b/test/tmux-control-integration.el
@@ -807,10 +807,14 @@ initial+extend instead of initial)."
                 ;; Give any extend timer that should have been suppressed an
                 ;; ample chance to (not) fire.
                 (tmux-control-it--pump 0.5)
-                ;; Still just the initial chunk -- not initial + extend.
+                ;; Still just the initial chunk -- not initial + extend --
+                ;; and nothing in flight (an extend scheduled-but-pending would
+                ;; leave depth at 50 yet `extending' non-nil, so check both).
                 (should (= (buffer-local-value
                             'tmux-control--scrollback-depth sb)
                            50))
+                (should-not (buffer-local-value
+                             'tmux-control--scrollback-extending sb))
                 (should (< (with-current-buffer sb
                              (count-lines (point-min) (point-max)))
                            120))

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -2646,6 +2646,20 @@ output), :calls (side-effect invocations in order), :active-pane,
                      "older-1\nolder-2\nold-top line\nlive tail\n"))
       (should (= tmux-control--scrollback-depth 2500)))))
 
+(ert-deftest tmux-control-test-scrollback-populate-arms-extension ()
+  ;; The pager opens with extension HELD OFF (extending = t) so the one-line
+  ;; "capturing…" placeholder -- which makes the top trivially visible --
+  ;; cannot trip the scroll watcher into loading a second chunk before the
+  ;; first arrives.  Populating with the initial content must clear that latch
+  ;; so real scrolling can extend.
+  (let ((tmux-control-compact-scrollback nil))
+    (with-temp-buffer
+      (tmux-control-scrollback-mode)
+      (setq-local tmux-control--scrollback-extending t) ; held during placeholder
+      (tmux-control--scrollback-populate (current-buffer) "L1\nL2\nL3" nil nil)
+      (should-not tmux-control--scrollback-extending)
+      (should (string-match-p "L1" (buffer-string))))))
+
 (ert-deftest tmux-control-test-scrollback-prepend-pins-viewport ()
   ;; Prepending older history must keep the view on the same content line,
   ;; not jump it to the freshly loaded lines.  The anchor marker (insertion

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -2120,7 +2120,14 @@ synchronously; BUFFER may have been killed in between."
           (forward-line (1- line))
           (move-to-column (or column 0))
           (when-let* ((window (get-buffer-window buffer t)))
-            (set-window-point window (point)))))))))
+            (set-window-point window (point)))))
+        ;; The full content has landed: arm lazy extension.  It was held off
+        ;; (extending = t) from the moment the pager opened so the one-line
+        ;; "capturing…" placeholder -- which makes the top trivially visible --
+        ;; could not trip the scroll watcher into a spurious extend before the
+        ;; initial chunk even arrived.  Clear it LAST, after the point/window
+        ;; moves above whose redisplay would otherwise fire the watcher.
+        (setq tmux-control--scrollback-extending nil)))))
 
 (defun tmux-control--scrollback-scroll-watch (window start)
   "Extend scrollback when WINDOW has scrolled near the top (START).
@@ -2316,7 +2323,11 @@ the live interactive pane."
         (setq-local tmux-control--scrollback-depth
                     (min tmux-control-scrollback-initial-lines
                          tmux-control-scrollback-lines))
-        (setq-local tmux-control--scrollback-extending nil)
+        ;; Hold extension OFF until the initial chunk lands (the populate
+        ;; callback clears this) so the "capturing…" placeholder, which makes
+        ;; the top trivially visible, cannot trip the watcher into loading a
+        ;; second chunk before the first has even arrived.
+        (setq-local tmux-control--scrollback-extending t)
         (setq-local tmux-control--scrollback-at-top nil)
         (add-hook 'window-scroll-functions
                   #'tmux-control--scrollback-scroll-watch nil t)
@@ -2365,6 +2376,9 @@ the initial chunk or ballooning to the cap."
     ;; A refresh may reveal more history again (e.g. the cap was raised), so
     ;; let extension resume.
     (setq tmux-control--scrollback-at-top nil)
+    ;; Hold extension off while the reload is in flight; the populate callback
+    ;; clears it once the content lands (as on first open).
+    (setq tmux-control--scrollback-extending t)
     (tmux-control--scrollback-request
      (current-buffer)
      tmux-control--scrollback-target


### PR DESCRIPTION
## What

Follow-up to #51, found while **dogfooding lazy scrollback live on a 30k-line pane**: opening the pager loaded **2500 lines, not the intended 500**.

## Why

The one-line `"capturing…"` placeholder makes the top of the buffer trivially visible. The `window-scroll-functions` watcher is installed the moment the pager opens, so it read the view as "near the top" and scheduled a spurious extend *before the initial chunk had even arrived* — partly defeating the instant-open that lazy loading exists to provide. (In a real GUI the initial 500-line chunk exceeds the window height so the view sits at the bottom — but the placeholder phase slips under that and trips the watcher.)

## Fix

Hold extension off (`extending = t`) from the moment the pager opens, and clear it only once the initial content lands (in `--scrollback-populate`, after the point/window moves whose redisplay would otherwise fire the watcher). The refresh path does the same around its reload.

After the fix, verified live: a fresh open loads exactly **500 lines in 13ms**, and scrolling up still extends smoothly (500→2500→4500→…→10000 cap), viewport pinned the whole way.

## Tests

- **Unit**: `--scrollback-populate` clears the latch.
- **Integration**: opens the pager with the **real** scroll watcher active (not stubbed, unlike the other lazy tests) and asserts the depth settles at the initial chunk — the exact condition this fixes. In batch the watcher fires on the open and, without the gate, extends to initial+extend, so this genuinely guards the regression.

155 unit + 18 integration green; clean byte-compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
