### PR TITLE
Document the Eat rendering choice and the display-drift workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,15 @@ The **tiled view** (`C-c C-t`) is **experimental** — whole-frame only, with a
 few [known limits](docs/guide.md#tiling) — but renders every pane cell-for-cell
 with live per-pane I/O and automatic re-tiling.
 
+## Troubleshooting
+
+**If the live view ever drifts a row or looks scrambled**, press **`C-c C-l`**
+(`M-x tmux-control-clear-and-repaint`) — it reseeds the buffer from tmux's own
+screen and clears the glitch instantly.  The cause is a bug in Eat's terminal
+emulation that drops a display row when a full-screen TUI repaints, so the
+offset can accumulate over redraws; it's tracked upstream at
+[emacs-eat#263](https://codeberg.org/akib/emacs-eat/issues/263).
+
 ## Terminal agent frameworks
 
 Some CLI coding-agent tools run a session per agent in tmux — one **pane** per

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -32,6 +32,21 @@
 ;; emulator.  The tmux session outlives Emacs: detach, restart Emacs, or
 ;; reconnect from another machine and the pane is still there.
 ;;
+;; Why Eat: tmux-control renders a pane by feeding the byte stream tmux emits
+;; over control mode (the escape-laden `%output' notifications) into a
+;; terminal emulator.  That calls for an emulator decoupled from any
+;; subprocess -- one built headlessly and fed arbitrary bytes
+;; (`eat-term-make' plus `eat-term-process-output', with input routed back
+;; through callbacks) rather than one wrapped around a shell it spawns
+;; itself.  Eat fits exactly, in pure Emacs Lisp with no native module to
+;; build.  vterm and term.el are both tied to a process they own and do not
+;; fit this "render an external stream" model -- and vterm needs a compiled C
+;; module besides.  The trade-off: Eat is a quiet single-maintainer project,
+;; so tmux-control stays ready to pin or fork it and carries its own
+;; resilience for emulator quirks -- e.g. `tmux-control-clear-and-repaint',
+;; which reseeds the view from `capture-pane' (see
+;; https://codeberg.org/akib/emacs-eat/issues/263 for one such quirk).
+;;
 ;; See `tmux-control-connect' to attach.
 
 ;;; Code:


### PR DESCRIPTION
Documentation only — no code or behavior changes.

Two small additions:

- **`tmux-control.el` Commentary — why Eat.** Records why tmux-control renders
  through Eat: it feeds tmux's control-mode `%output` byte stream into a
  terminal emulator, which needs one decoupled from any subprocess (built
  headlessly and fed arbitrary bytes via `eat-term-make` /
  `eat-term-process-output`) — pure Emacs Lisp, no native module. vterm and
  term.el are process-coupled (and vterm needs a compiled C module). Notes the
  single-maintainer trade-off.

- **README Troubleshooting.** Points users at `C-c C-l`
  (`tmux-control-clear-and-repaint`) to reseed the view when it drifts a row,
  with the cause and a link to the upstream Eat bug,
  [emacs-eat#263](https://codeberg.org/akib/emacs-eat/issues/263).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
