### PR TITLE
Tiling: size panes to the real window body so the bottom row doesn't clip

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -1498,9 +1498,13 @@ leaves a foreign window sharing the frame untouched -- the regression behind
       (kill-buffer foreign-buf))))
 
 (ert-deftest tmux-control-test-tiled-region-size-subtracts-foreign ()
-  "`tmux-control--tiled-region-size' is the whole frame with no foreign window
-\(the old size, so a frame-owning tiling is unchanged), and fewer columns at
-the same rows once a full-height foreign window shares the frame."
+  "`tmux-control--tiled-region-size' owns the full width with a positive row
+budget when no foreign window shares the frame, and a full-height foreign
+window steals columns while leaving the rows untouched (a side split).  The
+exact row count is a pixel measurement (inner height less the minibuffer and
+the real mode-line height, so it matches the window body and the bottom pane
+does not clip) and so is verified live, not pinned here; this locks the
+foreign-subtraction logic, which is display-independent."
   (let ((ctrl-buf (generate-new-buffer " tc-test-ctrl"))
         (foreign-buf (generate-new-buffer " tc-test-foreign")))
     (unwind-protect
@@ -1510,8 +1514,8 @@ the same rows once a full-height foreign window shares the frame."
                  (cw (selected-window)))
             (set-window-buffer cw ctrl-buf)
             (let ((whole (tmux-control--tiled-region-size frame ctrl-buf)))
-              (should (= (car whole) (frame-text-cols frame)))
-              (should (= (cdr whole) (1- (frame-text-lines frame))))
+              (should (= (car whole) (frame-text-cols frame)))  ; full width
+              (should (> (cdr whole) 0))                        ; a real row budget
               (let ((fw (split-window cw nil 'right)))
                 (set-window-buffer fw foreign-buf)
                 (let ((reduced (tmux-control--tiled-region-size frame ctrl-buf)))

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -5795,22 +5795,39 @@ is a foreign window -- a user's non-tmux buffer the tiling must not consume."
 
 (defun tmux-control--tiled-region-size (frame controller)
   "Return (COLS . ROWS): the size tmux should lay CONTROLLER's panes out in.
-This is FRAME's text area (its columns, and its lines minus the minibuffer
-row -- the rows must budget each stacked pane's mode line) reduced by any
-foreign window sharing the frame: a full-height neighbor steals columns, a
-full-width one steals rows.  With no foreign window it is exactly the old
-whole-frame size, so a tiling that owns the frame is unchanged; with one it
-is the smaller region the tiling may use, so panes never overrun a non-tmux
-window's space.  Computed the same way whether called before tiling (from
-the controller's own window) or while tiled (from the pane windows), so the
-size never disagrees with itself and never forces a spurious re-tile."
-  (let ((cols (frame-text-cols frame))
-        (rows (1- (frame-text-lines frame))))
-    (dolist (w (window-list frame 'no-mini))
+ROWS is how many terminal rows actually fit below the tiling: FRAME's inner
+pixel height less the minibuffer and one mode line, divided by the line
+height.  Measuring the mode line in PIXELS is the point -- it is commonly a
+hair taller than a text row (a larger mode-line face), so any fixed
+`frame-text-lines' row offset over-counts and the bottom pane's last row --
+a full-screen TUI's bottom border -- clips.  The grids are sized to the tmux
+pane heights this size produces, and `tmux-control--tile-arrange-node'
+budgets each stacked pane's mode line, so making the total match the real
+body keeps every pane's grid within its window.  This is the same height the
+single-pane path derives from `window-screen-lines' (the real body), so the
+two paths agree.  Reduced by any foreign window sharing the frame: a
+full-height neighbor steals columns, a full-width one steals rows.  Computed
+from frame-level measures (stable across the split, whether called before
+tiling from the controller's window or while tiled from a pane window), so
+the size never disagrees with itself and never forces a spurious re-tile."
+  (let* ((char-h (max 1 (frame-char-height frame)))
+         (windows (window-list frame 'no-mini))
+         ;; The mode line's real pixel height, read from one of our own
+         ;; windows (they share the face); a text row if none is up yet.
+         (ours (cl-remove-if-not
+                (lambda (w) (tmux-control--our-tiling-window-p w controller))
+                windows))
+         (ml-h (if ours (window-mode-line-height (car ours)) char-h))
+         (mini-h (window-pixel-height (minibuffer-window frame)))
+         (cols (frame-text-cols frame))
+         (rows (max 1 (floor (- (frame-inner-height frame) mini-h ml-h)
+                             char-h))))
+    (dolist (w windows)
       (unless (tmux-control--our-tiling-window-p w controller)
         (if (>= (window-total-height w) rows)
             (setq cols (- cols (window-total-width w)))     ; a side column
-          (setq rows (- rows (window-total-height w))))))    ; a top/bottom band
+          ;; a top/bottom band: its pixel height in rows
+          (setq rows (- rows (round (window-pixel-height w) char-h))))))
     (cons (max 1 cols) (max 1 rows))))
 
 (defun tmux-control--collapse-tile-windows (keep)

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -5819,15 +5819,21 @@ the size never disagrees with itself and never forces a spurious re-tile."
                 windows))
          (ml-h (if ours (window-mode-line-height (car ours)) char-h))
          (mini-h (window-pixel-height (minibuffer-window frame)))
+         ;; Full non-minibuffer height in rows: the threshold for "full-height
+         ;; side column" (steals columns) vs "top/bottom band" (steals rows).
+         ;; Classify against the FULL height, not the smaller body-row budget
+         ;; below -- a tall band whose total height reached the body budget
+         ;; would otherwise be misread as a full-height column.
+         (usable-rows (- (frame-text-lines frame)
+                         (window-total-height (minibuffer-window frame))))
          (cols (frame-text-cols frame))
          (rows (max 1 (floor (- (frame-inner-height frame) mini-h ml-h)
                              char-h))))
     (dolist (w windows)
       (unless (tmux-control--our-tiling-window-p w controller)
-        (if (>= (window-total-height w) rows)
+        (if (>= (window-total-height w) usable-rows)
             (setq cols (- cols (window-total-width w)))     ; a side column
-          ;; a top/bottom band: its pixel height in rows
-          (setq rows (- rows (round (window-pixel-height w) char-h))))))
+          (setq rows (- rows (window-total-height w))))))    ; a top/bottom band
     (cons (max 1 cols) (max 1 rows))))
 
 (defun tmux-control--collapse-tile-windows (keep)


### PR DESCRIPTION
## The bug

In tiled mode the per-pane Eat grids are sized to the tmux pane heights, which come from the client height `tmux-control--tiled-region-size` requests. That was `frame-text-lines - 1` (minibuffer only). But each Emacs pane window also spends a row on its **mode line**, so the bottom pane's grid ended up taller than its window body — and the last row, a full-screen TUI's bottom border, clipped.

`frame-text-lines - 2` is *also* wrong: the mode line is commonly a hair taller than a text row (a larger mode-line face), so the fit is a **pixel** relationship, not an integer one.

## Fix

Compute the row budget from pixels:

```
rows = floor((frame-inner-height − minibuffer-pixels − real-mode-line-pixels) / line-height)
```

reading the real mode-line height from one of our live windows via `window-mode-line-height`. This is the same height the single-pane path already derives from `window-screen-lines`, so the tiled and single-pane paths now agree and a grid matches its window body exactly. The foreign-window subtraction (a side neighbour steals columns, a band steals rows) is preserved.

## Verified live

GUI Emacs, two side-by-side tiled panes in a dedicated 110×34 frame:

| | grid height | `window-body-height` |
|---|---|---|
| old `frame-text-lines - 1` | 33 | 31 (clips 2) |
| this fix (pixel) | **31** | **31** (exact) |

With the fix, a full-screen box renders top border → bottom border with nothing clipped (`window-mode-line-height` measured 17px vs a 15px line — exactly the sub-row the integer formulas missed).

## Test

`tmux-control-test-tiled-region-size-subtracts-foreign` now asserts the display-independent foreign-subtraction behaviour (full width alone; a side split steals columns, preserves rows) rather than a magic row count; the exact pixel height is verified live. 161 ERT green; clean byte-compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
