### PR TITLE
Release v0.2.0

### DIFF
--- a/tmux-control.el
+++ b/tmux-control.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2026  Clay Sheaff
 
 ;; Author: Clay Sheaff
-;; Version: 0.1.0
+;; Version: 0.2.0
 ;; Package-Requires: ((emacs "29.1") (eat "0.9.4"))
 ;; Keywords: terminals, tmux
 ;; URL: https://github.com/csheaff/tmux-control


### PR DESCRIPTION
Bump the `Version:` header to 0.2.0 ahead of tagging `v0.2.0`.

`v0.1.0` captured the single-pane client plus a round of rendering-fidelity hardening (the seven fixes). The only user-facing change since is:

- **Split the active pane from Emacs** (#67) — `C-c |` (side by side) / `C-c -` (stacked), `M-x tmux-control-kill-pane`, auto-tiling so both panes show; pure control-mode split. Plus a README screenshot of the tiled pane view.

A new backward-compatible feature → minor bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
