### PR TITLE
Scrollback: scope live-history out of tiled mode + flood/limits docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,11 @@ attaches, typing a new name creates it.
   session is its own buffer with its own scrollback and tabs — with a dot
   flagging another session that wants you, or tile **every session at once**
   in a live grid (`C-c C-f`, experimental).
-- **Scrollback** as ordinary Emacs text (`C-c C-e`) — faithful by default, with
-  opt-in compaction of repeated full-screen redraws (toggle in the pager with
-  `c`).
+- **Scrollback** as ordinary Emacs text (`C-c C-e`) — opens instantly however
+  deep the history (loaded lazily, extended as you scroll), faithful by
+  default, with opt-in compaction of repeated full-screen redraws (toggle with
+  `c`). Optionally, scroll the live view's own history in place, iTerm-style,
+  rather than opening the pager.
 - **Tiled view** (`C-c C-t`, experimental) — every pane of a window at once,
   split to match tmux's layout.
 - **Persistent & remote** — the session lives on the server and outlives Emacs;

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -289,6 +289,17 @@ Off by default: it changes how the live view itself answers the wheel, so it
 is opt-in. With it off, wheel-up opens the pager immediately.  (Requires
 `tmux-control-wheel-enters-scrollback` to remain non-nil.)
 
+A few characteristics worth knowing. The retained history is Eat's own
+scrollback (bounded, ~128KB), so it covers this session's output, not the
+deeper pre-session history — that is what `C-c C-e` is for. During a **flood**
+larger than that buffer, the oldest retained lines (including a spot you had
+scrolled up to) are trimmed away and the view drops to the top of what
+remains; it does not get yanked to the bottom, and typing your next command
+snaps straight back to live. The pager (`C-c C-e`), being a fixed capture, is
+the steadier choice for studying history while a pane is gushing output. The
+feature is also scoped to the single live view — **tiled** panes keep the
+plain pager-on-wheel-up behavior regardless of this setting.
+
 Line numbers are disabled locally in live and scrollback buffers.
 
 ## Keys, raw mode, and paste

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -3227,7 +3227,16 @@ output), :calls (side-effect invocations in order), :active-pane,
           (let ((tmux-control-wheel-scrolls-live-history t))
             (tmux-control-wheel-scroll event)
             (should (= pager 2))
-            (should (= scrolled 1))))))))
+            (should (= scrolled 1)))
+          ;; ON but TILED: the feature is scoped out -- tiled panes keep the
+          ;; plain pager-on-wheel-up, never the in-place live-history scroll.
+          (setq exhausted nil)
+          (cl-letf (((symbol-function 'tmux-control--tiled-mode-p)
+                     (lambda () t)))
+            (let ((tmux-control-wheel-scrolls-live-history t))
+              (tmux-control-wheel-scroll event)
+              (should (= pager 3))
+              (should (= scrolled 1)))))))))
 
 (ert-deftest tmux-control-test-sync-windows-holds-scrolled-away ()
   ;; The scroll-follow set.  With live-history scrolling ON it is keyed on
@@ -3253,7 +3262,13 @@ output), :calls (side-effect invocations in order), :active-pane,
       ;; ON: keep `buffer' (point) + only the window showing the cursor.
       (let ((tmux-control-wheel-scrolls-live-history t))
         (should (equal (tmux-control--current-sync-windows)
-                       '(buffer win-a)))))))
+                       '(buffer win-a))))
+      ;; ON but TILED: scoped out -- the tiling layer anchors its own panes,
+      ;; so the follow set stays exactly Eat's own list.
+      (cl-letf (((symbol-function 'tmux-control--tiled-mode-p) (lambda () t)))
+        (let ((tmux-control-wheel-scrolls-live-history t))
+          (should (equal (tmux-control--current-sync-windows)
+                         '(buffer win-a win-b))))))))
 
 (defvar tmux-control-test--audit-modal nil
   "Stands in for a modal minor mode in the key-audit test.")

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -2623,6 +2623,20 @@ that has not grabbed the mouse.  Pure: the decision behind
        (not alt-screen)
        (not grabs-mouse)))
 
+(defun tmux-control--tiled-mode-p ()
+  "Return non-nil when the current buffer is part of a tiled multi-pane view.
+True for the tiled controller and for each of its pane buffers.  The
+continuous live-history wheel behavior is scoped OUT of tiled mode: a tiled
+pane is anchored to the top of its own screen by the tiling layer
+\(`tmux-control--anchor-windows-to-screen-top'), which the in-place scroll and
+the cursor-visibility follow set would fight, so tiled panes keep the plain
+pager-on-wheel-up behavior regardless of
+`tmux-control-wheel-scrolls-live-history'."
+  (or tmux-control--tiled
+      (and tmux-control--controller
+           (buffer-live-p tmux-control--controller)
+           (buffer-local-value 'tmux-control--tiled tmux-control--controller))))
+
 (defun tmux-control-wheel-scroll (event)
   "Handle a mouse wheel EVENT in a live tmux-control buffer.
 
@@ -2662,6 +2676,7 @@ be read, so the live behavior is otherwise unchanged."
                   (tmux-control--alt-screen-p)
                   (tmux-control--pane-grabs-mouse-p)))
             (if (and tmux-control-wheel-scrolls-live-history
+                     (not (tmux-control--tiled-mode-p))
                      (not (tmux-control--live-history-exhausted-p window)))
                 ;; There is retained history to scroll into (or you have
                 ;; already scrolled up into it): scroll the live view in
@@ -4392,7 +4407,11 @@ actually sees.  Eat's `buffer' point decision is preserved."
        tmux-control--terminal
        (eat-term-live-p tmux-control--terminal)
        (let ((base (eat--synchronize-scroll-windows)))
-         (if (not tmux-control-wheel-scrolls-live-history)
+         (if (or (not tmux-control-wheel-scrolls-live-history)
+                 ;; Tiled panes are anchored by the tiling layer, not by this
+                 ;; cursor-visibility follow set -- leave them on Eat's own
+                 ;; list (see `tmux-control--tiled-mode-p').
+                 (tmux-control--tiled-mode-p))
              base
            (let ((cursor (eat-term-display-cursor tmux-control--terminal)))
              (append


### PR DESCRIPTION
## What

Closes the technical gaps I flagged before we'd consider promoting `tmux-control-wheel-scrolls-live-history` (path #2) to default.

### Tiling — scoped out (the real gap)

The feature targets the single live view. In a tiled multi-pane view, each pane is anchored to the top of its own screen by the tiling layer — which the in-place scroll and the cursor-visibility follow set would fight. So I scoped the feature **out of tiled mode** (new `tmux-control--tiled-mode-p`, checked in both the wheel routing and the follow set): tiled panes keep the plain pager-on-wheel-up behavior and Eat's own follow set regardless of the setting. **Tiling is byte-identical whether the feature is on or off.** Unit tests added for both bypasses.

### Hold-under-flood — validated live (gate on, real wheel + 20,000-line flood)

- A scrolled-up view is **never yanked to the bottom** by streaming output ✓
- Under a flood larger than Eat's ~128KB scrollback, the oldest retained lines (including where you'd scrolled to) **trim away** and the view drops to the *top* of what remains — not the bottom. The render stays correct (matched tmux cell-for-cell). ✓
- **Recovery is trivial**: typing your next command snaps straight to live and resumes following ✓

This trim-under-flood is the one real characteristic vs the pager (a fixed capture, so it's the steadier choice for studying history while a pane gushes). Documented honestly in the guide.

### Chaos soak (gate-on)

The committed chaos harness assumes pager-on-wheel-up, so running it gate-on would false-fail on its wheel ops (the same "rotted test" trap we hit before). Rather than overhaul it, I stress-tested the feature-specific paths directly (flood, recovery, follow-set). The general ops (window churn, reconnect) aren't changed by the feature — at the live screen the cursor is visible, so the follow set matches gate-off. A gate-on-aware harness mode is a reasonable future addition; noted.

## Docs

Guide documents the flood/trim and tiled-scoping characteristics; README notes scrollback opens instantly (lazy) and the optional in-place scroll.

157 unit + 18 integration green, clean byte-compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
