### PR TITLE
Dedup the scrollback seam so a scrolling pane doesn't double lines

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -2939,6 +2939,9 @@ output), :calls (side-effect invocations in order), :active-pane,
        "older A\nolder B\ndup one\ndup two" 200)
       (should (equal (buffer-string)
                      "older A\nolder B\ndup one\ndup two\nloaded tail\n"))
+      ;; Depth is the captured -S depth of the TOP line ("older A"), which the
+      ;; seam drop preserves (only the duplicate tail is removed), so it is
+      ;; stored unchanged.
       (should (= tmux-control--scrollback-depth 200)))))
 
 (ert-deftest tmux-control-test-scrollback-populate-arms-extension ()

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -2901,6 +2901,46 @@ output), :calls (side-effect invocations in order), :active-pane,
                      "older-1\nolder-2\nold-top line\nlive tail\n"))
       (should (= tmux-control--scrollback-depth 2500)))))
 
+(ert-deftest tmux-control-test-scrollback-drop-seam-overlap ()
+  ;; Drops the new (older) chunk's tail when it duplicates the buffer head --
+  ;; the drift overlap from a pane that scrolled while the pager was open --
+  ;; but only on a SAFE (>=2 distinctive nonblank) overlap.
+  (let ((tmux-control-compact-scrollback-window 200))
+    ;; Two-line distinctive overlap: dropped.
+    (should (equal (tmux-control--scrollback-drop-seam-overlap
+                    '("old-1" "old-2" "dup-a" "dup-b")
+                    '("dup-a" "dup-b" "loaded-1"))
+                   '("old-1" "old-2")))
+    ;; No overlap (the normal, non-drifting extend): unchanged.
+    (should (equal (tmux-control--scrollback-drop-seam-overlap
+                    '("old-1" "old-2" "old-3")
+                    '("loaded-1" "loaded-2"))
+                   '("old-1" "old-2" "old-3")))
+    ;; A lone blank coincidental overlap is not safe, so not dropped.
+    (should (equal (tmux-control--scrollback-drop-seam-overlap
+                    '("old-1" "")
+                    '("" "loaded-1"))
+                   '("old-1" "")))))
+
+(ert-deftest tmux-control-test-scrollback-prepend-dedups-seam ()
+  ;; A pane that scrolls while the pager is open makes an extend re-capture
+  ;; lines already at the top (tmux's -S/-E slide with the screen).  The
+  ;; prepend must drop that overlapping tail instead of doubling it.
+  (let ((tmux-control-compact-scrollback nil)
+        (tmux-control-compact-scrollback-window 200))
+    (with-temp-buffer
+      (tmux-control-scrollback-mode)
+      (let ((inhibit-read-only t))
+        (insert "dup one\ndup two\nloaded tail\n"))
+      (setq-local tmux-control--scrollback-depth 100)
+      ;; The captured older chunk ends with the two lines already shown at the
+      ;; top (the drift overlap); only "older A/B" are genuinely new.
+      (tmux-control--scrollback-prepend
+       "older A\nolder B\ndup one\ndup two" 200)
+      (should (equal (buffer-string)
+                     "older A\nolder B\ndup one\ndup two\nloaded tail\n"))
+      (should (= tmux-control--scrollback-depth 200)))))
+
 (ert-deftest tmux-control-test-scrollback-populate-arms-extension ()
   ;; The pager opens with extension HELD OFF (extending = t) so the one-line
   ;; "capturing…" placeholder -- which makes the top trivially visible --

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -2420,6 +2420,10 @@ doubled."
         (insert "\n")))
     (when (and window (marker-position anchor))
       (set-window-start window anchor t))
+    ;; NEW-DEPTH still describes the top line: the seam dedup drops the chunk's
+    ;; NEWER tail (the lines duplicating the existing head), never its oldest
+    ;; line, so the top stays at the captured -S depth and the next extend
+    ;; continues from there without skipping history.
     (setq tmux-control--scrollback-depth new-depth)))
 
 (defun tmux-control--scrollback-request (buffer target lines trailing

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -2363,11 +2363,30 @@ extending (the snapshot stays put)."
                        (setq tmux-control--scrollback-at-top t)))
                    (setq tmux-control--scrollback-extending nil)))))))))))
 
