### PR TITLE
Route coalesced double/triple-wheel events like single ticks

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -692,6 +692,24 @@ each wrapped in an evolving prompt line and a status bar.")
   ;; Always returns a normalized boolean, never a truthy non-t value.
   (should (eq (tmux-control--alt-screen-effective-p t "alt") t)))
 
+(ert-deftest tmux-control-test-coalesced-wheel-events-bound ()
+  ;; A fast flick coalesces into double-/triple-wheel; those must route to
+  ;; the same handlers as a single tick, not fall through to pixel-scroll.
+  (dolist (ev '([double-wheel-up] [triple-wheel-up]))
+    (should (eq (lookup-key tmux-control--override-map ev)
+                #'tmux-control-wheel-scroll))
+    (should (eq (lookup-key tmux-control--char-mode-map ev)
+                #'tmux-control-wheel-scroll)))
+  (dolist (ev '([double-wheel-down] [triple-wheel-down]))
+    (should (eq (lookup-key tmux-control--override-map ev)
+                #'tmux-control-wheel-down))
+    (should (eq (lookup-key tmux-control--char-mode-map ev)
+                #'tmux-control-wheel-down))
+    (should (eq (lookup-key tmux-control-scrollback-mode-map ev)
+                #'tmux-control-scrollback-wheel-down))
+    (should (eq (lookup-key tmux-control--scrollback-override-map ev)
+                #'tmux-control-scrollback-wheel-down))))
+
 (ert-deftest tmux-control-test-wheel-should-enter-scrollback-p ()
   ;; The full gate: enter scrollback only on wheel-up, when enabled and
   ;; detectable, over a normal-screen pane that has not grabbed the mouse.

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -559,9 +559,11 @@ kills, which are deliberate.")
     (define-key map [wheel-up] #'tmux-control-wheel-scroll)
     (define-key map [wheel-down] #'tmux-control-wheel-down)
     ;; A fast flick coalesces into double-/triple-wheel events; bind them to
-    ;; the same handlers (which normalize via `event-basic-type') so they
-    ;; route like a single tick instead of falling through to the user's
-    ;; pixel-scroll and scrolling the buffer past a mouse-grabbing app.
+    ;; the same handlers so they route like a single tick instead of falling
+    ;; through to the user's pixel-scroll and scrolling the buffer past a
+    ;; mouse-grabbing app.  Both handlers cope with the coalesced variants:
+    ;; `tmux-control-wheel-scroll' matches on `event-basic-type', and
+    ;; `tmux-control-wheel-down' forwards/dispatches the event as-is.
     (define-key map [double-wheel-up] #'tmux-control-wheel-scroll)
     (define-key map [triple-wheel-up] #'tmux-control-wheel-scroll)
     (define-key map [double-wheel-down] #'tmux-control-wheel-down)

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -558,6 +558,14 @@ kills, which are deliberate.")
     ;; wins -- see `tmux-control-mode-map'.
     (define-key map [wheel-up] #'tmux-control-wheel-scroll)
     (define-key map [wheel-down] #'tmux-control-wheel-down)
+    ;; A fast flick coalesces into double-/triple-wheel events; bind them to
+    ;; the same handlers (which normalize via `event-basic-type') so they
+    ;; route like a single tick instead of falling through to the user's
+    ;; pixel-scroll and scrolling the buffer past a mouse-grabbing app.
+    (define-key map [double-wheel-up] #'tmux-control-wheel-scroll)
+    (define-key map [triple-wheel-up] #'tmux-control-wheel-scroll)
+    (define-key map [double-wheel-down] #'tmux-control-wheel-down)
+    (define-key map [triple-wheel-down] #'tmux-control-wheel-down)
     map)
   "High-precedence keymap for tmux-control buffers.
 Active in semi-char mode (`tmux-control--keys-active').  In char mode it
@@ -568,6 +576,11 @@ shadowing the pane's own C-c.")
   (let ((map (make-sparse-keymap)))
     (define-key map [wheel-up] #'tmux-control-wheel-scroll)
     (define-key map [wheel-down] #'tmux-control-wheel-down)
+    ;; Coalesced fast flicks, as in `tmux-control--override-map'.
+    (define-key map [double-wheel-up] #'tmux-control-wheel-scroll)
+    (define-key map [triple-wheel-up] #'tmux-control-wheel-scroll)
+    (define-key map [double-wheel-down] #'tmux-control-wheel-down)
+    (define-key map [triple-wheel-down] #'tmux-control-wheel-down)
     map)
   "High-precedence keymap for tmux-control buffers in char mode.
 Char mode exists to send EVERY key to the pane -- C-c above all, the
@@ -682,6 +695,8 @@ the cross-session activity strip (see `tmux-control-session-activity').")
     (define-key map (kbd "q") #'tmux-control-live)
     (define-key map [escape] #'tmux-control-live)
     (define-key map [wheel-down] #'tmux-control-scrollback-wheel-down)
+    (define-key map [double-wheel-down] #'tmux-control-scrollback-wheel-down)
+    (define-key map [triple-wheel-down] #'tmux-control-scrollback-wheel-down)
     (define-key map [remap eat-semi-char-mode] #'tmux-control-live)
     (define-key map [remap self-insert-command] #'tmux-control-live-self-insert)
     map)
@@ -690,6 +705,8 @@ the cross-session activity strip (see `tmux-control-session-activity').")
 (defvar tmux-control--scrollback-override-map
   (let ((map (make-sparse-keymap)))
     (define-key map [wheel-down] #'tmux-control-scrollback-wheel-down)
+    (define-key map [double-wheel-down] #'tmux-control-scrollback-wheel-down)
+    (define-key map [triple-wheel-down] #'tmux-control-scrollback-wheel-down)
     map)
   "High-precedence keymap for the scrollback pager.
 A global minor mode that binds the wheel -- `pixel-scroll-precision-mode'


### PR DESCRIPTION
## The bug

The wheel is bound in four keymaps (the live override map, the char-mode map, and the two scrollback-pager maps), but only for `[wheel-up]` / `[wheel-down]`.

A fast flick coalesces multiple ticks into `double-wheel-up`, `triple-wheel-down`, etc. (within `double-click-time`). Those symbols were unbound, so the flick fell through to the user's global `mwheel` / `pixel-scroll-precision-mode` handler:

- on a live buffer it scrolled the Eat buffer directly instead of entering scrollback or forwarding to a mouse-grabbing app (the exact case `tmux-control-wheel-down` was added to prevent — but only for the single tick);
- in the pager it skipped the "scroll past the bottom to return to live" gesture.

## Fix

Bind the coalesced variants to the same handlers as the single events, matching what each map already binds:

- **Live override map and char-mode map** — both `wheel-up` and `wheel-down` are bound, so add `[double-wheel-up]` / `[triple-wheel-up]` / `[double-wheel-down]` / `[triple-wheel-down]`.
- **The two scrollback-pager maps** — only `wheel-down` is bound there (wheel-up intentionally falls through to ordinary scrolling, per the `tmux-control--scrollback-override-map` docstring), so add only `[double-wheel-down]` / `[triple-wheel-down]`.

Both handlers cope with the coalesced events: `tmux-control-wheel-scroll` matches on `event-basic-type`, and `tmux-control-wheel-down` forwards/dispatches the event as-is.

## Test

New `tmux-control-test-coalesced-wheel-events-bound` checks the multi-click variants resolve to the right handler in every map (the up variants in the live maps, the down variants in all four). 158 ERT green; clean byte-compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
