### PR TITLE
Scrollback: cap lazy extension at history_size (fixes -J miscount + short-pane dup)

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -2707,6 +2707,9 @@ output), :calls (side-effect invocations in order), :active-pane,
     ;; history known, the request reaches the oldest line -> at top.
     (should (equal (res 8000 10000 1800 10000) '(10000 . t)))
     (should (equal (res 8000 10000 9999 10000) '(10000 . t)))
+    ;; history_size 0 (a pane with history disabled) is a valid count, not a
+    ;; failed reply: already at the top, nothing older than the screen.
+    (should (equal (res 0 0 0 0) '(0 . t)))
     ;; history UNKNOWN (reply not yet landed): fall back to the line count.
     ;; A full reply (got == span) advances by got and is not at top.
     (should (equal (res 500 2500 2000 nil) '(2500 . nil)))

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -2290,6 +2290,10 @@ output), :calls (side-effect invocations in order), :active-pane,
                (lambda (w h) (push (list 'resize w h) calls)))
               ((symbol-function 'tmux-control--scrollback-request)
                (lambda (&rest _) (push 'capture calls)))
+              ;; Refresh also re-queries history_size (re-wrapping on a resize
+              ;; changes it); not the subject of this ordering test.
+              ((symbol-function 'tmux-control--scrollback-update-history-rows)
+               #'ignore)
               ((symbol-function 'process-live-p)
                (lambda (p) (eq p 'fake-proc))))
       (let ((live (generate-new-buffer " *tc-sb-live*"))
@@ -2687,6 +2691,28 @@ output), :calls (side-effect invocations in order), :active-pane,
           ;; Same line is still at the top of the window.
           (should (equal (funcall line-at) "orig 05"))
           (should (= tmux-control--scrollback-depth 2500)))))))
+
+(ert-deftest tmux-control-test-scrollback-extend-result ()
+  ;; The seam math: with history_size known, depth is the requested row
+  ;; offset (NEW-DEPTH) and the top is reached when it meets history_size --
+  ;; independent of the reply's line count, which `-J' shrinks below the row
+  ;; span.  Without history_size, the old line-count heuristic is the fallback.
+  (cl-flet ((res #'tmux-control--scrollback-extend-result))
+    ;; history known, no wrapping: depth = requested, not yet at top.
+    (should (equal (res 500 2500 2000 10000) '(2500 . nil)))
+    ;; history known, -J wrapped the rows so got (1500) < the 2000-row span:
+    ;; depth still advances by the ROW span (2500), NOT old+got (2000), and it
+    ;; does NOT falsely latch at-top.  This is the #4 bug the cap fixes.
+    (should (equal (res 500 2500 1500 10000) '(2500 . nil)))
+    ;; history known, the request reaches the oldest line -> at top.
+    (should (equal (res 8000 10000 1800 10000) '(10000 . t)))
+    (should (equal (res 8000 10000 9999 10000) '(10000 . t)))
+    ;; history UNKNOWN (reply not yet landed): fall back to the line count.
+    ;; A full reply (got == span) advances by got and is not at top.
+    (should (equal (res 500 2500 2000 nil) '(2500 . nil)))
+    ;; A short reply means tmux clamped at the oldest line -> at top, and
+    ;; depth advances only by what was actually returned.
+    (should (equal (res 500 2500 1 nil) '(501 . t)))))
 
 (ert-deftest tmux-control-test-scrollback-scroll-watch-gates-extend ()
   ;; The scroll watcher only schedules an extend when the view is near the

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -404,9 +404,19 @@ Grows as `tmux-control--scrollback-extend' prepends older lines, up to
   "Non-nil while an extend capture is in flight, to coalesce scrolls.")
 (defvar-local tmux-control--scrollback-at-top nil
   "Non-nil once extension has reached the oldest available pane-history line.
-Set when an extend capture returns fewer lines than requested -- there is
+Set when an extend reaches the pane's `history_size' (or, when that is not
+known, when a capture returns fewer lines than requested) -- there is
 nothing older to load -- so the scroll watcher stops firing futile
 captures.  Reset when the pager opens or is refreshed.")
+(defvar-local tmux-control--scrollback-history-rows nil
+  "The pane's `#{history_size}' (history lines above the screen), or nil.
+Queried asynchronously when the pager opens or refreshes.  When known it
+bounds extension exactly: the requested `-S' depth is capped at it, so a
+capture can never run off the oldest line and re-fetch tmux's clamped
+oldest row as a duplicate, and depth tracks the requested row offset
+rather than the reply's line count -- which `-J' (join-wrapped-lines)
+makes smaller than the row span.  Nil until the query lands, where the
+old line-count heuristic is used as a fallback.")
 (defvar-local tmux-control--command-queue nil
   "Pending control-mode command entries, oldest first.
 Each entry is a cons (KIND . SEND-TIME): the reply-handler kind enqueued
@@ -2178,17 +2188,66 @@ inside redisplay."
         (setq tmux-control--scrollback-extending t))
       (run-at-time 0 nil #'tmux-control--scrollback-extend buffer))))
 
+(defun tmux-control--scrollback-extend-result (old-depth new-depth got history-rows)
+  "Return (DEPTH . AT-TOP) for an extend that asked for OLD-DEPTH..NEW-DEPTH.
+GOT is the reply's line count; HISTORY-ROWS is the pane's `history_size'
+when known, else nil.  With HISTORY-ROWS known the requested range is
+always within history (NEW-DEPTH is capped at it before the query), so the
+loaded top sits exactly NEW-DEPTH rows back regardless of how `-J' joined
+wrapped rows, and the top is reached when NEW-DEPTH meets HISTORY-ROWS.
+Without it, fall back to the line-count heuristic: assume one reply line
+per requested row, so a short reply means tmux clamped at the oldest line.
+Pure: the seam math behind `tmux-control--scrollback-extend', for testing
+the `-J' and short-pane cases that the heuristic alone gets wrong."
+  (if history-rows
+      (cons new-depth (>= new-depth history-rows))
+    (cons (+ old-depth got) (< got (- new-depth old-depth)))))
+
+(defun tmux-control--scrollback-update-history-rows (buffer)
+  "Query BUFFER's pane `#{history_size}' and cap its loaded depth to it.
+Resolves `tmux-control--scrollback-history-rows' so extension knows the
+exact oldest line (see that variable).  A short pane's open capture
+over-states `tmux-control--scrollback-depth' (it asks for more lines than
+exist); capping it here keeps the first extend from requesting a range
+entirely past the top and prepending tmux's clamped oldest line as a
+duplicate.  Async over the live connection; a no-op when disconnected."
+  (when (buffer-live-p buffer)
+    (let* ((live (buffer-local-value 'tmux-control--live-buffer buffer))
+           (target (buffer-local-value 'tmux-control--scrollback-target buffer))
+           (proc (and (buffer-live-p live)
+                      (buffer-local-value 'tmux-control--process live))))
+      (when (and (process-live-p proc) target)
+        (with-current-buffer live
+          (tmux-control--query
+           (format "display-message -p -t %s '#{history_size}'" target)
+           (lambda (reply)
+             (when (buffer-live-p buffer)
+               (with-current-buffer buffer
+                 (let ((h (string-to-number
+                           (string-trim (or (car reply) "")))))
+                   (when (> h 0)
+                     (setq tmux-control--scrollback-history-rows h)
+                     (setq tmux-control--scrollback-depth
+                           (min tmux-control--scrollback-depth h))
+                     (when (>= tmux-control--scrollback-depth h)
+                       (setq tmux-control--scrollback-at-top t)))))))))))))
+
 (defun tmux-control--scrollback-extend (buffer)
   "Capture the next older chunk of history and prepend it to BUFFER.
 Loads `tmux-control-scrollback-extend-lines' more lines (capped at
-`tmux-control-scrollback-lines') strictly above what is already shown,
-keeping the viewport fixed.  Over the live control connection, async;
-a dead connection just stops extending (the snapshot stays put)."
+`tmux-control-scrollback-lines', and at the pane's `history_size' once
+known) strictly above what is already shown, keeping the viewport fixed.
+Over the live control connection, async; a dead connection just stops
+extending (the snapshot stays put)."
   (when (buffer-live-p buffer)
     (with-current-buffer buffer
       (let* ((old-depth tmux-control--scrollback-depth)
+             (history-rows tmux-control--scrollback-history-rows)
              (new-depth (min tmux-control-scrollback-lines
-                             (+ old-depth tmux-control-scrollback-extend-lines)))
+                             (+ old-depth tmux-control-scrollback-extend-lines)
+                             ;; Never ask past the oldest line: that is what
+                             ;; made a short pane re-fetch the clamped top row.
+                             (or history-rows tmux-control-scrollback-lines)))
              (target tmux-control--scrollback-target)
              (trailing tmux-control--capture-trailing-p)
              (live tmux-control--live-buffer)
@@ -2211,29 +2270,22 @@ a dead connection just stops extending (the snapshot stays put)."
           (with-current-buffer live
             (tmux-control--query
              ;; Strictly older than the current top line (OLD-DEPTH back):
-             ;; from NEW-DEPTH back down to OLD-DEPTH+1 back.  This delta is
-             ;; pure history (its end is above the visible screen), so the
-             ;; reply's line count is exactly how many older lines exist.
+             ;; from NEW-DEPTH back down to OLD-DEPTH+1 back.
              (tmux-control--scrollback-capture-command
               target new-depth trailing (1+ old-depth))
              (lambda (reply-lines)
                (when (buffer-live-p buffer)
                  (with-current-buffer buffer
-                   (let ((got (length reply-lines)))
+                   (let* ((got (length reply-lines))
+                          (res (tmux-control--scrollback-extend-result
+                                old-depth new-depth got history-rows)))
                      (when reply-lines
-                       ;; Advance depth by the lines ACTUALLY received, not
-                       ;; the lines requested: tmux clamps the capture to the
-                       ;; oldest available line, so a short reply means the
-                       ;; loaded top really sits OLD-DEPTH+GOT back, and the
-                       ;; next extend must continue from there to stay
-                       ;; seam-accurate.
                        (tmux-control--scrollback-prepend
-                        (string-join reply-lines "\n") (+ old-depth got)))
-                     ;; Fewer lines than asked for: that was the top of the
-                     ;; available history -- stop extending until reopen or
-                     ;; refresh, instead of re-querying an empty range on
-                     ;; every further scroll.
-                     (when (< got (- new-depth old-depth))
+                        (string-join reply-lines "\n") (car res)))
+                     ;; Reached the oldest available line: stop extending
+                     ;; until reopen or refresh, instead of re-querying an
+                     ;; empty/clamped range on every further scroll.
+                     (when (cdr res)
                        (setq tmux-control--scrollback-at-top t)))
                    (setq tmux-control--scrollback-extending nil)))))))))))
 
@@ -2349,6 +2401,7 @@ the live interactive pane."
         ;; second chunk before the first has even arrived.
         (setq-local tmux-control--scrollback-extending t)
         (setq-local tmux-control--scrollback-at-top nil)
+        (setq-local tmux-control--scrollback-history-rows nil)
         (add-hook 'window-scroll-functions
                   #'tmux-control--scrollback-scroll-watch nil t)
         ;; Fresh pager: not yet scrolled up into history, so a wheel-down
@@ -2375,6 +2428,10 @@ the live interactive pane."
       (when-let* ((window (get-buffer-window scrollback-buffer t)))
         (setq tmux-control--scrollback-size
               (tmux-control--scrollback-window-size window)))
+      ;; Queue the history_size query first so its reply (a single number)
+      ;; lands before the larger capture populates and clears the extend
+      ;; latch -- then the first extend already knows the exact oldest line.
+      (tmux-control--scrollback-update-history-rows scrollback-buffer)
       (tmux-control--scrollback-request
        scrollback-buffer target
        (min tmux-control-scrollback-initial-lines
@@ -2399,6 +2456,9 @@ the initial chunk or ballooning to the cap."
     ;; Hold extension off while the reload is in flight; the populate callback
     ;; clears it once the content lands (as on first open).
     (setq tmux-control--scrollback-extending t)
+    ;; Re-query history_size in case the pane grew (or its history was
+    ;; trimmed) since the pager opened; resolved before the reload populates.
+    (tmux-control--scrollback-update-history-rows (current-buffer))
     (tmux-control--scrollback-request
      (current-buffer)
      tmux-control--scrollback-target

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -2223,9 +2223,15 @@ duplicate.  Async over the live connection; a no-op when disconnected."
            (lambda (reply)
              (when (buffer-live-p buffer)
                (with-current-buffer buffer
-                 (let ((h (string-to-number
-                           (string-trim (or (car reply) "")))))
-                   (when (> h 0)
+                 ;; Only a digits reply is a real count -- accept 0 (a pane
+                 ;; with history disabled: nothing older than the screen, so
+                 ;; cap depth at 0 and latch at-top at once), but keep nil on
+                 ;; an empty/garbled reply so the heuristic stays the fallback
+                 ;; (`string-to-number' would turn both into a spurious 0).
+                 (let* ((s (string-trim (or (car reply) "")))
+                        (h (and (string-match-p "\\`[0-9]+\\'" s)
+                                (string-to-number s))))
+                   (when h
                      (setq tmux-control--scrollback-history-rows h)
                      (setq tmux-control--scrollback-depth
                            (min tmux-control--scrollback-depth h))


### PR DESCRIPTION
## The bug(s)

`tmux-control--scrollback-extend` advanced the loaded depth by, and decided "reached the top" from, the **line count** of each capture reply — assuming one reply line per requested grid row. Two cases violate that:

1. **`-J` (join-wrapped-lines).** tmux joins wrapped rows into fewer logical lines, so `got < requested-rows` whenever any wrapping occurred — even mid-history. Result: `--scrollback-at-top` latched after the first extend (you couldn't scroll to the real top), and `depth += got` drifted low, so the next request overlapped already-shown rows → duplicated/gapped seam.

2. **Short pane (< the 500-line initial capture).** The open over-states depth; the first extend requests a range entirely past the oldest line; tmux clamps `-S`/`-E` to the oldest line and returns *it again*, which was prepended as a visible duplicate at the top. (This is the minor bug noted but never landed in #57.)

## Fix

Query `#{history_size}` when the pager opens and on refresh; store it; then:

- cap the requested `-S` depth at `history_size` (never ask past the oldest line);
- set the new depth to the **requested row offset** — seam-exact regardless of `-J` joining — not `old + got`;
- decide "at top" by `new-depth ≥ history_size`, not by the line count.

If the query hasn't landed yet, the old line-count heuristic is the fallback, so the common path is unchanged. Extracted as a pure `tmux-control--scrollback-extend-result` for testing.

## Verified

- `#{history_size}` returns a clean number over a real control-mode connection (tmux 3.6a), e.g. `%begin … 58 … %end`.
- Empirically reconfirmed the capture itself is faithful (`-J` off): a deep scrollback matches `tmux capture-pane` byte-for-byte — the defect was purely the extend bookkeeping.

## Test

`tmux-control-test-scrollback-extend-result` covers the `-J`, short-pane-clamp, and history-unknown-fallback cases. 161 ERT green; clean byte-compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
