### PR TITLE
Scrollback: opt-in continuous live-view scrolling (iTerm-style)

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -264,6 +264,25 @@ view):
   copy-mode rule: the gesture that took you into history takes you back out,
   no key to remember.  `ESC` also returns to the live view.
 
+### Continuous live-view scrollback (iTerm-style, opt-in)
+
+```elisp
+(setq tmux-control-wheel-scrolls-live-history t)
+```
+
+Eat keeps everything that has streamed since you connected as ordinary,
+already-colored buffer text above the live screen.  With this enabled,
+wheel-up over a normal-screen pane scrolls **that** — in place, in the same
+buffer, with no mode switch and no capture round trip — and incoming output no
+longer yanks the view back to the bottom while you read (following resumes the
+moment you scroll back down or type, exactly like iTerm).  Only when you reach
+the top of that retained history does wheel-up open the full pager for the
+deeper, pre-session history that lives in tmux rather than Eat.
+
+Off by default: it changes how the live view itself answers the wheel, so it
+is opt-in. With it off, wheel-up opens the pager immediately, as described
+above. (Requires `tmux-control-wheel-enters-scrollback` to remain non-nil.)
+
 Line numbers are disabled locally in live and scrollback buffers.
 
 ## Keys, raw mode, and paste

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -3186,6 +3186,65 @@ output), :calls (side-effect invocations in order), :active-pane,
             (should (= forwarded 1))
             (should (= scrolled 1))))))))
 
