### PR TITLE
Read alternate-screen state from the controller in render buffers

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -692,6 +692,37 @@ each wrapped in an evolving prompt line and a status bar.")
   ;; Always returns a normalized boolean, never a truthy non-t value.
   (should (eq (tmux-control--alt-screen-effective-p t "alt") t)))
 
+(ert-deftest tmux-control-test-effective-alt-screen-honored ()
+  ;; The phantom-alt-screen correction is resolved only in the controller
+  ;; buffer; a render buffer (per-window or tiled pane) must defer to its
+  ;; controller, not read its own frozen-`t' local -- else wheel-up would
+  ;; forward to the pane instead of opening scrollback under
+  ;; `alternate-screen off'.
+  (let ((controller (generate-new-buffer " *tc-test-ctrl*")))
+    (unwind-protect
+        (progn
+          (with-current-buffer controller
+            (setq-local tmux-control--alt-screen-honored nil) ; resolved: off
+            (setq-local tmux-control--controller nil))        ; it IS the controller
+          ;; A render buffer keeps the conservative `t' it was created with...
+          (with-temp-buffer
+            (setq-local tmux-control--alt-screen-honored t)
+            (setq-local tmux-control--controller controller)
+            ;; ...but the effective value comes from the controller.
+            (should (eq (tmux-control--effective-alt-screen-honored) nil)))
+          ;; The controller itself reads its own resolved local.
+          (with-current-buffer controller
+            (should (eq (tmux-control--effective-alt-screen-honored) nil))
+            (setq-local tmux-control--alt-screen-honored t)
+            (should (eq (tmux-control--effective-alt-screen-honored) t)))
+          ;; A dead controller falls back to the buffer's own local.
+          (with-temp-buffer
+            (setq-local tmux-control--alt-screen-honored t)
+            (setq-local tmux-control--controller (generate-new-buffer " *dead*"))
+            (kill-buffer tmux-control--controller)
+            (should (eq (tmux-control--effective-alt-screen-honored) t))))
+      (when (buffer-live-p controller) (kill-buffer controller)))))
+
 (ert-deftest tmux-control-test-wheel-should-enter-scrollback-p ()
   ;; The full gate: enter scrollback only on wheel-up, when enabled and
   ;; detectable, over a normal-screen pane that has not grabbed the mouse.

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -2583,16 +2583,35 @@ effective `alternate-screen' option is on (`tmux-control--alt-screen-honored').
 When that option is off, tmux keeps the pane on its normal screen and
 forwards a phantom alternate-screen request to the control client, so
 Eat's state alone is unreliable.  Read locally, with no tmux query."
-  (and tmux-control--alt-screen-honored
-       tmux-control--terminal
-       (eat-term-live-p tmux-control--terminal)
-       (tmux-control--alt-screen-effective-p
-        tmux-control--alt-screen-honored
-        (cond
-         ((fboundp 'eat-term-in-alternative-display-p)
-          (eat-term-in-alternative-display-p tmux-control--terminal))
-         ((fboundp 'eat--t-term-main-display)
-          (eat--t-term-main-display tmux-control--terminal))))))
+  (let ((honored (tmux-control--effective-alt-screen-honored)))
+    (and honored
+         tmux-control--terminal
+         (eat-term-live-p tmux-control--terminal)
+         (tmux-control--alt-screen-effective-p
+          honored
+          (cond
+           ((fboundp 'eat-term-in-alternative-display-p)
+            (eat-term-in-alternative-display-p tmux-control--terminal))
+           ((fboundp 'eat--t-term-main-display)
+            (eat--t-term-main-display tmux-control--terminal)))))))
+
+(defun tmux-control--effective-alt-screen-honored ()
+  "Return whether the rendered pane's window honors the alternate screen.
+`tmux-control--alt-screen-honored' is resolved (via the two-stage
+`show-options' query) only in the controller buffer.  Render buffers --
+the per-window buffers and tiled pane buffers that are the default
+display path -- keep the conservative `t' they were created with and are
+never updated, so reading their own local would defeat the
+phantom-alternate-screen correction (wheel-up would forward to the pane
+instead of opening scrollback under `alternate-screen off').  When this
+is such a render buffer, defer to its controller's resolved value; the
+`alternate-screen' option is a server/window setting shared across the
+panes we render, so the active window's resolution applies."
+  (if (and tmux-control--controller
+           (buffer-live-p tmux-control--controller))
+      (buffer-local-value 'tmux-control--alt-screen-honored
+                          tmux-control--controller)
+    tmux-control--alt-screen-honored))
 
 (defun tmux-control--pane-grabs-mouse-p ()
   "Return non-nil when the pane's application has requested mouse tracking.

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -2604,9 +2604,20 @@ display path -- keep the conservative `t' they were created with and are
 never updated, so reading their own local would defeat the
 phantom-alternate-screen correction (wheel-up would forward to the pane
 instead of opening scrollback under `alternate-screen off').  When this
-is such a render buffer, defer to its controller's resolved value; the
-`alternate-screen' option is a server/window setting shared across the
-panes we render, so the active window's resolution applies."
+is such a render buffer, defer to its controller's resolved value.
+
+The controller resolves the option for its OWN active window, so this is
+exact when `alternate-screen' is uniform across the session -- which is how
+it is used in practice (a server/global `.tmux.conf' setting).  It assumes
+that uniformity: a sibling render buffer showing a different window that
+*overrode* `alternate-screen' would read the active window's value instead
+of its own.  That is a deliberate trade -- still strictly better than the
+conservative `t' these buffers used to freeze (wrong under a global
+`alternate-screen off'), and it avoids an extra two-stage `show-options'
+round trip per render buffer for a per-window override that essentially
+never occurs.  The strictly-correct alternative, if it ever matters, is to
+resolve the option per render buffer at seed time (or cache it on the
+controller keyed by window id)."
   (if (and tmux-control--controller
            (buffer-live-p tmux-control--controller))
       (buffer-local-value 'tmux-control--alt-screen-honored


### PR DESCRIPTION
## The bug

`tmux-control--alt-screen-honored` is the flag that distinguishes a *real* alternate screen (vim/htop while tmux honors `alternate-screen`) from a *phantom* one (the pane is on its normal screen because `alternate-screen off`, but tmux still forwards the alt-screen escape to the control client, so Eat reports the alternate display).

That flag is resolved — via the two-stage `show-options` query — **only in the controller buffer**. Every per-window render buffer (`tmux-control--make-window-buffer`) and tiled pane buffer (`tmux-control--make-pane-buffer`) hardcodes it to `t` at creation and never updates it. `tmux-control--alt-screen-p` read the *current* buffer's value, so in the default `tmux-control-window-buffers` mode it always saw `t`.

**Effect:** under `alternate-screen off`, wheel-up over an alt-screen app that doesn't grab the mouse (a pager — `man`, `git log`, `less`) was forwarded to the pane instead of opening the Emacs scrollback. That's precisely the behaviour `alternate-screen off` exists to enable, silently broken on the default path.

## Confirmed empirically

Against a throwaway tmux 3.6a server, under `alternate-screen off`:

| | tmux `#{alternate_on}` | smcup reaches control client? |
|---|---|---|
| `alternate-screen off` | **0** (pane on normal screen) | **yes** → Eat reports alt-display ⇒ phantom |
| `alternate-screen on` | 1 | yes ⇒ real |

So Eat's alt-display state alone is unreliable, and the controller's resolved `honored` value is the source of truth.

## Fix

`tmux-control--effective-alt-screen-honored`: when in a render buffer (it has a live `tmux-control--controller`), read the controller's resolved value; otherwise the buffer's own. The `alternate-screen` option is a server/window setting shared across the panes we render, so the controller's resolution applies.

## Test

New `tmux-control-test-effective-alt-screen-honored` (render buffer defers to controller; controller reads its own local; dead controller falls back). 158 ERT green; clean byte-compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
