### PR TITLE
Truncate terminal rows instead of soft-wrapping them

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -692,6 +692,26 @@ each wrapped in an evolving prompt line and a status bar.")
   ;; Always returns a normalized boolean, never a truthy non-t value.
   (should (eq (tmux-control--alt-screen-effective-p t "alt") t)))
 
+(ert-deftest tmux-control-test-no-line-wrap ()
+  ;; Terminal grid rows must truncate, not wrap.  The helper runs AFTER the
+  ;; major mode because a globalized `visual-line-mode' re-enables itself (and
+  ;; `word-wrap') on `after-change-major-mode-hook', undoing a mode-body
+  ;; setting -- so it must force truncation even when visual-line-mode is
+  ;; already on (stood in for here).
+  (with-temp-buffer
+    (visual-line-mode 1)
+    (should (bound-and-true-p visual-line-mode))
+    (should word-wrap)                  ; precondition: visual-line set it
+    (tmux-control--no-line-wrap)
+    (should-not (bound-and-true-p visual-line-mode))
+    (should-not word-wrap)
+    (should truncate-lines))
+  ;; The scrollback pager deliberately keeps the opposite: it wraps to show
+  ;; overflowing history, so the two must not drift into agreement.
+  (with-temp-buffer
+    (tmux-control-scrollback-mode)
+    (should-not truncate-lines)))
+
 (ert-deftest tmux-control-test-wheel-should-enter-scrollback-p ()
   ;; The full gate: enter scrollback only on wheel-up, when enabled and
   ;; detectable, over a normal-screen pane that has not grabbed the mouse.

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -666,6 +666,11 @@ the cross-session activity strip (see `tmux-control-session-activity').")
   "Major mode for tmux-control buffers."
   (tmux-control--disable-line-numbers)
   (tmux-control--disable-margins)
+  ;; Terminal rows are fixed grid lines and must never be re-wrapped, but the
+  ;; setting that ensures it (`tmux-control--no-line-wrap') cannot live here:
+  ;; it must run AFTER the mode, once `after-change-major-mode-hook' has fired
+  ;; (a globalized `visual-line-mode' re-wraps from there).  The render-buffer
+  ;; setup calls it; see `tmux-control--reset-buffer' and friends.
   ;; Arriving at a live buffer always shows the live screen, however the
   ;; buffer got into the window; see `tmux-control--snap-to-live-screen'.
   (add-hook 'window-buffer-change-functions
@@ -2766,6 +2771,24 @@ clip the leftmost terminal column (e.g. a prompt glyph)."
   (dolist (window (get-buffer-window-list (current-buffer) nil t))
     (set-window-margins window 0 0)))
 
+(defun tmux-control--no-line-wrap ()
+  "Make the current buffer truncate terminal rows instead of wrapping them.
+Terminal rows are fixed grid lines that tmux already wrapped, so Emacs must
+not re-wrap them: with the fringes removed on a tiled pane window a row whose
+width equals the window body reserves the last column for a continuation
+glyph and soft-wraps to two screen lines, doubling its height and mangling a
+full-width TUI.  Truncating shows a fitting row in full on one line, and the
+grid is sized to the window so nothing real overflows.
+
+Must run AFTER the major mode is established, not from the mode body: a
+globalized `visual-line-mode' (in the user's config) turns itself -- and
+`word-wrap' -- back on from the `after-change-major-mode-hook' that fires
+when the mode is set, so a mode-body setting would be undone at once."
+  (when (bound-and-true-p visual-line-mode)
+    (visual-line-mode -1))
+  (setq-local word-wrap nil)
+  (setq-local truncate-lines t))
+
 (defun tmux-control--eat-semi-char-mode-advice (orig-fn &rest args)
   "Make `eat-semi-char-mode' return tmux-control scrollback buffers live.
 In a live tmux-control buffer, also restore the full override keymap
@@ -2842,6 +2865,7 @@ so the tmux-control keys get out of the way; the mode line shows
     (remove-hook 'kill-buffer-hook #'tmux-control--kill-process t)
     (erase-buffer)
     (tmux-control-mode)
+    (tmux-control--no-line-wrap)
     (setq-local emulation-mode-map-alists
                 (cons tmux-control--emulation-mode-map-alist
                       (delq tmux-control--emulation-mode-map-alist
@@ -5183,6 +5207,7 @@ it asynchronously over the control connection."
       (with-current-buffer buffer
         (let ((inhibit-read-only t)) (erase-buffer))
         (tmux-control-mode)
+        (tmux-control--no-line-wrap)
         (setq-local emulation-mode-map-alists
                     (cons tmux-control--emulation-mode-map-alist
                           (delq tmux-control--emulation-mode-map-alist
@@ -5623,6 +5648,7 @@ its own and routes commands through CONTROLLER."
     (with-current-buffer buffer
       (let ((inhibit-read-only t)) (erase-buffer))
       (tmux-control-mode)
+      (tmux-control--no-line-wrap)
       (setq-local emulation-mode-map-alists
                   (cons tmux-control--emulation-mode-map-alist
                         (delq tmux-control--emulation-mode-map-alist


### PR DESCRIPTION
## The bug

A terminal row is a fixed grid line — tmux has already wrapped the application's output into rows. Emacs must render each row as exactly one screen line. But in a tiled pane (where fringes are removed to reclaim columns for the terminal), a row whose width **equals the window body** reserves the last column for a continuation glyph and **soft-wraps to two screen lines** — doubling the row's height and mangling a full-width TUI (the doubled box-drawing rails / borders we saw while verifying the tiling-clip fix).

Isolated probe (0 fringes, line == body-width):

| `truncate-lines` | line vs body | pixel height |
|---|---|---|
| nil | 82 == 82 | **30px — wraps** |
| t | 82 == 82 | **15px — one line, full** |

## Why a mode-body setting doesn't work

`eat-mode` leaves `truncate-lines` nil. Setting it in `tmux-control-mode`'s body **fails** when the user runs `global-visual-line-mode`: that globalized mode re-enables `visual-line-mode` (→ `word-wrap t`, `truncate-lines nil`) from the `after-change-major-mode-hook` that fires *after* the mode body. (This is why it "passed" under `emacs -Q` but not in a real config — the same mechanism behind the reverted #58.)

## Fix

`tmux-control--no-line-wrap` turns off `visual-line-mode`, sets `word-wrap nil` and `truncate-lines t`, and is called from the three render-buffer setup paths (`--reset-buffer`, `--make-window-buffer`, `--make-pane-buffer`) **after** `(tmux-control-mode)`, where it survives the hook. A fitting row shows in full on one line; the grid is sized to the window, so nothing real overflows.

This is the live-grid analogue of the reverted #58 — but here re-wrapping a hard terminal row is genuinely wrong, unlike the scrollback pager's soft wrap (which deliberately stays on to show overflowing history).

## Verified live

GUI Emacs **with `global-visual-line-mode` on** (the config that exposed it), two tiled panes:

| | grid-w vs body-w | `truncate-lines` | row pixel height |
|---|---|---|---|
| before | 55 == 55 | nil (vlm on) | 30px (wrapped) |
| after | 55 == 55 | t (vlm off) | **15px (one line)** |

The full-width box top border renders intact; the single-pane view is unchanged.

## Test

New `tmux-control-test-no-line-wrap` checks the helper forces truncation even when `visual-line-mode` is already on, and that the scrollback pager keeps the deliberate opposite. 158 ERT green; clean byte-compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
