### PR TITLE
Fix three bug-hunt findings: block-content guard, seed literal, tiling focus-follow

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -891,6 +891,17 @@ each wrapped in an evolving prompt line and a status bar.")
       (should (string-match-p (concat "box" (make-string 5 ?\s)) seq))
       (should (string-match-p "\e\\[1;1H\e\\[m\e\\[K\e\\[42mbox" seq)))))
 
+(ert-deftest tmux-control-test-screen-seed-sequence-no-shared-literal ()
+  ;; The escape list ends in `nreverse', which rewires its tail in place.
+  ;; Built from a shared quoted literal it leaked the prior frame into every
+  ;; later seed and buried the home+clear mid-stream.  Built fresh, every
+  ;; call -- not just the first -- must still BEGIN with the home+clear so no
+  ;; stale content can survive ahead of it.
+  (let ((tmux-control--terminal nil))
+    (dotimes (_ 5)
+      (let ((seq (tmux-control--screen-seed-sequence "alpha\nbeta\n" '(1 . 1))))
+        (should (string-prefix-p "\e[H\e[2J" seq))))))
+
 ;;; Session and window listing (parsing only; the process call is stubbed).
 
 (ert-deftest tmux-control-test-list-sessions-parses ()
@@ -1176,6 +1187,32 @@ each wrapped in an evolving prompt line and a status bar.")
     (tmux-control--build-tiling-callback (current-buffer) '("ignored reply"))
     (should-not tmux-control--tiled)
     (should (null tmux-control--panes))))
+
+(ert-deftest tmux-control-test-build-tiling-unmatched-exhaustion-clears-suppression ()
+  ;; A persistent layout/pane-list mismatch retries a few times then gives
+  ;; up.  The give-up path must reset the retry count AND release any
+  ;; focus-follow suppression a window switch armed -- the flag is otherwise
+  ;; cleared only by a SUCCESSFUL build, so a stuck mismatch would strand it
+  ;; and silently stop a focused pane from selecting itself in tmux.
+  (with-temp-buffer
+    (let ((proc (make-pipe-process :name "tc-tile-test" :buffer (current-buffer)
+                                   :noquery t)))
+      (unwind-protect
+          (cl-letf (((symbol-function 'tmux-control--schedule-retile)
+                     (lambda (_controller) nil)))
+            (setq-local tmux-control--process proc
+                        tmux-control--tiled-layout nil
+                        tmux-control--panes nil
+                        tmux-control--unmatched-retries 4 ; one short of the cap
+                        tmux-control--suppress-focus-follow t)
+            ;; Leaf pane "0" at (0,0); geometry names a different pane at
+            ;; different coords, so the leaf cannot be matched and the build
+            ;; exhausts its retries.
+            (tmux-control--build-tiling-apply
+             (current-buffer) "bf3a,80x24,0,0,0" '(("%9" . (:left 5 :top 5))))
+            (should (= tmux-control--unmatched-retries 0))
+            (should-not tmux-control--suppress-focus-follow))
+        (delete-process proc)))))
 
 ;;; Window tab bar.
 
@@ -1816,6 +1853,28 @@ buffer's own directory with a prefix arg or when the option is off."
      (tmux-control--handle-line "%error 2 9 0")
      (should (null called))
      (should-not tmux-control--collecting-command))))
+
+(ert-deftest tmux-control-test-block-collects-notification-shaped-content ()
+  ;; Lines that look like %exit/%pause/%continue but arrive INSIDE a reply
+  ;; block are captured pane content (a control-mode transcript), not
+  ;; protocol: collect them verbatim and fire no side effects -- a stray
+  ;; %pause must not reseed/enqueue a continue, a stray %exit must not print
+  ;; a false "session ended".
+  (tmux-control-test--with-reply-buffer
+   (let (got (paused nil))
+     (cl-letf (((symbol-function 'tmux-control--handle-pause)
+                (lambda (pane) (setq paused pane))))
+       (setq tmux-control--command-queue
+             (list (cons (lambda (lines) (setq got lines)) (float-time))))
+       (tmux-control--handle-line "%begin 1 7 0")
+       (tmux-control--handle-line "%pause %0")
+       (tmux-control--handle-line "%exit")
+       (tmux-control--handle-line "%continue %0")
+       (should tmux-control--collecting-command)
+       (tmux-control--handle-line "%end 2 7 0")
+       (should-not tmux-control--collecting-command)
+       (should (null paused))
+       (should (equal got '("%pause %0" "%exit" "%continue %0")))))))
 
 (ert-deftest tmux-control-test-scrollback-capture-command ()
   ;; The DEFAULT is raw rows, no -J: tmux re-wraps pane history to the

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -4029,6 +4029,14 @@ the matching pane's render buffer instead, so every pane updates at once."
             (funcall kind nil)
           (tmux-control--message
            (format "tmux command failed (%s)" kind)))))
+     ;; While collecting a reply block, any other line is block CONTENT --
+     ;; including lines that merely LOOK like notifications (a captured
+     ;; control-mode transcript can hold %exit/%pause/%continue).  This sits
+     ;; ABOVE those clauses so a captured token is collected verbatim instead
+     ;; of acted on: a stray %pause would reseed and enqueue a bogus continue,
+     ;; a stray %exit would print a false "tmux session ended".
+     (tmux-control--collecting-command
+      (push line tmux-control--command-output))
      ((or (string= line "%exit") (string-prefix-p "%exit " line))
       ;; tmux is closing the control connection (the session was killed,
       ;; the server exited, or the client was detached).  The process
@@ -4044,8 +4052,6 @@ the matching pane's render buffer instead, so every pane updates at once."
      ((string-prefix-p "%continue " line)
       ;; tmux resumed streaming the pane; nothing further to do.
       nil)
-     (tmux-control--collecting-command
-      (push line tmux-control--command-output))
      ((string-match "\\`%window-pane-changed \\([^ ]+\\) \\(%[0-9]+\\)\\'" line)
       ;; The window's active pane changed (a split, a select-pane, a closed
       ;; pane).  In single-pane mode only the active pane is mirrored, so
