### PR TITLE
Quote session names in the remaining control-mode targets

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -70,6 +70,40 @@
   ;; the session with no specific window, like a nil index.
   (should (equal (tmux-control--window-target "main" "") "\"main\":")))
 
+(ert-deftest tmux-control-test-quote-tmux-name-neutralizes-hash ()
+  ;; A window NAME is format-expanded by rename-window/new-window -n, so a
+  ;; literal #{...}/#(...) must be doubled to ## (tmux collapses ## back to a
+  ;; single # when it expands the argument).  --quote-tmux-arg, which is for
+  ;; targets, must NOT do this -- hence a separate name quoter.
+  (should (equal (tmux-control--quote-tmux-name "plain") "\"plain\""))
+  (should (equal (tmux-control--quote-tmux-name "a#{pane_id}b")
+                 "\"a##{pane_id}b\""))
+  (should (equal (tmux-control--quote-tmux-name "x#(echo hi)y")
+                 "\"x##(echo hi)y\""))
+  ;; A lone # is doubled too -- harmless, it round-trips back to a literal #.
+  (should (equal (tmux-control--quote-tmux-name "feat#1") "\"feat##1\"")))
+
+(ert-deftest tmux-control-test-window-state-command-quotes-session ()
+  ;; The in-band window-state query drives tiling and every %layout-change
+  ;; retile.  A spaced session name must be quoted or tmux's parser errors
+  ;; ("too many arguments") and tiling reads no layout.
+  (with-temp-buffer
+    (setq-local tmux-control--session "my proj")
+    (should (string-prefix-p "list-panes -t \"my proj\": -F \""
+                             (tmux-control--window-state-command)))))
+
+(ert-deftest tmux-control-test-fallback-control-target-quotes-session ()
+  ;; The connect-window fallback target (send-keys/paste before the pane id
+  ;; is known) must quote the session for the control-mode parser, while the
+  ;; raw --fallback-target stays unquoted for CLI argv use.
+  (with-temp-buffer
+    (setq-local tmux-control--fallback-target "my proj:")
+    (should (equal (tmux-control--fallback-control-target) "\"my proj\":"))
+    (setq-local tmux-control--fallback-target "main:")
+    (should (equal (tmux-control--fallback-control-target) "\"main\":"))
+    (setq-local tmux-control--fallback-target nil)
+    (should (null (tmux-control--fallback-control-target)))))
+
 ;;; Control-mode output decoding.
 
 (ert-deftest tmux-control-test-octal-digit-p ()
@@ -3449,7 +3483,7 @@ output), :calls (side-effect invocations in order), :active-pane,
         ;; The connect-time fallback (NOT homeless) still works.
         (setq tmux-control--homeless nil)
         (tmux-control--send-input nil "x")
-        (should (cl-some (lambda (c) (string-match-p "send-keys -t s:" c))
+        (should (cl-some (lambda (c) (string-match-p "send-keys -t \"s\":" c))
                          sent))))))
 
 (ert-deftest tmux-control-test-homeless-controller-stays-out-of-routing ()

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -1576,6 +1576,18 @@ prompt."
   "Return STRING quoted for the tmux command parser."
   (concat "\"" (replace-regexp-in-string "[\"\\]" "\\\\\\&" string) "\""))
 
+(defun tmux-control--quote-tmux-name (name)
+  "Quote NAME for a tmux command that FORMAT-EXPANDS its argument.
+Like `tmux-control--quote-tmux-arg', but first doubles `#' to `##' so a
+literal `#{...}'/`#(...)'/`#[...]' typed into a window name renders
+literally instead of being taken as a tmux format/command/style
+expansion -- `rename-window' and `new-window -n' expand their name
+argument, so a name of `a#{pane_id}b' would otherwise become `a%0b' and
+`#(cmd)' would run CMD on the tmux host.  tmux collapses each `##' back
+to a single `#' when it expands the argument.  `--quote-tmux-arg' alone
+is for *targets*, which tmux does not format-expand."
+  (tmux-control--quote-tmux-arg (replace-regexp-in-string "#" "##" name)))
+
 (defun tmux-control--window-target (session &optional index)
   "Return a control-mode window target for SESSION, quoted for tmux's parser.
 SESSION is wrapped in quotes so a name with spaces or shell/tmux specials
@@ -1591,6 +1603,20 @@ nil (or empty) the target is \"SESSION:\" -- the session, no specific window."
           (if (and index (not (equal index "")))
               (format "%s" index)
             "")))
