### PR TITLE
Scrollback: fix live-history handoff fling + resume-follow

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -275,13 +275,19 @@ already-colored buffer text above the live screen.  With this enabled,
 wheel-up over a normal-screen pane scrolls **that** — in place, in the same
 buffer, with no mode switch and no capture round trip — and incoming output no
 longer yanks the view back to the bottom while you read (following resumes the
-moment you scroll back down or type, exactly like iTerm).  Only when you reach
-the top of that retained history does wheel-up open the full pager for the
-deeper, pre-session history that lives in tmux rather than Eat.
+moment you scroll back down or type, exactly like iTerm).  Scrolling back to
+the bottom returns to live; scrolling up simply stops at the top of the
+retained history.
+
+For the deeper, pre-session history that lives in tmux rather than Eat, use
+`C-c C-e` (`tmux-control-scrollback`) — the full pager, unchanged.  (Wheel-up
+also opens it directly from the live screen, when the pane is fresh or quiet
+enough that its whole history already fits on screen; from there the pager
+opens at the same tail, so it is seamless.)
 
 Off by default: it changes how the live view itself answers the wheel, so it
-is opt-in. With it off, wheel-up opens the pager immediately, as described
-above. (Requires `tmux-control-wheel-enters-scrollback` to remain non-nil.)
+is opt-in. With it off, wheel-up opens the pager immediately.  (Requires
+`tmux-control-wheel-enters-scrollback` to remain non-nil.)
 
 Line numbers are disabled locally in live and scrollback buffers.
 

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -3242,9 +3242,10 @@ output), :calls (side-effect invocations in order), :active-pane,
             ((symbol-function 'eat-term-display-cursor) (lambda (_) 42))
             ((symbol-function 'get-buffer-window-list)
              (lambda (&rest _) (list 'win-a 'win-b)))
-            ;; The live cursor is visible only in win-a.
+            ;; The live cursor is visible only in win-a (accepts the PARTIALLY
+            ;; arg the follow-set check now passes).
             ((symbol-function 'pos-visible-in-window-p)
-             (lambda (_pos w) (eq w 'win-a))))
+             (lambda (_pos w &optional _partially) (eq w 'win-a))))
     (let ((tmux-control--terminal 'term))
       (let ((tmux-control-wheel-scrolls-live-history nil))
         (should (equal (tmux-control--current-sync-windows)

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -3189,14 +3189,17 @@ output), :calls (side-effect invocations in order), :active-pane,
 (ert-deftest tmux-control-test-wheel-scrolls-live-history-routing ()
   ;; `tmux-control-wheel-scrolls-live-history' off: wheel-up over a
   ;; normal-screen pane opens the pager immediately (legacy behavior).  On:
-  ;; it scrolls the live view's retained history until the top, where it
-  ;; hands off to the pager for the deeper pre-session history.
-  (let ((scrolled 0) (pager 0) (at-top nil)
+  ;; while there is retained history to scroll into (or you have scrolled up
+  ;; into it) wheel-up scrolls the live view in place; only when the whole
+  ;; retained history already fits on screen -- so you are still at the live
+  ;; screen and cannot scroll -- does it open the pager.  Crucially, being
+  ;; scrolled up (not exhausted) never flings to the pager.
+  (let ((scrolled 0) (pager 0) (exhausted nil)
         (event (list 'wheel-up (list (selected-window) 1 '(0 . 0) 0))))
     (cl-letf (((symbol-function 'tmux-control--wheel-should-enter-scrollback-p)
                (lambda (&rest _) t))
-              ((symbol-function 'tmux-control--live-history-at-top-p)
-               (lambda (_w) at-top))
+              ((symbol-function 'tmux-control--live-history-exhausted-p)
+               (lambda (_w) exhausted))
               ((symbol-function 'tmux-control--scroll-live-history)
                (lambda (_e _w) (cl-incf scrolled)))
               ((symbol-function 'tmux-control-scrollback)
@@ -3211,29 +3214,34 @@ output), :calls (side-effect invocations in order), :active-pane,
             (tmux-control-wheel-scroll event)
             (should (= pager 1))
             (should (= scrolled 0)))
-          ;; ON, not at the top: scroll the live retained history.
-          (setq at-top nil)
+          ;; ON, history available / scrolled up (not exhausted): scroll in
+          ;; place, never the pager -- no fling back to the live tail.
+          (setq exhausted nil)
           (let ((tmux-control-wheel-scrolls-live-history t))
             (tmux-control-wheel-scroll event)
             (should (= scrolled 1))
             (should (= pager 1)))
-          ;; ON, at the top of retained history: open the deep pager.
-          (setq at-top t)
+          ;; ON, whole retained history on screen (at the live screen, cannot
+          ;; scroll): open the pager -- seamless from the live tail.
+          (setq exhausted t)
           (let ((tmux-control-wheel-scrolls-live-history t))
             (tmux-control-wheel-scroll event)
             (should (= pager 2))
             (should (= scrolled 1))))))))
 
 (ert-deftest tmux-control-test-sync-windows-holds-scrolled-away ()
-  ;; The scroll-follow set: with live-history scrolling ON, a window whose
-  ;; live cursor is scrolled out of view is dropped (so streaming output
-  ;; cannot yank a scrolled-up reader back to the bottom); the `buffer'
-  ;; entry and any window still showing the cursor stay.  With it OFF, the
-  ;; set is exactly what Eat reports -- byte-identical legacy behavior.
+  ;; The scroll-follow set.  With live-history scrolling ON it is keyed on
+  ;; cursor visibility: a window showing the live cursor follows (win-a), one
+  ;; scrolled away does not (win-b) -- so a scrolled-up reader holds and a
+  ;; scrolled-back-down one resumes, regardless of where point sits.  Eat's
+  ;; `buffer' point decision is preserved.  With it OFF, the set is exactly
+  ;; what Eat reports -- byte-identical legacy behavior.
   (cl-letf (((symbol-function 'eat--synchronize-scroll-windows)
              (lambda (&rest _) (list 'buffer 'win-a 'win-b)))
             ((symbol-function 'eat-term-live-p) (lambda (_) t))
             ((symbol-function 'eat-term-display-cursor) (lambda (_) 42))
+            ((symbol-function 'get-buffer-window-list)
+             (lambda (&rest _) (list 'win-a 'win-b)))
             ;; The live cursor is visible only in win-a.
             ((symbol-function 'pos-visible-in-window-p)
              (lambda (_pos w) (eq w 'win-a))))
@@ -3241,6 +3249,7 @@ output), :calls (side-effect invocations in order), :active-pane,
       (let ((tmux-control-wheel-scrolls-live-history nil))
         (should (equal (tmux-control--current-sync-windows)
                        '(buffer win-a win-b))))
+      ;; ON: keep `buffer' (point) + only the window showing the cursor.
       (let ((tmux-control-wheel-scrolls-live-history t))
         (should (equal (tmux-control--current-sync-windows)
                        '(buffer win-a)))))))

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -2658,11 +2658,17 @@ be read, so the live behavior is otherwise unchanged."
                   (tmux-control--alt-screen-p)
                   (tmux-control--pane-grabs-mouse-p)))
             (if (and tmux-control-wheel-scrolls-live-history
-                     (not (tmux-control--live-history-at-top-p window)))
-                ;; Scroll the live view's own retained history in place.
+                     (not (tmux-control--live-history-exhausted-p window)))
+                ;; There is retained history to scroll into (or you have
+                ;; already scrolled up into it): scroll the live view in
+                ;; place.  Do NOT fling to the pager here -- being scrolled up
+                ;; and wheeling further must not jump you back to the live
+                ;; tail; it simply stops at the top.
                 (tmux-control--scroll-live-history event window)
-              ;; At the top of retained history (or the feature is off):
-              ;; open the pager for the deeper pre-session history.
+              ;; The whole retained history is already on screen (a fresh or
+              ;; quiet pane, so you are still at the live screen) -- or the
+              ;; feature is off.  Open the pager for the full history; from
+              ;; the live screen this is seamless (it opens at the same tail).
               (select-window window)
               (tmux-control-scrollback)))
            (t
@@ -2670,24 +2676,31 @@ be read, so the live behavior is otherwise unchanged."
               (eat-self-input 1 event)))))
       (eat-self-input 1 event))))
 
-(defun tmux-control--live-history-at-top-p (window)
-  "Return non-nil when WINDOW shows the top of the live view's retained history.
-That is the oldest line Eat still holds in this buffer; above it lies only
-the deeper pre-session history that lives in tmux, reachable through the
-`tmux-control-scrollback' pager."
-  (pos-visible-in-window-p (point-min) window))
+(defun tmux-control--live-history-exhausted-p (window)
+  "Return non-nil when WINDOW already shows all of the live view's history.
+True when both the top of the buffer and the live cursor are visible -- the
+whole of what Eat still holds fits on screen, so wheel-up cannot scroll it
+any further and the deeper pre-session history (which lives in tmux, not
+Eat) needs the `tmux-control-scrollback' pager.  False once there is
+retained history above the view to scroll into, or once you have scrolled up
+off the live screen -- in which case wheel-up keeps scrolling in place."
+  (and (pos-visible-in-window-p (point-min) window)
+       (or (not (and tmux-control--terminal
+                     (eat-term-live-p tmux-control--terminal)))
+           (pos-visible-in-window-p
+            (eat-term-display-cursor tmux-control--terminal) window))))
 
 (defun tmux-control--scroll-live-history (event window)
   "Scroll WINDOW up through the live view's retained history for EVENT.
 Defers to the user's ordinary wheel scrolling (`tmux-control--dispatch-wheel'
 honors `pixel-scroll-precision-mode'), so momentum and feel match every
-other buffer.  Reaching the top mid-scroll opens the pager for the deeper
-pre-session history instead of stopping at a hard edge."
+other buffer.  At the very top it simply stops -- the deeper pre-session
+history is an explicit `tmux-control-scrollback' (\\[tmux-control-scrollback])
+away, so wheeling past the top never flings the view back to the live tail."
   (with-selected-window window
     (condition-case nil
         (tmux-control--dispatch-wheel event)
-      ((beginning-of-buffer args-out-of-range)
-       (tmux-control-scrollback)))))
+      ((beginning-of-buffer end-of-buffer args-out-of-range) nil))))
 
 (defun tmux-control-wheel-down (event)
   "Handle a wheel-down EVENT in a live tmux-control buffer.
@@ -4356,23 +4369,28 @@ window by its point sitting on the current cursor, so once output moves
 the cursor the association is lost.  Captured at the start of a render
 pass and replayed by `tmux-control--flush-display'.
 
-With `tmux-control-wheel-scrolls-live-history', a window the user has
-scrolled up -- so the live cursor is no longer visible in it -- is dropped
-from the follow set: incoming output keeps accumulating below but the view
-stays where they put it (iTerm behavior), and following resumes naturally
-once the cursor scrolls back into view or a keystroke snaps to the bottom."
+With `tmux-control-wheel-scrolls-live-history' the follow set is keyed on
+CURSOR VISIBILITY instead: every window of this buffer that currently shows
+the live cursor follows, the rest do not.  So a window scrolled up off the
+live screen holds (output accumulates below without yanking the reader back),
+and one scrolled back down to it resumes following -- both regardless of where
+point happens to sit, which a mouse-wheel scroll under
+`pixel-scroll-precision-mode' leaves on the cursor rather than moving.  Eat's
+own list keys on point==cursor, which the wheel does not maintain, so it can
+neither hold reliably nor re-arm on the way back; this keys on what the user
+actually sees.  Eat's `buffer' point decision is preserved."
   (and (fboundp 'eat--synchronize-scroll-windows)
        tmux-control--terminal
        (eat-term-live-p tmux-control--terminal)
-       (let ((windows (eat--synchronize-scroll-windows)))
+       (let ((base (eat--synchronize-scroll-windows)))
          (if (not tmux-control-wheel-scrolls-live-history)
-             windows
+             base
            (let ((cursor (eat-term-display-cursor tmux-control--terminal)))
-             (seq-filter
-              (lambda (w)
-                (or (eq w 'buffer)
-                    (pos-visible-in-window-p cursor w)))
-              windows))))))
+             (append
+              (and (memq 'buffer base) '(buffer))
+              (seq-filter
+               (lambda (w) (pos-visible-in-window-p cursor w))
+               (get-buffer-window-list (current-buffer) nil t))))))))
 
 (defun tmux-control--snap-to-live-screen (window)
   "Point WINDOW, newly showing this buffer, at the live terminal screen.

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -2632,10 +2632,14 @@ buffer (when `tmux-control-wheel-enters-scrollback').  This is the
 Emacs-side analog of tmux's default wheel-up binding, which opens
 copy-mode scrollback for normal-screen panes.
 
-With `tmux-control-wheel-scrolls-live-history', wheel-up first scrolls
-the live buffer's own retained history (the output Eat has kept since you
-connected); only at the top of that does it open the pager for the deeper
-pre-session history.  Otherwise wheel-up opens the pager immediately.
+With `tmux-control-wheel-scrolls-live-history', wheel-up scrolls the live
+buffer's own retained history (the output Eat has kept since you connected)
+in place, stopping at the top -- it never flings back to the live tail.  It
+opens the pager only when that whole retained history already fits on screen
+(a fresh or quiet pane, where you are still at the live screen, so the pager
+opens at the same tail); the deeper pre-session history is otherwise an
+explicit `tmux-control-scrollback' (\\[tmux-control-scrollback]) away.  With
+the option off, wheel-up opens the pager immediately.
 
 In every other case -- a genuine full-screen (alternate-screen)
 application or a mouse-aware application -- the event is forwarded to the
@@ -2683,12 +2687,17 @@ whole of what Eat still holds fits on screen, so wheel-up cannot scroll it
 any further and the deeper pre-session history (which lives in tmux, not
 Eat) needs the `tmux-control-scrollback' pager.  False once there is
 retained history above the view to scroll into, or once you have scrolled up
-off the live screen -- in which case wheel-up keeps scrolling in place."
-  (and (pos-visible-in-window-p (point-min) window)
+off the live screen -- in which case wheel-up keeps scrolling in place.
+
+The PARTIALLY arg to `pos-visible-in-window-p' is essential under
+`pixel-scroll-precision-mode', which routinely parks a line a few pixels
+clipped: without it a barely-clipped top or cursor line reads as not visible
+and the routing misfires."
+  (and (pos-visible-in-window-p (point-min) window t)
        (or (not (and tmux-control--terminal
                      (eat-term-live-p tmux-control--terminal)))
            (pos-visible-in-window-p
-            (eat-term-display-cursor tmux-control--terminal) window))))
+            (eat-term-display-cursor tmux-control--terminal) window t))))
 
 (defun tmux-control--scroll-live-history (event window)
   "Scroll WINDOW up through the live view's retained history for EVENT.
@@ -4389,7 +4398,10 @@ actually sees.  Eat's `buffer' point decision is preserved."
              (append
               (and (memq 'buffer base) '(buffer))
               (seq-filter
-               (lambda (w) (pos-visible-in-window-p cursor w))
+               ;; PARTIALLY: under `pixel-scroll-precision-mode' the cursor
+               ;; line at the bottom is often a few pixels clipped; without
+               ;; this it reads as not visible and following never resumes.
+               (lambda (w) (pos-visible-in-window-p cursor w t))
                (get-buffer-window-list (current-buffer) nil t))))))))
 
 (defun tmux-control--snap-to-live-screen (window)


### PR DESCRIPTION
## What

Two fixes to the opt-in continuous scrollback (#53), both found by driving **real pixel-scroll wheel events** through it in your live Emacs (thanks for clearing the Spaces obstacle — that's what surfaced these).

### 1. Jarring handoff → fixed

Before: scroll up to the top of retained history, wheel once more, and the view **flung back to the live tail** (pager opened at the bottom). Backwards and disorienting.

After: wheel-up opens the pager **only when the whole retained history already fits on screen** — a fresh/quiet pane where you're still at the live screen, so the pager opens at the same tail (seamless). Once you've scrolled up off the live screen, wheel-up scrolls in place and just **stops at the top**; deeper pre-session history is an explicit `C-c C-e`, never an auto-fling.

### 2. Resume-follow broken → fixed

Before: after scrolling back down to the bottom, streaming output **didn't resume following** — the view sat still while new lines piled up below.

Why: the follow set was keyed on Eat's `point == cursor` test, which a wheel scroll under `pixel-scroll-precision` doesn't maintain (point stays on the cursor while the view moves). So it could *hold* a scrolled-up view but never *re-arm* one scrolled back down.

After: re-key the follow set (feature-on only) on **cursor visibility** — every window showing the live cursor follows, the rest don't. Holds when scrolled away, resumes when scrolled back, regardless of where point sits.

## Validated (real wheel events, end to end)

Seamless scroll up into session history ✓ · hold across 150+ streamed lines while scrolled up ✓ · no fling at the top ✓ · resume-follow on the way back down (streamed RESUME2 lines tracked to the live bottom) ✓ · `C-c C-e` still opens the deep pager ✓.

Gate still default-off; off path byte-identical. 157 unit + 18 integration green, clean byte-compile. Unit tests updated for both (routing on exhausted-vs-not; follow set keyed on cursor visibility).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
