### PR TITLE
Quote the session in control-mode window-command targets

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -58,6 +58,18 @@
   ;; A backslash is doubled.
   (should (equal (tmux-control--quote-tmux-arg "back\\slash") "\"back\\\\slash\"")))
 
+(ert-deftest tmux-control-test-window-target-quotes-session ()
+  ;; A session name with a space must be quoted so tmux's control-mode parser
+  ;; reads "name with space":INDEX as a single target token; an unquoted
+  ;; space splits the argument and tmux errors ("too many arguments").  A
+  ;; normal name is quoted too -- harmless, tmux strips the quotes.
+  (should (equal (tmux-control--window-target "my proj" 2) "\"my proj\":2"))
+  (should (equal (tmux-control--window-target "my proj") "\"my proj\":"))
+  (should (equal (tmux-control--window-target "main" 0) "\"main\":0"))
+  ;; An empty index (the pinned-size warn path's empty current-window) targets
+  ;; the session with no specific window, like a nil index.
+  (should (equal (tmux-control--window-target "main" "") "\"main\":")))
+
 ;;; Control-mode output decoding.
 
 (ert-deftest tmux-control-test-octal-digit-p ()
@@ -957,27 +969,29 @@ each wrapped in an evolving prompt line and a status bar.")
     (nreverse sent)))
 
 (ert-deftest tmux-control-test-select-window-command ()
+  ;; The session is quoted in the target so a name with spaces parses as one
+  ;; token; tmux strips the quotes from a plain name like "0".
   (should (equal (tmux-control-test--capture-commands
                   (lambda () (tmux-control-select-window "2")))
-                 '("select-window -t 0:2"))))
+                 '("select-window -t \"0\":2"))))
 
 (ert-deftest tmux-control-test-new-window-command ()
   (should (equal (tmux-control-test--capture-commands
                   (lambda () (tmux-control-new-window "my win")))
-                 '("new-window -t 0: -n \"my win\"")))
+                 '("new-window -t \"0\": -n \"my win\"")))
   (should (equal (tmux-control-test--capture-commands
                   (lambda () (tmux-control-new-window nil)))
-                 '("new-window -t 0:"))))
+                 '("new-window -t \"0\":"))))
 
 (ert-deftest tmux-control-test-kill-window-command ()
   (should (equal (tmux-control-test--capture-commands
                   (lambda () (tmux-control-kill-window "1")))
-                 '("kill-window -t 0:1"))))
+                 '("kill-window -t \"0\":1"))))
 
 (ert-deftest tmux-control-test-rename-window-command ()
   (should (equal (tmux-control-test--capture-commands
                   (lambda () (tmux-control-rename-window "1" "new name")))
-                 '("rename-window -t 0:1 \"new name\"")))
+                 '("rename-window -t \"0\":1 \"new name\"")))
   ;; An empty name is rejected.
   (should-error (tmux-control-test--capture-commands
                  (lambda () (tmux-control-rename-window "1" "")))
@@ -2633,7 +2647,7 @@ output), :calls (side-effect invocations in order), :active-pane,
                     tmux-control--size-pin-warned t)
         (tmux-control-adopt-window-size)
         ;; Targets the window THIS buffer renders (@2 -> index 1).
-        (should (equal (car sent) "set-option -w -t s:1 window-size latest"))
+        (should (equal (car sent) "set-option -w -t \"s\":1 window-size latest"))
         (should resized)
         (should-not tmux-control--size-pin-warned)))))
 

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -1576,6 +1576,16 @@ prompt."
   "Return STRING quoted for the tmux command parser."
   (concat "\"" (replace-regexp-in-string "[\"\\]" "\\\\\\&" string) "\""))
 
+(defun tmux-control--window-target (session &optional index)
+  "Return a control-mode window target for SESSION, quoted for tmux's parser.
+SESSION is wrapped in quotes so a name with spaces or shell/tmux specials
+parses as a single token -- tmux concatenates the adjacent quoted session and
+the \":INDEX\" suffix (\"my proj\":0 resolves to the my-proj session, window
+0; an unquoted space would split the argument and tmux errors).  With INDEX
+nil (or empty) the target is \"SESSION:\" -- the session, no specific window."
+  (concat (tmux-control--quote-tmux-arg session) ":"
+          (if index (format "%s" index) "")))
+
 (defun tmux-control-select-window (&optional index)
   "Switch the live tmux-control view to window INDEX in the same session.
 
@@ -1613,7 +1623,8 @@ to the new window's panes, so only the single-pane view reseeds here."
       (with-current-buffer ctrl
         (setq tmux-control--suppress-focus-follow t)))
     (tmux-control--send-command
-     (format "select-window -t %s:%s" tmux-control--session index))
+     (format "select-window -t %s"
+             (tmux-control--window-target tmux-control--session index)))
     (unless ctrl
       (if tmux-control-window-buffers
           (progn
@@ -1652,7 +1663,7 @@ window, so any other client attached to the session follows along."
       (with-current-buffer ctrl
         (setq tmux-control--suppress-focus-follow t)))
     (tmux-control--send-command
-     (format "%s -t %s" verb tmux-control--session))
+     (format "%s -t %s" verb (tmux-control--quote-tmux-arg tmux-control--session)))
     (unless ctrl
       ;; See `tmux-control--do-select-window' on the per-window-buffers case.
       (if tmux-control-window-buffers
@@ -1693,7 +1704,8 @@ With a NAME, give the new window that name."
            (unless (string-empty-p n) n))))
   (tmux-control--ensure-live)
   (tmux-control--send-command
-   (concat (format "new-window -t %s:" tmux-control--session)
+   (concat (format "new-window -t %s"
+                   (tmux-control--window-target tmux-control--session))
            (when (and name (not (string-empty-p name)))
              (concat " -n " (tmux-control--quote-tmux-arg name)))))
   ;; Per-window buffers: the echoed %session-window-changed creates and
@@ -1718,7 +1730,8 @@ window in the session ends the session and disconnects this client."
   (tmux-control--ensure-live)
   (setq index (tmux-control--normalize-window-index index))
   (tmux-control--send-command
-   (format "kill-window -t %s:%s" tmux-control--session index))
+   (format "kill-window -t %s"
+           (tmux-control--window-target tmux-control--session index)))
   ;; Mirror tmux-control-new-window: with per-window buffers the
   ;; %window-close/%session-window-changed echoes do all the work.
   (if tmux-control-window-buffers
@@ -1740,8 +1753,8 @@ is left untouched."
     (user-error "Window name must not be empty"))
   (setq index (tmux-control--normalize-window-index index))
   (tmux-control--send-command
-   (format "rename-window -t %s:%s %s"
-           tmux-control--session index
+   (format "rename-window -t %s %s"
+           (tmux-control--window-target tmux-control--session index)
            (tmux-control--quote-tmux-arg name))))
 
 ;;;; Window tab bar
@@ -5186,8 +5199,8 @@ Resolving it is one command: `tmux-control-adopt-window-size'."
                           'tmux-control--window-id
                           (tmux-control--session-display-buffer buffer)))
              (target (or display-id
-                         (format "%s:%s" tmux-control--session
-                                 (or tmux-control--current-window "")))))
+                         (tmux-control--window-target
+                          tmux-control--session tmux-control--current-window))))
         (tmux-control--query
          (format "show-options -wqv -t %s window-size" target)
          (lambda (lines)
@@ -5225,9 +5238,8 @@ client (e.g. iTerm2) for the trade-offs."
                                   return (plist-get w :index))))
                   (buffer-local-value 'tmux-control--current-window ctrl))))
     (tmux-control--send-command
-     (format "set-option -w -t %s%s window-size latest"
-             tmux-control--session
-             (if idx (concat ":" idx) ":")))
+     (format "set-option -w -t %s window-size latest"
+             (tmux-control--window-target tmux-control--session idx)))
     (with-current-buffer ctrl
       (setq tmux-control--size-pin-warned nil))
     (tmux-control--resize-to-window)

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -1584,7 +1584,13 @@ the \":INDEX\" suffix (\"my proj\":0 resolves to the my-proj session, window
 0; an unquoted space would split the argument and tmux errors).  With INDEX
 nil (or empty) the target is \"SESSION:\" -- the session, no specific window."
   (concat (tmux-control--quote-tmux-arg session) ":"
-          (if index (format "%s" index) "")))
+          ;; Treat an empty-string INDEX like nil -- both mean "no specific
+          ;; window" (target "SESSION:") -- so the behavior matches the
+          ;; docstring rather than relying on `(format "%s" "")' happening to
+          ;; return "".
+          (if (and index (not (equal index "")))
+              (format "%s" index)
+            "")))
 
 (defun tmux-control-select-window (&optional index)
   "Switch the live tmux-control view to window INDEX in the same session.


### PR DESCRIPTION
## Quote the session in control-mode window-command targets

A session name with a space (or other tmux-special character) broke **every** control-mode window command. tmux's command parser splits the unquoted target on the space, so `select-window -t my proj:0` errored. Verified live against tmux 3.6a:

```
# unquoted (current code):
select-window -t my proj:0   →  %error: too many arguments (need at most 0)
# quoted (this PR):
select-window -t "my proj":0 →  %end     (tmux concatenates the token → my proj:0)
```

The window *name* was already quoted via `--quote-tmux-arg`; the session in the target was not.

### Change
- New `tmux-control--window-target` helper: quotes the session and appends `:INDEX` (unit-tested).
- Routed through it: `select-window`, `next/previous/last-window`, `new-window`, `kill-window`, `rename-window`, `adopt-window-size`, and the pinned-size probe.
- Quoting is **unconditional** — tmux strips the quotes from a plain name, and a "does this need quoting?" predicate would only add an edge to get wrong.
- Updated the five command-string tests to expect the quoted form.

### Out of scope
The bootstrap `fallback-target` (`"SESSION:"`) still embeds the raw session, because it also flows into a **CLI argv** (`--pane-directory`) where quoting would be *wrong*. It only matters transiently before the active pane resolves, and only for a space-named session — noted for a possible follow-up.

169 ERT pass (source and byte-compiled); clean `make compile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