+(defun tmux-control--scrollback-drop-seam-overlap (new-lines head-lines)
+  "Drop NEW-LINES' tail that already appears at the head of HEAD-LINES.
+NEW-LINES is the older chunk about to be prepended; HEAD-LINES is the
+current top of the loaded buffer.  When the pane scrolls while the pager is
+open, tmux's -S/-E capture offsets are relative to the moving screen top, so
+an extend re-captures lines already shown -- the chunk's tail then
+duplicates the buffer's head.  Drop that safe suffix/prefix overlap (the
+same distinctive-run test `tmux-control--line-list-overlap' uses for the
+live-history merge), leaving the genuinely older lines.  Returns NEW-LINES
+unchanged when there is no safe overlap, so a normal non-drifting extend --
+whose chunk abuts the head without overlapping it -- is untouched."
+  (let ((overlap (tmux-control--line-list-overlap new-lines head-lines)))
+    (if (> overlap 0)
+        (butlast new-lines overlap)
+      new-lines)))
+
 (defun tmux-control--scrollback-prepend (text new-depth)
   "Prepend colorized older history TEXT to the current scrollback buffer.
 Keeps the viewport on the same content -- the window start sits on a
 marker that the insertion at point-min shifts forward with the text --
-and records the loaded depth as NEW-DEPTH."
+and records the loaded depth as NEW-DEPTH.  Any tail of TEXT the pager
+already shows at its head (a drift-induced re-capture; see
+`tmux-control--scrollback-drop-seam-overlap') is dropped so the seam is not
+doubled."
   (let* ((window (get-buffer-window (current-buffer) t))
          ;; Insertion-type t so the anchor tracks the content line it sits on
          ;; even when the view is at the very top (window-start = point-min):
@@ -2375,14 +2394,30 @@ and records the loaded depth as NEW-DEPTH."
          ;; would jump to the freshly loaded older lines instead of staying
          ;; pinned where you were reading.
          (anchor (and window (copy-marker (window-start window) t)))
-         (inhibit-read-only t))
+         (inhibit-read-only t)
+         (prepared (tmux-control--prepare-scrollback-text text))
+         ;; Dedup the seam against the lines already at the buffer head, in
+         ;; the buffer's own prepared form (ANSI already folded to faces, so
+         ;; the match keys line up).  The first window-worth of lines is all
+         ;; `tmux-control--line-list-overlap' ever inspects.
+         (head (save-excursion
+                 (goto-char (point-min))
+                 (split-string
+                  (buffer-substring-no-properties
+                   (point-min)
+                   (line-end-position tmux-control-compact-scrollback-window))
+                  "\n")))
+         (prepared (string-join
+                    (tmux-control--scrollback-drop-seam-overlap
+                     (split-string (string-trim-right prepared "\n+") "\n")
+                     head)
+                    "\n")))
     (save-excursion
       (goto-char (point-min))
-      (let ((prepared (tmux-control--prepare-scrollback-text text)))
-        (insert prepared)
-        (unless (or (string-suffix-p "\n" prepared)
-                    (bolp))
-          (insert "\n"))))
+      (insert prepared)
+      (unless (or (string-suffix-p "\n" prepared)
+                  (bolp))
+        (insert "\n")))
     (when (and window (marker-position anchor))
       (set-window-start window anchor t))
     (setq tmux-control--scrollback-depth new-depth)))


### PR DESCRIPTION
## Dedup the scrollback seam so a scrolling pane doesn't double lines

tmux's `capture-pane -S/-E` offsets are relative to the **visible screen top**, which moves as the pane produces output. The scrollback pager's lazy extension captures `-S -new_depth -E -(old_depth+1)` against a depth snapshot taken when the pager *opened* — so if the pane scrolls K lines while you're paging, the extend re-captures ~K lines already loaded, and `--scrollback-prepend` inserted them raw, **doubling them at the history/loaded seam**.

Confirmed live against tmux 3.6a — the same offsets return different content as the pane scrolls:

```
history_size 47:  capture -S -5 -E -1  →  line-39 line-40 line-41 line-42 line-43
# pane scrolls 9 lines...
history_size 56:  capture -S -5 -E -1  →  line-48 line-49 line-50 ...
```

### Fix
Drop the overlap when prepending, in the buffer's own prepared form (ANSI already folded to faces, so match keys line up), reusing `--line-list-overlap` — the **same distinctive suffix/prefix test the live-history merge already relies on**. It removes only a *safe* (≥2 distinctive nonblank) overlap, and a normal non-drifting extend abuts the head without overlapping it, so:
- the common (no-drift) case is byte-for-byte untouched, and
- the dedup can only ever remove a genuine duplicate, never corrupt content.

### Known remaining limitation
Separate, minor, self-heals on Refresh: the `history_size` cap is still an open-time snapshot, so lines that age into history *after* the pager opens can latch at-top early and stay just out of reach until a Refresh re-queries it. Left for a possible follow-up.

170 ERT pass (source and byte-compiled); clean `make compile`. Both new tests fail without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
