### PR TITLE
Scrollback: stop terminal rows soft-wrapping (fixes mangled render #57)

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -2660,6 +2660,19 @@ output), :calls (side-effect invocations in order), :active-pane,
       (should-not tmux-control--scrollback-extending)
       (should (string-match-p "L1" (buffer-string))))))
 
+(ert-deftest tmux-control-test-disable-soft-wrap ()
+  ;; Scrollback rows are terminal grid lines; `word-wrap' (soft, word-boundary
+  ;; wrapping) reflows an overflowing row mid-word and smears fixed-column TUI
+  ;; borders across the wrap (issue #57).  The helper turns it off even when a
+  ;; global `visual-line-mode' (stood in for here) had switched it on.
+  (with-temp-buffer
+    (visual-line-mode 1)
+    (should (bound-and-true-p visual-line-mode))
+    (should word-wrap)                  ; precondition visual-line set it
+    (tmux-control--disable-soft-wrap)
+    (should-not (bound-and-true-p visual-line-mode))
+    (should-not word-wrap)))
+
 (ert-deftest tmux-control-test-scrollback-prepend-pins-viewport ()
   ;; Prepending older history must keep the view on the same content line,
   ;; not jump it to the freshly loaded lines.  The anchor marker (insertion

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -2332,6 +2332,10 @@ the live interactive pane."
                              tmux-control-scrollback-lines)))
         (tmux-control-scrollback-mode)
         (tmux-control--disable-line-numbers)
+        ;; Terminal rows must not soft-wrap at word boundaries (mangles
+        ;; fixed-column TUI borders); run here, after the mode, so a global
+        ;; `visual-line-mode' cannot re-enable it.
+        (tmux-control--disable-soft-wrap)
         (setq-local tmux-control--host host)
         (setq-local tmux-control--socket-name socket-name)
         (setq-local tmux-control--session session)
@@ -2765,6 +2769,22 @@ clip the leftmost terminal column (e.g. a prompt glyph)."
   (setq-local right-margin-width 0)
   (dolist (window (get-buffer-window-list (current-buffer) nil t))
     (set-window-margins window 0 0)))
+
+(defun tmux-control--disable-soft-wrap ()
+  "Turn off `visual-line-mode' / `word-wrap' in the current buffer.
+Scrollback rows are terminal grid lines; when a row overflows the window
+\(e.g. a wide remote pane captured for a narrower window) `word-wrap' reflows
+it at a WORD boundary, which smears fixed-column box borders -- the `|'/`\\='
+sidebar of a TUI -- across the wrap and mangles the layout.  Plain character
+wrapping keeps every column aligned.
+
+Must run AFTER the major mode is established, not from the mode body: a
+globalized `global-visual-line-mode' (in the user's config) turns
+`visual-line-mode' back on from the `after-change-major-mode-hook' that fires
+when the mode is set, so anything the mode body does is immediately undone."
+  (when (bound-and-true-p visual-line-mode)
+    (visual-line-mode -1))
+  (setq-local word-wrap nil))
 
 (defun tmux-control--eat-semi-char-mode-advice (orig-fn &rest args)
   "Make `eat-semi-char-mode' return tmux-control scrollback buffers live.

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -2774,9 +2774,9 @@ clip the leftmost terminal column (e.g. a prompt glyph)."
   "Turn off `visual-line-mode' / `word-wrap' in the current buffer.
 Scrollback rows are terminal grid lines; when a row overflows the window
 \(e.g. a wide remote pane captured for a narrower window) `word-wrap' reflows
-it at a WORD boundary, which smears fixed-column box borders -- the `|'/`\\='
-sidebar of a TUI -- across the wrap and mangles the layout.  Plain character
-wrapping keeps every column aligned.
+it at a WORD boundary, which smears a fixed-column box border (a TUI's │
+sidebar) across the wrap and mangles the layout.  Plain character wrapping
+keeps every column aligned.
 
 Must run AFTER the major mode is established, not from the mode body: a
 globalized `global-visual-line-mode' (in the user's config) turns


### PR DESCRIPTION
Fixes #57.

## Root cause

A globalized `global-visual-line-mode` in the user's config turns `visual-line-mode` — and thus `word-wrap` (soft, word-boundary wrapping) — on in the scrollback buffer. Scrollback rows are terminal grid lines; when a row overflows the window (e.g. a **wide remote TUI captured for a narrower Emacs window**), `word-wrap` reflows it at a *word* boundary, which smears a fixed-column box border (a TUI's `│` sidebar) across the wrap and breaks the column alignment → "persistent broken vertical bar + mangled wrapping."

Confirmed live in the reporter's config: the pager buffer had `visual-line-mode t`, `word-wrap t`.

## Reproduced + verified (live, GUI)

Wide `│`-bordered rows with word-wrap **on**: each row reflows mid-word and the `│` appears on only the first line of each wrapped pair — broken, inconsistent bar. With it **off** (char-wrap): rows break at the exact column and the `│` stays a clean, aligned vertical column.

## Fix

`tmux-control--disable-soft-wrap` turns `visual-line-mode`/`word-wrap` off in the scrollback buffer. It runs from `tmux-control-scrollback` **after** the major mode is established — *not* from the mode body — because a globalized visual-line-mode re-enables it on the `after-change-major-mode-hook` that fires when the mode is set, so a mode-body call would be undone immediately. Verified: a freshly-opened pager now has both off.

`truncate-lines` is left as the mode set it (nil), so an overflowing row still character-wraps to show all its content — column-aligned, not smeared.

## Note for the reporter

This makes whatever wrapping happens *faithful* (column-preserving). The deeper question of *why the rows overflowed at all* — a row captured wider than the Emacs window, likely a multi-client remote session whose pane didn't resize to this client — is a separate capture-width concern. **Please pull this and confirm it resolves the artifacts on `nebius-0`**; if rows still wrap (vs render flush), we'll chase the capture-width side next.

158 unit + 18 integration green; clean byte-compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
