### PR TITLE
Build the tiled view in-band over the control connection

### DIFF
--- a/test/tmux-control-integration.el
+++ b/test/tmux-control-integration.el
@@ -311,6 +311,76 @@ the full async pipeline (process filter -> batch -> Eat), not just the seed."
       (ignore-errors (delete-file fa))
       (ignore-errors (delete-file fb)))))
 
+;;; Tiling build: the in-band (re)tile creates and seeds each pane buffer.
+
+(ert-deftest tmux-control-it-tile-builds-and-seeds-panes ()
+  "`tmux-control-tile' builds the tiled view entirely over the control
+connection: it queries the layout in-band, creates a render buffer per pane,
+and seeds each from its own screen via an in-band capture -- no out-of-band
+tmux/ssh process.  Asserts both pane buffers appear and render their own
+content (no cross-feed), exercising the async build end to end."
+  (skip-unless (tmux-control-it--available-p))
+  (let ((fa (make-temp-file "tc-ert-tile-a"))
+        (fb (make-temp-file "tc-ert-tile-b")))
+    (unwind-protect
+        (progn
+          (with-temp-file fa (insert "LEFT pane alpha\nstill LEFT\n"))
+          (with-temp-file fb (insert "RIGHT pane bravo\nstill RIGHT\n"))
+          (tmux-control-it--tmux-ok "kill-server")
+          (tmux-control-it--tmux
+           "new-session" "-d" "-s" "t" "-x" "80" "-y" "24"
+           (format "cat %s; sleep 600" (shell-quote-argument fa)))
+          (tmux-control-it--tmux
+           "split-window" "-h" "-t" "t"
+           (format "cat %s; sleep 600" (shell-quote-argument fb)))
+          (let* ((ids (split-string
+                       (string-trim
+                        (tmux-control-it--tmux "list-panes" "-t" "t"
+                                               "-F" "#{pane_id}"))
+                       "\n" t))
+                 (pa (nth 0 ids)) (pb (nth 1 ids)))
+            (tmux-control-it--wait-settle pa)
+            (tmux-control-it--wait-settle pb)
+            ;; A frame big enough for the tiling window split in batch.
+            (set-frame-size (selected-frame) 80 24)
+            (let ((buf (tmux-control-connect nil tmux-control-it--socket "t")))
+              (unwind-protect
+                  (with-current-buffer buf
+                    (tmux-control-it--pump 1.0)   ; initial connect/seed
+                    (tmux-control-tile)
+                    ;; The async build must create BOTH pane buffers and seed
+                    ;; them (non-blank) -- all via the control connection.
+                    (should
+                     (tmux-control-it--pump-until
+                      8 (lambda ()
+                          (and (= (length tmux-control--panes) 2)
+                               (cl-every
+                                (lambda (np)
+                                  (let ((b (cdr np)))
+                                    (and (buffer-live-p b)
+                                         (not (string-empty-p
+                                               (string-trim
+                                                (tmux-control-it--buffer-text b)))))))
+                                tmux-control--panes)))))
+                    ;; Each pane buffer holds ITS pane's content, not its
+                    ;; neighbor's -- the in-band seed painted the right pane.
+                    (let ((ba (cdr (assoc pa tmux-control--panes)))
+                          (bb (cdr (assoc pb tmux-control--panes))))
+                      (should (buffer-live-p ba))
+                      (should (buffer-live-p bb))
+                      (let ((ta (tmux-control-it--buffer-text ba))
+                            (tb (tmux-control-it--buffer-text bb)))
+                        (should (string-match-p "LEFT pane alpha" ta))
+                        (should (string-match-p "RIGHT pane bravo" tb))
+                        (should-not (string-match-p "RIGHT pane bravo" ta))
+                        (should-not (string-match-p "LEFT pane alpha" tb)))))
+                (when (buffer-live-p buf)
+                  (with-current-buffer buf (ignore-errors (tmux-control-disconnect)))
+                  (kill-buffer buf))
+                (tmux-control-it--tmux-ok "kill-server")))))
+      (ignore-errors (delete-file fa))
+      (ignore-errors (delete-file fb)))))
+
 ;;; Layout-leaf -> pane-id matching must be by id, not coordinates.
 
 (ert-deftest tmux-control-it-leaf-id-matches-pane-id ()

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -1123,6 +1123,49 @@ each wrapped in an evolving prompt line and a status bar.")
   (should (null (tmux-control--parse-layout "bf3a,80x24,0,0{40x24,0,0,1")))
   (should (null (tmux-control--parse-layout "bf3a,not-a-layout"))))
 