+(ert-deftest tmux-control-test-wheel-scrolls-live-history-routing ()
+  ;; `tmux-control-wheel-scrolls-live-history' off: wheel-up over a
+  ;; normal-screen pane opens the pager immediately (legacy behavior).  On:
+  ;; it scrolls the live view's retained history until the top, where it
+  ;; hands off to the pager for the deeper pre-session history.
+  (let ((scrolled 0) (pager 0) (at-top nil)
+        (event (list 'wheel-up (list (selected-window) 1 '(0 . 0) 0))))
+    (cl-letf (((symbol-function 'tmux-control--wheel-should-enter-scrollback-p)
+               (lambda (&rest _) t))
+              ((symbol-function 'tmux-control--live-history-at-top-p)
+               (lambda (_w) at-top))
+              ((symbol-function 'tmux-control--scroll-live-history)
+               (lambda (_e _w) (cl-incf scrolled)))
+              ((symbol-function 'tmux-control-scrollback)
+               (lambda () (cl-incf pager)))
+              ((symbol-function 'posn-window) (lambda (_) (selected-window))))
+      (save-window-excursion
+        (with-temp-buffer
+          (tmux-control-mode)
+          (set-window-buffer (selected-window) (current-buffer))
+          ;; OFF: pager immediately, no live-history scroll.
+          (let ((tmux-control-wheel-scrolls-live-history nil))
+            (tmux-control-wheel-scroll event)
+            (should (= pager 1))
+            (should (= scrolled 0)))
+          ;; ON, not at the top: scroll the live retained history.
+          (setq at-top nil)
+          (let ((tmux-control-wheel-scrolls-live-history t))
+            (tmux-control-wheel-scroll event)
+            (should (= scrolled 1))
+            (should (= pager 1)))
+          ;; ON, at the top of retained history: open the deep pager.
+          (setq at-top t)
+          (let ((tmux-control-wheel-scrolls-live-history t))
+            (tmux-control-wheel-scroll event)
+            (should (= pager 2))
+            (should (= scrolled 1))))))))
+
+(ert-deftest tmux-control-test-sync-windows-holds-scrolled-away ()
+  ;; The scroll-follow set: with live-history scrolling ON, a window whose
+  ;; live cursor is scrolled out of view is dropped (so streaming output
+  ;; cannot yank a scrolled-up reader back to the bottom); the `buffer'
+  ;; entry and any window still showing the cursor stay.  With it OFF, the
+  ;; set is exactly what Eat reports -- byte-identical legacy behavior.
+  (cl-letf (((symbol-function 'eat--synchronize-scroll-windows)
+             (lambda (&rest _) (list 'buffer 'win-a 'win-b)))
+            ((symbol-function 'eat-term-live-p) (lambda (_) t))
+            ((symbol-function 'eat-term-display-cursor) (lambda (_) 42))
+            ;; The live cursor is visible only in win-a.
+            ((symbol-function 'pos-visible-in-window-p)
+             (lambda (_pos w) (eq w 'win-a))))
+    (let ((tmux-control--terminal 'term))
+      (let ((tmux-control-wheel-scrolls-live-history nil))
+        (should (equal (tmux-control--current-sync-windows)
+                       '(buffer win-a win-b))))
+      (let ((tmux-control-wheel-scrolls-live-history t))
+        (should (equal (tmux-control--current-sync-windows)
+                       '(buffer win-a)))))))
+
 (defvar tmux-control-test--audit-modal nil
   "Stands in for a modal minor mode in the key-audit test.")
 

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -239,6 +239,26 @@ or when the application requests mouse events itself, the wheel event
 is forwarded to the terminal unchanged."
   :type 'boolean)
 
+(defcustom tmux-control-wheel-scrolls-live-history nil
+  "Non-nil means wheel-up first scrolls the live view's own retained history.
+
+iTerm-style continuous scrollback.  Eat keeps the output that has streamed
+since you connected as ordinary buffer text above the live screen, already
+rendered with its colors.  With this enabled, scrolling up over a
+normal-screen pane scrolls *that* -- instantly, in the same buffer, with no
+mode switch and no capture round trip -- and incoming output no longer yanks
+the view back to the bottom while you read (it resumes following when you
+scroll back down or type).  Only once you reach the top of that retained
+history does wheel-up open the full `tmux-control-scrollback' pager for the
+deeper, pre-session history that lives in tmux rather than Eat.
+
+When nil (the default), wheel-up opens the pager immediately, as before --
+the behavior is byte-identical, including the scroll-follow logic.  This is
+opt-in because it changes how the live view itself responds to the wheel.
+
+Has no effect unless `tmux-control-wheel-enters-scrollback' is also non-nil."
+  :type 'boolean)
+
 (defcustom tmux-control-pane-aware-find-file t
   "Non-nil means file commands in a tmux-control buffer start at the pane's dir.
 
@@ -2612,6 +2632,11 @@ buffer (when `tmux-control-wheel-enters-scrollback').  This is the
 Emacs-side analog of tmux's default wheel-up binding, which opens
 copy-mode scrollback for normal-screen panes.
 
+With `tmux-control-wheel-scrolls-live-history', wheel-up first scrolls
+the live buffer's own retained history (the output Eat has kept since you
+connected); only at the top of that does it open the pager for the deeper
+pre-session history.  Otherwise wheel-up opens the pager immediately.
+
 In every other case -- a genuine full-screen (alternate-screen)
 application or a mouse-aware application -- the event is forwarded to the
 terminal unchanged so the application keeps its own handling.  Wheel-down
@@ -2632,12 +2657,37 @@ be read, so the live behavior is otherwise unchanged."
                   (tmux-control--wheel-detectable-p)
                   (tmux-control--alt-screen-p)
                   (tmux-control--pane-grabs-mouse-p)))
-            (select-window window)
-            (tmux-control-scrollback))
+            (if (and tmux-control-wheel-scrolls-live-history
+                     (not (tmux-control--live-history-at-top-p window)))
+                ;; Scroll the live view's own retained history in place.
+                (tmux-control--scroll-live-history event window)
+              ;; At the top of retained history (or the feature is off):
+              ;; open the pager for the deeper pre-session history.
+              (select-window window)
+              (tmux-control-scrollback)))
            (t
             (with-selected-window window
               (eat-self-input 1 event)))))
       (eat-self-input 1 event))))
+
+(defun tmux-control--live-history-at-top-p (window)
+  "Return non-nil when WINDOW shows the top of the live view's retained history.
+That is the oldest line Eat still holds in this buffer; above it lies only
+the deeper pre-session history that lives in tmux, reachable through the
+`tmux-control-scrollback' pager."
+  (pos-visible-in-window-p (point-min) window))
+
+(defun tmux-control--scroll-live-history (event window)
+  "Scroll WINDOW up through the live view's retained history for EVENT.
+Defers to the user's ordinary wheel scrolling (`tmux-control--dispatch-wheel'
+honors `pixel-scroll-precision-mode'), so momentum and feel match every
+other buffer.  Reaching the top mid-scroll opens the pager for the deeper
+pre-session history instead of stopping at a hard edge."
+  (with-selected-window window
+    (condition-case nil
+        (tmux-control--dispatch-wheel event)
+      ((beginning-of-buffer args-out-of-range)
+       (tmux-control-scrollback)))))
 
 (defun tmux-control-wheel-down (event)
   "Handle a wheel-down EVENT in a live tmux-control buffer.
@@ -4304,11 +4354,25 @@ next time.  Pure, for unit testing."
 Must be called BEFORE feeding new output: Eat identifies a following
 window by its point sitting on the current cursor, so once output moves
 the cursor the association is lost.  Captured at the start of a render
-pass and replayed by `tmux-control--flush-display'."
+pass and replayed by `tmux-control--flush-display'.
+
+With `tmux-control-wheel-scrolls-live-history', a window the user has
+scrolled up -- so the live cursor is no longer visible in it -- is dropped
+from the follow set: incoming output keeps accumulating below but the view
+stays where they put it (iTerm behavior), and following resumes naturally
+once the cursor scrolls back into view or a keystroke snaps to the bottom."
   (and (fboundp 'eat--synchronize-scroll-windows)
        tmux-control--terminal
        (eat-term-live-p tmux-control--terminal)
-       (eat--synchronize-scroll-windows)))
+       (let ((windows (eat--synchronize-scroll-windows)))
+         (if (not tmux-control-wheel-scrolls-live-history)
+             windows
+           (let ((cursor (eat-term-display-cursor tmux-control--terminal)))
+             (seq-filter
+              (lambda (w)
+                (or (eq w 'buffer)
+                    (pos-visible-in-window-p cursor w)))
+              windows))))))
 
 (defun tmux-control--snap-to-live-screen (window)
   "Point WINDOW, newly showing this buffer, at the live terminal screen.


### PR DESCRIPTION
## What — path #2 toward true iTerm parity

Make wheel-up scroll the **live view's own retained history** in place, instead of opening a separate pager for it. Opt-in via `tmux-control-wheel-scrolls-live-history` (default **off**).

Eat already keeps everything that has streamed since you connected as ordinary, already-colored buffer text above the live screen (its scrollback, ~128KB ≈ a couple thousand lines). Today wheel-up ignores that and opens the capture-pane pager. With this enabled, wheel-up scrolls that retained history **in the same buffer — no mode switch, no capture round trip, colors already rendered** — and only opens the pager once you reach the top of it, for the deeper pre-session history that lives in tmux rather than Eat.

This is the "no modality" piece that path #1 (instant lazy pager) couldn't give: for recent output you're just scrolling the live buffer, exactly like iTerm.

## How (two surgical pieces, both gated)

1. **Wheel routing** — when on and not yet at the top of retained history, defer to ordinary wheel scrolling (honoring `pixel-scroll-precision-mode`); at the top, hand off to the pager.
2. **Scroll-follow hold** — a window whose live cursor has scrolled out of view is dropped from the follow set, so streaming output accumulates below without yanking a scrolled-up reader back to the bottom. Following resumes the instant the cursor scrolls back into view or a keystroke snaps to live. (Eat's native follow only covers the point-left-the-cursor case; under pixel-scroll point stays *on* the cursor while the view scrolls, so this fills the gap.)

With the gate off, **both paths are byte-identical to today**, including the follow set.

## Investigation that grounded this

I confirmed against the real code + a config-loaded GUI Emacs (pixel-scroll on):
- Eat retains ~1500+ clean, faced scrollback lines from post-connect output (`eat-term-scrollback-size` 128KB).
- tmux-control's output flush already uses the *non-force* sync, so it never force-follows — the machinery to hold a scrolled-up view was already there; wheel-up was just intercepted.
- **Live-validated**: a scrolled-up view held across 200+ streamed lines (window-start unchanged), returned to following at the bottom, detected the top for the pager handoff, and rendered retained history cleanly in place.

## Tests

- Unit: wheel routing (off / on-not-at-top / on-at-top) and the follow-set exclusion (held-when-on vs byte-identical-when-off). 157 unit + 18 integration green; clean byte-compile.

## To try it

`(setq tmux-control-wheel-scrolls-live-history t)`, then wheel up over a pane that's been producing output. Default-off because it changes how the live view answers the wheel — your call whether it becomes the default. Known untested: interaction with tiled multi-pane view (the feature targets the single live/window-buffer view).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