+
+(defun tmux-control--fallback-control-target ()
+  "Quoted control-mode target for the connect-window session fallback.
+`tmux-control--fallback-target' is the raw \"SESSION:\" string kept for
+CLI argv use (`call-process' passes it as one argument, so quoting there
+would inject literal quote characters).  A control-mode command string
+instead needs the session quoted for tmux's parser, so a spaced or
+special session name parses as one token rather than splitting the
+argument.  tmux session names cannot contain `:', so stripping the
+trailing window separator and re-quoting via `tmux-control--window-target'
+is unambiguous.  Returns nil when there is no fallback target."
+  (when tmux-control--fallback-target
+    (tmux-control--window-target
+     (replace-regexp-in-string ":\\'" "" tmux-control--fallback-target))))
 
 (defun tmux-control-select-window (&optional index)
   "Switch the live tmux-control view to window INDEX in the same session.
@@ -1713,7 +1739,7 @@ With a NAME, give the new window that name."
    (concat (format "new-window -t %s"
                    (tmux-control--window-target tmux-control--session))
            (when (and name (not (string-empty-p name)))
-             (concat " -n " (tmux-control--quote-tmux-arg name)))))
+             (concat " -n " (tmux-control--quote-tmux-name name)))))
   ;; Per-window buffers: the echoed %session-window-changed creates and
   ;; displays the new window's buffer; re-querying the active pane here
   ;; would aim THIS buffer at the new window's pane while it still renders
@@ -1761,7 +1787,7 @@ is left untouched."
   (tmux-control--send-command
    (format "rename-window -t %s %s"
            (tmux-control--window-target tmux-control--session index)
-           (tmux-control--quote-tmux-arg name))))
+           (tmux-control--quote-tmux-name name))))
 
 ;;;; Window tab bar
 ;;
@@ -4872,7 +4898,7 @@ terminal, so make them the recovery path instead of a silent no-op."
     ;; from a frozen view (Copilot review).
     (let ((target (or tmux-control--active-pane
                       (and (not tmux-control--homeless)
-                           tmux-control--fallback-target))))
+                           (tmux-control--fallback-control-target)))))
       (if target
           (let* ((bytes (encode-coding-string string 'utf-8-unix))
                  (n (length bytes))
@@ -4966,7 +4992,7 @@ bracketed-paste state, but tmux does."
     ;; the session's current pane from a buffer that renders nothing.
     (let ((target (or tmux-control--active-pane
                       (and (not tmux-control--homeless)
-                           tmux-control--fallback-target))))
+                           (tmux-control--fallback-control-target)))))
       (if (not target)
           (tmux-control--message "No active tmux pane yet")
         (let* ((bytes (encode-coding-string text 'utf-8-unix))
@@ -5810,7 +5836,8 @@ so the layout/geometry read rides the same channel as `%output' and works
 identically for a local or remote session.  Parse the reply with
 `tmux-control--parse-window-state'."
   (format "list-panes -t %s -F \"%s\""
-          tmux-control--session tmux-control--window-state-format))
+          (tmux-control--window-target tmux-control--session)
+          tmux-control--window-state-format))
 
 (defun tmux-control--parse-window-state (lines)
   "Parse `list-panes' reply LINES into (LAYOUT . PANES).


### PR DESCRIPTION
## What

Completes the control-mode quoting sweep started in #73. Three remaining spots interpolated a tmux session/window name into a control-mode command **unquoted**, so a session name with a space (or other tmux-parser special) broke the command. All three surfaced during a live bug-hunt against a remote tmux session over SSH.

| Fix | Symptom before | Severity |
|-----|----------------|----------|
| `--window-state-command` now routes the session through `--window-target` | Tiling **completely non-functional** for a spaced session name — the `list-panes` layout query errored `too many arguments`, so tiling/`%layout-change` retiles read no layout | High |
| New `--fallback-control-target` quotes the connect-window fallback for control-mode use, leaving the raw `--fallback-target` for CLI argv paths | `send-keys`/paste before the pane id is known sent keys to the wrong pane / failed for a spaced session name (remote-only, connect window) | Med |
| New `--quote-tmux-name` doubles `#`→`##` for `rename-window`/`new-window -n` | A `#{...}`/`#(...)` in a window name was format-expanded (`a#{pane_id}b` → `a%0b`; `#(cmd)` ran CMD on the tmux host) — `--quote-tmux-arg` (for targets, which tmux does not format-expand) is unchanged | Low–Med |

## Why the fallback split

`--fallback-target` flows into **both** control-mode command strings (which need tmux quoting) and CLI `call-process` argv (where the value rides as one argument and quoting would inject literal `"`). So the new helper re-quotes only at the control-mode use sites; the stored value stays raw.

## Testing

- `tmux-control--quote-tmux-name`, `--window-state-command`, and `--fallback-control-target` each get a regression test; the homeless-fallback test's assertion is updated to the quoted form. Reverting **only** the source change fails exactly those 4 tests; with the fix, **174/174 ERT green**, clean byte-compile.
- The `##` doubling was verified against tmux 3.6b's own command-string parser (`source-file`): raw `#{pane_id}` → `a%0b`, doubled `##{pane_id}` → literal `a#{pane_id}b`.
- **Fix #1 verified live** on a remote session named `my proj`: the window-state query now emits `list-panes -t "my proj": …`, the layout reads, and the window tiles (`%0`/`%1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