+(ert-deftest tmux-control-test-parse-window-state ()
+  ;; The in-band `list-panes' reply (tab-separated: layout, then each pane's
+  ;; geometry / cursor / cmd / title) parses to (LAYOUT . PANES) -- the layout
+  ;; from the first line, the panes in order with their plists.
+  (let* ((lines (list (mapconcat #'identity
+                                 '("LAY" "%0" "0" "0" "40" "24" "1"
+                                   "5" "3" "1" "bash" "tty")
+                                 "\t")
+                      (mapconcat #'identity
+                                 '("LAY" "%1" "41" "0" "39" "24" "0"
+                                   "0" "0" "0" "vim" "edit")
+                                 "\t")))
+         (state (tmux-control--parse-window-state lines))
+         (panes (cdr state)))
+    (should (equal (car state) "LAY"))
+    (should (equal (mapcar #'car panes) '("%0" "%1")))
+    (let ((p0 (cdr (assoc "%0" panes))))
+      (should (= (plist-get p0 :left) 0))
+      (should (= (plist-get p0 :width) 40))
+      (should (eq (plist-get p0 :active) t))
+      (should (equal (plist-get p0 :cursor) '(5 . 3)))
+      (should (equal (plist-get p0 :cmd) "bash"))
+      (should (equal (plist-get p0 :title) "tty")))
+    (let ((p1 (cdr (assoc "%1" panes))))
+      (should (eq (plist-get p1 :active) nil))
+      (should (equal (plist-get p1 :cmd) "vim")))
+    ;; A short/garbled line is skipped, not parsed into a bogus pane.
+    (should (null (cdr (tmux-control--parse-window-state '("LAY\t%0\t0")))))))
+
+(ert-deftest tmux-control-test-build-tiling-callback-aborts-when-cleared ()
+  ;; The build is async: a teardown (untile, disconnect) during an in-flight
+  ;; layout query clears `tmux-control--tiling-build-active', and the reply
+  ;; callback must then ABORT rather than rebuild the torn-down view -- so a
+  ;; late reply cannot resurrect a tiling the user just dismissed.
+  (with-temp-buffer
+    (setq-local tmux-control--tiling-build-active nil ; teardown cleared it
+                tmux-control--tiled nil
+                tmux-control--panes nil)
+    ;; No error, no apply, no resurrection.
+    (tmux-control--build-tiling-callback (current-buffer) '("ignored reply"))
+    (should-not tmux-control--tiled)
+    (should (null tmux-control--panes))))
+
 ;;; Window tab bar.
 
 (ert-deftest tmux-control-test-update-windows-parses-and-sorts ()

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -1150,7 +1150,18 @@ each wrapped in an evolving prompt line and a status bar.")
       (should (eq (plist-get p1 :active) nil))
       (should (equal (plist-get p1 :cmd) "vim")))
     ;; A short/garbled line is skipped, not parsed into a bogus pane.
-    (should (null (cdr (tmux-control--parse-window-state '("LAY\t%0\t0")))))))
+    (should (null (cdr (tmux-control--parse-window-state '("LAY\t%0\t0"))))))
+  ;; Empty trailing fields (an unset pane title, sometimes an empty command)
+  ;; must NOT drop the pane or shift columns: `split-string' with an explicit
+  ;; separator keeps empty fields, so the line is still 12 fields.
+  (let* ((line (concat "LAY\t%7\t0\t0\t80\t24\t1\t0\t0\t1\t\t")) ; empty cmd + title
+         (panes (cdr (tmux-control--parse-window-state (list line))))
+         (p (cdr (assoc "%7" panes))))
+    (should (= (length panes) 1))
+    (should p)
+    (should (= (plist-get p :width) 80))     ; columns did not shift
+    (should (equal (plist-get p :cmd) ""))
+    (should (equal (plist-get p :title) ""))))
 
 (ert-deftest tmux-control-test-build-tiling-callback-aborts-when-cleared ()
   ;; The build is async: a teardown (untile, disconnect) during an in-flight

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -541,13 +541,25 @@ single command queue and process.  nil in the controller buffer itself.")
   "Non-nil when a %layout-change asked for a re-tile at the next flush.")
 (defvar-local tmux-control--retile-timer nil
   "Idle timer coalescing notification-driven re-tiles, or nil.
-Re-tiling issues synchronous tmux queries (a blocking SSH round-trip when
-remote), so it is debounced off the process filter instead of running
-inline on every %layout-change.")
+A re-tile is async -- its layout and per-pane seed queries ride the control
+connection in-band -- but it stays debounced off the process filter so a
+burst of %layout-change notifications still collapses into one rebuild
+rather than one per message.")
 (defvar-local tmux-control--tiled-client-size nil
   "(W . H) char size last requested from tmux for the tiled frame area.
 Compared on frame resize so tmux is only re-sized (and the panes re-tiled)
 when the area devoted to tiling actually changed.")
+(defvar-local tmux-control--tiling-build-active nil
+  "Non-nil while a tiling build's in-band layout query is in flight.
+The build is async (`tmux-control--build-tiling' queries the layout over the
+control connection and finishes in the reply callback), so this serializes
+overlapping builds: a build requested while one is active sets
+`tmux-control--tiling-build-again' instead of starting a second, concurrent
+reconcile.  `tmux-control--teardown-tiling' clears it, which makes an
+in-flight build's callback abort rather than re-create a torn-down tiling.")
+(defvar-local tmux-control--tiling-build-again nil
+  "Non-nil when a tiling build was requested while one was already in flight.
+The active build re-runs once when it finishes, coalescing the burst.")
 (defvar-local tmux-control--unmatched-retries 0
   "Consecutive re-tiles where a layout leaf matched no pane.
 Bounds the retry so a persistent mismatch cannot reschedule forever.")
@@ -5698,24 +5710,34 @@ controller or pane render buffer where those locals are bound."
                        (tmux-control--tmux-command-string full))))
       (tmux-control--call "tmux" full))))
 
-(defun tmux-control--query-window-state ()
-  "Return (LAYOUT . PANES) for the active window in one tmux query.
+(defconst tmux-control--window-state-format
+  (concat "#{window_layout}\t#{pane_id}\t#{pane_left}\t#{pane_top}\t"
+          "#{pane_width}\t#{pane_height}\t#{pane_active}\t"
+          "#{cursor_x}\t#{cursor_y}\t#{cursor_flag}\t#{pane_current_command}\t"
+          "#{pane_title}")
+  "`list-panes -F' format folding the layout and every pane's geometry,
+cursor, command, and title into one query, so a (re)tile costs a single
+round trip rather than a `display-message' for the layout plus one per pane
+for the cursor.")
+
+(defun tmux-control--window-state-command ()
+  "Return the in-band `list-panes' command for the active window's state.
+Targets `tmux-control--session' (its current window) over the control
+connection -- no -L socket, no ssh, unlike the old out-of-band CLI query --
+so the layout/geometry read rides the same channel as `%output' and works
+identically for a local or remote session.  Parse the reply with
+`tmux-control--parse-window-state'."
+  (format "list-panes -t %s -F \"%s\""
+          tmux-control--session tmux-control--window-state-format))
+
+(defun tmux-control--parse-window-state (lines)
+  "Parse `list-panes' reply LINES into (LAYOUT . PANES).
 LAYOUT is the `window_layout' string; PANES is an alist (PANE-ID . INFO)
-with INFO a plist of :left :top :width :height :active :cmd :title :cursor
-and :cursor-visible.
-Folding the layout, every pane's geometry, and every pane's cursor into a
-single `list-panes' call avoids a separate `display-message' for the layout
-and one per pane for the cursor -- each a blocking (possibly SSH) round-trip
-that previously ran for every re-tile."
-  (let* ((fmt (concat "#{window_layout}\t#{pane_id}\t#{pane_left}\t#{pane_top}\t"
-                      "#{pane_width}\t#{pane_height}\t#{pane_active}\t"
-                      "#{cursor_x}\t#{cursor_y}\t#{cursor_flag}\t#{pane_current_command}\t"
-                      "#{pane_title}"))
-         (text (tmux-control--run-tmux
-                (list "list-panes" "-t" tmux-control--session "-F" fmt)))
-         (layout nil)
-         (panes nil))
-    (dolist (line (split-string (string-trim text) "\n" t))
+with INFO a plist of :left :top :width :height :active :cursor
+:cursor-visible :cmd and :title.  See `tmux-control--window-state-format'.
+Pure, so the reply shape is unit-testable without a live tmux."
+  (let ((layout nil) (panes nil))
+    (dolist (line lines)
       (let ((f (split-string line "\t")))
         (when (>= (length f) 12)
           (unless layout (setq layout (nth 0 f)))
@@ -5934,11 +5956,36 @@ so there is no reseed or flicker."
               (tmux-control--send-command
                (format "select-pane -t %s" tmux-control--active-pane)))))))))
 
+(defun tmux-control--pane-screen-command (pane &optional trailing)
+  "Return the in-band `capture-pane' command for PANE's visible screen.
+TRAILING keeps trailing blanks (`-N').  Rides the control connection via
+`tmux-control--query', so a tiled-pane seed costs no out-of-band process."
+  (concat "capture-pane -p -e"
+          (when trailing " -N")
+          (format " -t %s" pane)))
+
+(defun tmux-control--paint-seed (buffer text cursor cursor-visible)
+  "Paint BUFFER's terminal from screen TEXT with CURSOR / CURSOR-VISIBLE.
+Shared by the synchronous and in-band seed paths."
+  (when (and (buffer-live-p buffer) text)
+    (with-current-buffer buffer
+      (when (and tmux-control--terminal (eat-term-live-p tmux-control--terminal))
+        (setq tmux-control--seed-cursor cursor)
+        (setq tmux-control--seed-cursor-visible (or cursor-visible :unknown))
+        ;; Clear the scrollback (\e[3J) before painting, not just the screen,
+        ;; so a reseed (e.g. after a resize) does not leave the previous,
+        ;; now-reflowed frame stacked above the fresh one -- an app on a tmux
+        ;; with `alternate-screen off' repaints by appending.
+        (tmux-control--write-terminal
+         (concat "\e[3J"
+                 (tmux-control--screen-seed-sequence
+                  text cursor cursor-visible)))))))
+
 (defun tmux-control--seed-pane-buffer-sync (buffer)
   "Paint BUFFER's terminal from its pane's current screen (synchronous CLI).
-Used on (re)tile; live %output keeps the pane current afterward.  The cursor
-comes from the batched window-state query (stored in `tmux-control--pane-info'),
-so only the screen capture costs a round-trip here."
+Used by the one-off reseeds (a paused pane, returning to the single-pane
+view), where one blocking capture is cheaper than wiring an async callback;
+the (re)tile build uses `tmux-control--seed-pane-buffer-async' instead."
   (when (buffer-live-p buffer)
     (with-current-buffer buffer
       (when (and tmux-control--terminal (eat-term-live-p tmux-control--terminal))
@@ -5949,17 +5996,37 @@ so only the screen capture costs a round-trip here."
                                               :cursor-visible)
                                   :unknown))
                (text (ignore-errors (tmux-control--capture-pane-screen pane))))
-          (when text
-            (setq tmux-control--seed-cursor cursor)
-            (setq tmux-control--seed-cursor-visible cursor-visible)
-            ;; Clear the scrollback (\e[3J) before painting, not just the
-            ;; screen, so a reseed (e.g. after a resize) does not leave the
-            ;; previous, now-reflowed frame stacked above the fresh one -- an
-            ;; app on a tmux with `alternate-screen off' repaints by appending.
-            (tmux-control--write-terminal
-             (concat "\e[3J"
-                     (tmux-control--screen-seed-sequence
-                      text cursor cursor-visible)))))))))
+          (tmux-control--paint-seed buffer text cursor cursor-visible))))))
+
+(defun tmux-control--seed-pane-buffer-async (buffer controller)
+  "Capture BUFFER's pane screen in-band and paint it when the reply lands.
+The capture rides CONTROLLER's control connection (`tmux-control--query'),
+so on a (re)tile the per-pane seeds no longer each cost a blocking,
+possibly-SSH round trip; the cursor comes from the batched window-state
+query stashed in `tmux-control--pane-info'.  After painting, point the
+pane's window at the terminal cursor so a non-selected pane shows its hollow
+cursor where tmux has it.  Every callback re-checks `buffer-live-p', so a
+pane killed by a teardown or a faster retile before its reply arrives is a
+safe no-op."
+  (when (and (buffer-live-p buffer) (buffer-live-p controller))
+    (let* ((info (buffer-local-value 'tmux-control--pane-info buffer))
+           (pane (buffer-local-value 'tmux-control--active-pane buffer))
+           (trailing (buffer-local-value 'tmux-control--capture-trailing-p buffer))
+           (cursor (plist-get info :cursor))
+           (cursor-visible (or (plist-get info :cursor-visible) :unknown)))
+      (when pane
+        (with-current-buffer controller
+          (tmux-control--query
+           (tmux-control--pane-screen-command pane trailing)
+           (lambda (reply)
+             (when (buffer-live-p buffer)
+               (tmux-control--paint-seed
+                buffer (and reply (string-join reply "\n"))
+                cursor cursor-visible)
+               (let ((term (buffer-local-value 'tmux-control--terminal buffer))
+                     (win (get-buffer-window buffer t)))
+                 (when (and term (eat-term-live-p term) (window-live-p win))
+                   (set-window-point win (eat-term-display-cursor term))))))))))))
 
 ;;; Window arrangement from the parsed layout tree.
 
@@ -6140,19 +6207,53 @@ buffer captured its scroll-following windows just before its own feed."
 
 (defun tmux-control--build-tiling (controller)
   "Build or refresh the tiled view of CONTROLLER's current tmux window.
-Queries the live layout and pane geometry, reconciles the per-pane render
-buffers (reusing survivors, creating new panes, killing gone ones),
-arranges the Emacs windows to match, and seeds each pane from its current
-screen.  Safe to call repeatedly; a %layout-change routes here."
+Queries the live layout and pane geometry IN-BAND over the control
+connection, then in the reply callback reconciles the per-pane render
+buffers (reusing survivors, creating new panes, killing gone ones), arranges
+the Emacs windows to match, and seeds each new pane.  Safe to call
+repeatedly; a %layout-change routes here.  Builds are serialized: one
+requested while another's query is in flight coalesces into a single re-run
+\(see `tmux-control--tiling-build-active'), so two reconciles never overlap."
   (when (buffer-live-p controller)
     (with-current-buffer controller
       (when (process-live-p tmux-control--process)
-        ;; One batched query: layout + every pane's geometry and cursor,
-        ;; read atomically so the layout and the pane list never disagree.
-        (let* ((state (ignore-errors (tmux-control--query-window-state)))
-               (layout (car state))
-               (geometry (cdr state))
-               (tree (tmux-control--parse-layout layout))
+        (if tmux-control--tiling-build-active
+            (setq tmux-control--tiling-build-again t)
+          (setq tmux-control--tiling-build-active t)
+          ;; One batched query: layout + every pane's geometry and cursor,
+          ;; read atomically so the layout and the pane list never disagree.
+          (tmux-control--query
+           (tmux-control--window-state-command)
+           (lambda (reply)
+             (tmux-control--build-tiling-callback controller reply))))))))
+
+(defun tmux-control--build-tiling-callback (controller reply)
+  "Apply a tiling build from the in-band window-state REPLY, with bookkeeping.
+Runs in CONTROLLER from the process filter.  A teardown that cleared
+`tmux-control--tiling-build-active' while the query was in flight makes this
+abort rather than rebuild a torn-down tiling; otherwise it clears the flag
+and re-runs once when a retile was requested mid-build."
+  (when (buffer-live-p controller)
+    (with-current-buffer controller
+      (when tmux-control--tiling-build-active
+        (unwind-protect
+            (when (process-live-p tmux-control--process)
+              (let ((state (tmux-control--parse-window-state reply)))
+                (tmux-control--build-tiling-apply
+                 controller (car state) (cdr state))))
+          (setq tmux-control--tiling-build-active nil)
+          (when tmux-control--tiling-build-again
+            (setq tmux-control--tiling-build-again nil)
+            (tmux-control--build-tiling controller)))))))
+
+(defun tmux-control--build-tiling-apply (controller layout geometry)
+  "Reconcile and arrange CONTROLLER's tiled view from LAYOUT and GEOMETRY.
+The body of a tiling build, run from `tmux-control--build-tiling-callback'
+once the in-band window-state reply has been parsed."
+  (when (buffer-live-p controller)
+    (with-current-buffer controller
+      (when (process-live-p tmux-control--process)
+        (let* ((tree (tmux-control--parse-layout layout))
                (leaves (tmux-control--layout-leaves tree)))
           (cond
            ((or (null tree) (null leaves) (null geometry))
@@ -6262,8 +6363,13 @@ screen.  Safe to call repeatedly; a %layout-change routes here."
                   ;; of truth for what the app draws); fringe/scroll-bar
                   ;; removal makes the body span the full pane width, so it
                   ;; fits without shrinking the grid (which would drop a row).
+                  ;; Seed each new pane in-band: the captures stream back over
+                  ;; the connection and paint as they land, so the build never
+                  ;; blocks on N (possibly-SSH) round trips.  Each capture's
+                  ;; cursor is the geometry query's, stashed in the pane's
+                  ;; `tmux-control--pane-info' just above.
                   (dolist (buf to-seed)
-                    (tmux-control--seed-pane-buffer-sync buf))
+                    (tmux-control--seed-pane-buffer-async buf controller))
                   ;; Point every pane window at its terminal cursor, so a
                   ;; non-selected pane draws its hollow cursor where tmux has
                   ;; it (like iTerm) instead of at point-min.  A freshly
@@ -6301,7 +6407,11 @@ window.  Does not reseed; callers that resume single-pane do that."
               tmux-control--panes nil
               tmux-control--tiled-layout nil
               tmux-control--retile-pending nil
-              tmux-control--suppress-focus-follow nil)
+              tmux-control--suppress-focus-follow nil
+              ;; Cancel any in-flight build: clearing the active flag makes its
+              ;; reply callback abort instead of rebuilding this torn-down view.
+              tmux-control--tiling-build-active nil
+              tmux-control--tiling-build-again nil)
         (unless keep-windows
           (let ((win (or (cl-some (lambda (np) (get-buffer-window (cdr np) t))
                                   panes)


### PR DESCRIPTION
## What

Build the tiled view **in-band over the control connection** instead of via out-of-band `tmux` CLI calls — the "control mode for everything" convergence (the one place tiling still shelled out).

Before, a (re)tile:
1. read the window layout + per-pane geometry with one synchronous `tmux` CLI call (`--query-window-state` → `--run-tmux`), and
2. seeded each new pane with a synchronous `capture-pane` CLI call (`--seed-pane-buffer-sync`).

Each is a fresh process and, on a **remote** session, a fresh **SSH connection** — so a tile of *N* new panes froze Emacs for *1 + N* blocking round trips.

## How

`tmux-control--build-tiling` now:
- queries the layout/geometry **in-band** (`tmux-control--query`, the same `%begin/%end` mechanism scrollback uses) and runs the reconcile/arrange in the reply callback (`--build-tiling-callback` → `--build-tiling-apply`);
- seeds each new pane with an **in-band** `capture-pane` (`--seed-pane-buffer-async`) that paints — and points its window at the cursor — as its reply lands.

No out-of-band process, no per-call SSH; the build never blocks the filter. The one-off reseeds (a paused pane, returning to the single-pane view) keep the synchronous capture — one call each, where a callback isn't worth it.

## Concurrency (the crux of an async build)

Async means builds can overlap, so they're **serialized by construction**:
- `--tiling-build-active` / `--tiling-build-again`: a build requested while another's query is in flight coalesces into a single re-run, so two reconciles never run at once.
- A teardown (untile/disconnect) **clears** those flags, so an in-flight build's callback **aborts** rather than resurrecting a dismissed tiling.
- Every seed/build callback re-checks `buffer-live-p`, so a pane killed by a faster retile before its reply arrives is a safe no-op.

## Verification

- **New integration test** (`tmux-control-it-tile-builds-and-seeds-panes`): tiles a 2-pane window over a **real control connection** and asserts both pane buffers seed with their own content (no cross-feed). Plus a unit test for the parser and for the abort-on-teardown guard.
- **Full suites green**: 165 pure-logic + 19 integration.
- **Live GUI soak**: connect → tile (both panes seeded) → **rapid concurrent splits to 6 panes** → **rapid kills** → untile. Every pane rendered its own content, the pane set matched tmux exactly at each step, and the build flags settled to `nil` every time (the coalescing converges). Screenshot confirmed the 6-pane render. The rapid concurrent retiles induce the same overlapping-build races that remote latency would.

Tiling is labeled experimental and the single-pane path is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