@@ -4458,7 +4464,11 @@ unchanged."
                   lines))
          (lines (last lines (min height (length lines))))
          (row 1)
-         (out '("\e[H\e[2J")))
+         ;; A freshly consed list, never a quoted literal: the `nreverse'
+         ;; below rewires the tail in place, so a shared literal would leak
+         ;; the previous frame's escapes into every later seed (cf. the same
+         ;; note in `tmux-control--quote-tmux-data').
+         (out (list "\e[H\e[2J")))
     (dolist (line lines)
       ;; Clip to terminal width by visible columns, ignoring the
       ;; non-printing color escapes; only over-wide lines (rare and
@@ -6309,8 +6319,16 @@ once the in-band window-state reply has been parsed."
               ;; mapping that leaves a pane blank, try again shortly -- but only
               ;; a few times, so a persistent mismatch can't reschedule forever.
               (if unmatched
-                  (when (< (cl-incf tmux-control--unmatched-retries) 5)
-                    (tmux-control--schedule-retile controller))
+                  (if (< (cl-incf tmux-control--unmatched-retries) 5)
+                      (tmux-control--schedule-retile controller)
+                    ;; Gave up after repeated layout/pane-list disagreement.
+                    ;; Reset the retry count and release any focus-follow
+                    ;; suppression a window switch armed -- it is otherwise
+                    ;; cleared only by a successful build (below), so without
+                    ;; this a persistent mismatch would strand it and silently
+                    ;; stop a focused pane from selecting itself in tmux.
+                    (setq tmux-control--unmatched-retries 0)
+                    (setq tmux-control--suppress-focus-follow nil))
                 (setq tmux-control--unmatched-retries 0)
                 (let* ((old-panes tmux-control--panes)
                    (meta (list :host tmux-control--host


### PR DESCRIPTION
## Three correctness fixes from a bug-hunting pass

A focused review of the control-mode parser, the render-seed path, and the tiling lifecycle surfaced three independent bugs. Each is fixed with a regression test that **fails without the change**. All 168 ERT tests pass (source and byte-compiled); clean `make compile`.

The three are independent and can be split into separate PRs on request.

### 1. `%exit` / `%pause` / `%continue` inside a reply block are acted on, not collected
`tmux-control--handle-line` guards `%begin`/`%end`/`%error` against the "collecting a reply block" state, but the `%exit`/`%pause`/`%continue` clauses sat *above* the collecting catch-all with no such guard. A `capture-pane` reply that contains those tokens — a captured control-mode transcript, routine when you develop a tmux client — dropped the line from the captured text and fired side effects: a stray `%pause` reseeded and enqueued a bogus `refresh-client -A "%PANE:continue"`; a stray `%exit` printed a false "tmux session ended". Fix: move the collecting-command catch-all above those clauses, matching the existing terminator guards.

### 2. `--screen-seed-sequence` mutates a shared quoted literal
The escape list was initialised from a quoted literal `'("\e[H\e[2J")` and returned via `nreverse`, which rewires the literal's tail in place. Every seed after the first then started from the previous call's mutated list, leaking the prior frame's escapes ahead of the home+clear. The trailing clear masks it in practice, but it's fragile, doubles the seed payload, and is the exact footgun already documented and avoided in `--quote-tmux-data`. Fix: cons the list fresh.

### 3. Tiling give-up strands `--suppress-focus-follow`
When a layout/pane-list mismatch exhausts its retries, `--build-tiling-apply` returned without resetting `--unmatched-retries` or `--suppress-focus-follow`. That flag is otherwise cleared only by a *successful* build, so a persistent mismatch left it stuck `t` and silently stopped a focused Emacs pane window from selecting its pane in tmux. Fix: reset both on give-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
