### PR TITLE
Quote the scrollback pager's in-band session-fallback target

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -104,6 +104,17 @@
     (setq-local tmux-control--fallback-target nil)
     (should (null (tmux-control--fallback-control-target)))))
 
+(ert-deftest tmux-control-test-quote-target-quotes-session-fallback ()
+  ;; In-band control-mode targets (the scrollback pager's capture and
+  ;; history_size queries): a pane/window id is already a safe token; the
+  ;; connect-window session fallback "SESSION:" must be re-quoted so a spaced
+  ;; name parses as one token.  The CLI argv capture keeps the raw target.
+  (should (equal (tmux-control--quote-target "%3") "%3"))
+  (should (equal (tmux-control--quote-target "@2") "@2"))
+  (should (equal (tmux-control--quote-target "my proj:") "\"my proj\":"))
+  (should (equal (tmux-control--quote-target "main:") "\"main\":"))
+  (should (equal (tmux-control--quote-target nil) nil)))
+
 ;;; Control-mode output decoding.
 
 (ert-deftest tmux-control-test-octal-digit-p ()

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -1618,6 +1618,21 @@ is unambiguous.  Returns nil when there is no fallback target."
     (tmux-control--window-target
      (replace-regexp-in-string ":\\'" "" tmux-control--fallback-target))))
 
+(defun tmux-control--quote-target (target)
+  "Return control-mode TARGET with any session name quoted for tmux's parser.
+A pane (\"%N\") or window (\"@N\") id is already a single safe token and is
+returned unchanged; the connect-window session fallback \"SESSION:\" is
+re-quoted so a spaced or special session name parses as one token (tmux
+session names cannot contain `:', so stripping the trailing window separator
+is unambiguous).  TARGET nil returns nil.  For in-band command strings only --
+a CLI argv target rides `call-process' as one argument and must stay raw."
+  (cond
+   ((null target) nil)
+   ((or (string-prefix-p "%" target) (string-prefix-p "@" target)) target)
+   ((string-suffix-p ":" target)
+    (tmux-control--window-target (substring target 0 -1)))
+   (t target)))
+
 (defun tmux-control-select-window (&optional index)
   "Switch the live tmux-control view to window INDEX in the same session.
 
@@ -2234,7 +2249,7 @@ lazy extension; without it the capture runs to the bottom as before."
           (when trailing " -N")
           (format " -S -%d" lines)
           (when end-back (format " -E -%d" end-back))
-          (when target (format " -t %s" target))))
+          (when target (format " -t %s" (tmux-control--quote-target target)))))
 
 (defun tmux-control--scrollback-populate (buffer text &optional line column)
   "Fill scrollback BUFFER with prepared TEXT and restore the view.
@@ -2332,7 +2347,8 @@ duplicate.  Async over the live connection; a no-op when disconnected."
       (when (and (process-live-p proc) target)
         (with-current-buffer live
           (tmux-control--query
-           (format "display-message -p -t %s '#{history_size}'" target)
+           (format "display-message -p -t %s '#{history_size}'"
+                   (tmux-control--quote-target target))
            (lambda (reply)
              (when (buffer-live-p buffer)
                (with-current-buffer buffer


### PR DESCRIPTION
## What

Completes the control-mode quoting sweep (#73/#75) into the **scrollback pager**, found by a focused audit during the live remote bug-hunt.

The pager builds two **in-band** control-mode commands from its target:
- `capture-pane -p -e … -t <target>` (`tmux-control--scrollback-capture-command`)
- `display-message -p -t <target> '#{history_size}'` (`tmux-control--scrollback-update-history-rows`)

The target is the active pane id when known, but during the connect window (before the `:pane-id` reply lands — widest on a high-latency remote) it falls back to the raw `SESSION:` string. Unquoted, a session name with a space breaks both queries → `[tmux-control] capture failed`, and lazy extension never runs.

## Fix

New `tmux-control--quote-target`: pane/window ids (`%N`/`@N`) pass through unchanged; a `SESSION:` fallback is re-quoted via `tmux-control--window-target` → `"SESSION":`. Applied at the two in-band build sites only. The stored `--scrollback-target` stays **raw**, because the dead-connection CLI fallback (`tmux-control--capture-pane`) passes it as a `call-process` argv element where quoting would inject literal quotes.

## Testing

- Regression test for `tmux-control--quote-target`; reverting only the source change fails exactly that test. **175/175 ERT**, clean byte-compile.
- Integrated check: `tmux-control--scrollback-capture-command "my proj:" …` → `capture-pane … -t "my proj":` (quoted); `"%5"` → `-t %5` (raw).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
