### PR TITLE
Guard user scrollback regexps against invalid patterns in the filter

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -286,6 +286,24 @@
    ;; A short rule is not chrome.
    (should-not (tmux-control--scrollback-chrome-line-p "─────"))))
 
+(ert-deftest tmux-control-test-regexp-matches-p-tolerates-bad-regexp ()
+  ;; The frame-start/chrome patterns are user defcustoms tested inside the
+  ;; capture's process-filter callback; a malformed one must degrade to nil,
+  ;; not throw and abort the scrollback open.
+  (should (tmux-control--regexp-matches-p "foo" "a foo b"))
+  (should-not (tmux-control--regexp-matches-p "foo" "bar"))
+  ;; Invalid regexp -> nil, no error.
+  (should-not (tmux-control--regexp-matches-p "[" "abc"))
+  (should-not (tmux-control--regexp-matches-p "\\(" "abc"))
+  ;; A non-string element (e.g. a stray nil in the chrome list) -> nil.
+  (should-not (tmux-control--regexp-matches-p nil "abc"))
+  ;; And the predicates that route through it survive a bad user pattern.
+  (let ((tmux-control-scrollback-frame-start-regexp "["))
+    (should-not (tmux-control--scrollback-frame-start-line-p "abc")))
+  (let ((tmux-control-scrollback-chrome-regexps '("[" nil "valid")))
+    (should-not (tmux-control--scrollback-chrome-line-p "abc"))
+    (should (tmux-control--scrollback-chrome-line-p "this is valid here"))))
+
 (ert-deftest tmux-control-test-scrollback-chunks ()
   (tmux-control-test--with-compaction
    (should (equal (tmux-control--scrollback-chunks

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -3378,10 +3378,14 @@ whole (up to several-thousand-line) scrollback each time."
 `tmux-control-scrollback-chrome-regexps' are user `defcustom's tested
 here from inside the capture's process-filter callback; a malformed
 pattern (or a non-string element) must degrade to \"no match\" rather
-than throw out of the filter and abort every scrollback open."
-  (condition-case nil
-      (string-match-p regexp string)
-    (error nil)))
+than throw out of the filter and abort every scrollback open.
+The `stringp' guard short-circuits a non-string element without paying the
+`condition-case' error path, which matters since this runs per line over a
+several-thousand-line scrollback."
+  (and (stringp regexp)
+       (condition-case nil
+           (string-match-p regexp string)
+         (error nil))))
 
 (defun tmux-control--scrollback-frame-start-line-p (line)
   "Return non-nil when LINE looks like the start of a TUI redraw frame.

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -3372,6 +3372,17 @@ whole (up to several-thousand-line) scrollback each time."
       (push (nreverse current) chunks))
     (nreverse chunks)))
 
+(defun tmux-control--regexp-matches-p (regexp string)
+  "Like `string-match-p' but nil, not an error, on an invalid REGEXP.
+`tmux-control-scrollback-frame-start-regexp' and the elements of
+`tmux-control-scrollback-chrome-regexps' are user `defcustom's tested
+here from inside the capture's process-filter callback; a malformed
+pattern (or a non-string element) must degrade to \"no match\" rather
+than throw out of the filter and abort every scrollback open."
+  (condition-case nil
+      (string-match-p regexp string)
+    (error nil)))
+
 (defun tmux-control--scrollback-frame-start-line-p (line)
   "Return non-nil when LINE looks like the start of a TUI redraw frame.
 Matches `tmux-control-scrollback-frame-start-regexp' when configured, else the
@@ -3380,7 +3391,8 @@ Nil when neither is available, so compaction does nothing without a frame
 marker."
   (cond
    (tmux-control-scrollback-frame-start-regexp
-    (string-match-p tmux-control-scrollback-frame-start-regexp line))
+    (tmux-control--regexp-matches-p
+     tmux-control-scrollback-frame-start-regexp line))
    (tmux-control--auto-frame-start
     (string= (tmux-control--scrollback-match-key line)
              tmux-control--auto-frame-start))))
@@ -3485,8 +3497,8 @@ whitespace, so an anchored pattern matches regardless of indentation.
 Returns nil when no chrome patterns are configured."
   (let ((trimmed (string-trim line)))
     (seq-some (lambda (re)
-                (or (string-match-p re line)
-                    (string-match-p re trimmed)))
+                (or (tmux-control--regexp-matches-p re line)
+                    (tmux-control--regexp-matches-p re trimmed)))
               tmux-control-scrollback-chrome-regexps)))
 
 (defun tmux-control--merge-scrollback-chunk (out chunk)


### PR DESCRIPTION
## The bug

`tmux-control--scrollback-frame-start-line-p` and `tmux-control--scrollback-chrome-line-p` call `string-match-p` directly on user `defcustom`s:

- `tmux-control-scrollback-frame-start-regexp`
- `tmux-control-scrollback-chrome-regexps`

These run inside the scrollback capture's `tmux-control--query` reply callback — i.e. from the process filter. A malformed pattern (e.g. `"["` → `invalid-regexp`) or a stray non-string element in the chrome list (→ `wrong-type-argument`) therefore threw *out of the filter* and aborted every scrollback open, instead of simply not matching.

## Fix

Route both predicates through a small `tmux-control--regexp-matches-p` that wraps `string-match-p` and returns nil (not an error) on a bad pattern. The patterns are documented `defcustom`s with example values, so a user typo is plausible and shouldn't wedge the pager. (Compaction is opt-in, so this only bites users who configure it — but the failure mode is bad.)

## Test

New `tmux-control-test-regexp-matches-p-tolerates-bad-regexp` (valid match, invalid regexp → nil, non-string → nil, and the two predicates survive a bad user pattern while still matching a good one). 158 ERT green; clean byte-compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
