### PR TITLE
Cancel the command watchdog timer on buffer kill

### DIFF
--- a/tmux-control.el
+++ b/tmux-control.el
@@ -5059,6 +5059,13 @@ client (e.g. iTerm2) for the trade-offs."
 
 (defun tmux-control--kill-process ()
   "Delete the tmux control process and any dependent render buffers."
+  ;; Cancel the command watchdog: its timer lives on the global `timer-list'
+  ;; and holds this buffer as its argument, so without this the killed
+  ;; controller is retained until the timer next fires.  Mirrors the
+  ;; cancellation in `tmux-control--reset-buffer'.
+  (when tmux-control--command-watchdog-timer
+    (cancel-timer tmux-control--command-watchdog-timer)
+    (setq tmux-control--command-watchdog-timer nil))
   (when tmux-control--panes
     (dolist (np tmux-control--panes)
       (when (buffer-live-p (cdr np))


### PR DESCRIPTION
## What

`tmux-control--kill-process` (the controller buffer's `kill-buffer-hook`) deletes the process and dependent render buffers but never cancels `tmux-control--command-watchdog-timer`.

Its sibling teardown, `tmux-control--reset-buffer`, *does* cancel it.

## Why it matters

The watchdog timer lives on the global `timer-list` and holds the controller buffer as its callback argument. Kill a connected controller while a command is in flight (queue non-empty, `tmux-control-command-timeout` set) and the dead buffer is retained until the timer next fires (≤ `command-timeout`, default 10s). It then no-ops on `buffer-live-p` and does not re-arm, so the leak is bounded — but it's a needless retention the reset path already knew to avoid.

## Fix

Cancel and clear the timer at the top of `tmux-control--kill-process`, mirroring `tmux-control--reset-buffer`.

## Test

157 ERT tests green; clean byte-compile (warnings-as-errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
