### PR TITLE
Cancel re-tile and pager-resize timers on teardown; drop dead code

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -3714,5 +3714,32 @@ output), :calls (side-effect invocations in order), :active-pane,
         (when (buffer-live-p b)
           (let ((kill-buffer-query-functions nil)) (kill-buffer b)))))))
 
+(ert-deftest tmux-control-test-scrollback-cancel-resize-timer ()
+  ;; A pager killed within its resize-debounce window must not leak the timer.
+  (with-temp-buffer
+    (setq-local tmux-control--scrollback-resize-timer
+                (run-with-timer 100 nil #'ignore))
+    (let ((tm tmux-control--scrollback-resize-timer))
+      (should (memq tm timer-list))
+      (tmux-control--scrollback-cancel-resize-timer)
+      (should-not (memq tm timer-list))
+      (should (null tmux-control--scrollback-resize-timer)))))
+
+(ert-deftest tmux-control-test-kill-process-cancels-retile-timer ()
+  ;; Killing a tiled controller must cancel its pending re-tile timer -- it
+  ;; lives on the global timer-list holding the dead controller, exactly like
+  ;; the command watchdog the function already cancels.
+  (with-temp-buffer
+    (let ((tm (run-with-timer 100 nil #'ignore)))
+      (setq-local tmux-control--retile-timer tm
+                  tmux-control--tiled t
+                  tmux-control--panes nil
+                  tmux-control--window-buffers nil
+                  tmux-control--process nil
+                  tmux-control--command-watchdog-timer nil)
+      (tmux-control--kill-process)
+      (should-not (memq tm timer-list))
+      (should (null tmux-control--retile-timer)))))
+
 (provide 'tmux-control-test)
 ;;; tmux-control-test.el ends here

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -2562,6 +2562,10 @@ the live interactive pane."
         (setq-local tmux-control--scrollback-history-rows nil)
         (add-hook 'window-scroll-functions
                   #'tmux-control--scrollback-scroll-watch nil t)
+        ;; Cancel the resize-debounce timer if the pager is killed before it
+        ;; fires -- it lives on the global `timer-list' holding this buffer.
+        (add-hook 'kill-buffer-hook
+                  #'tmux-control--scrollback-cancel-resize-timer nil t)
         ;; Fresh pager: not yet scrolled up into history, so a wheel-down
         ;; cannot leave to live yet (see `tmux-control-scrollback-wheel-down').
         (setq-local tmux-control--scrollback-left-bottom nil)
@@ -2636,6 +2640,16 @@ agree on the pane size for the Emacs window they share."
   (cons (max 1 (window-max-chars-per-line window))
         (max 1 (with-selected-window window
                  (floor (window-screen-lines))))))
+
+(defun tmux-control--scrollback-cancel-resize-timer ()
+  "Cancel the pager's pending resize-debounce timer.
+Run from the scrollback buffer's `kill-buffer-hook': the debounce timer
+\(armed by `tmux-control--scrollback-follow-resize') lives on the global
+`timer-list' holding this buffer, so a pager killed within the debounce
+window would otherwise leak it until it fires."
+  (when (timerp tmux-control--scrollback-resize-timer)
+    (cancel-timer tmux-control--scrollback-resize-timer)
+    (setq tmux-control--scrollback-resize-timer nil)))
 
 (defun tmux-control--scrollback-follow-resize (frame)
   "Re-capture scrollback views on FRAME whose window changed size.
@@ -3155,19 +3169,6 @@ so the tmux-control keys get out of the way; the mode line shows
               #'eat--manipulate-kill-ring
             #'ignore))
     (tmux-control--disable-line-numbers)))
-
-(defun tmux-control--stop-live-process ()
-  "Stop the live tmux control process without killing the tmux session."
-  (when (process-live-p tmux-control--process)
-    ;; Deliberate shutdown: keep the deferred sentinel from announcing it.
-    (set-process-sentinel tmux-control--process #'ignore)
-    (delete-process tmux-control--process))
-  (setq tmux-control--process nil)
-  (setq tmux-control--terminal nil)
-  (setq eat-terminal nil)
-  (setq tmux-control--keys-active nil)
-  (setq tmux-control--char-mode-keys nil)
-  (remove-hook 'kill-buffer-hook #'tmux-control--kill-process t))
 
 (defun tmux-control--command (host socket-name session)
   "Return process command for HOST, SOCKET-NAME, and SESSION."
@@ -5358,12 +5359,22 @@ client (e.g. iTerm2) for the trade-offs."
   (when tmux-control--command-watchdog-timer
     (cancel-timer tmux-control--command-watchdog-timer)
     (setq tmux-control--command-watchdog-timer nil))
-  (when tmux-control--panes
-    (dolist (np tmux-control--panes)
-      (when (buffer-live-p (cdr np))
-        (let ((kill-buffer-query-functions nil))
-          (kill-buffer (cdr np)))))
-    (setq tmux-control--panes nil))
+  ;; Cancel a pending re-tile too: like the watchdog it lives on the global
+  ;; `timer-list' holding this controller, and killing the pane buffers below
+  ;; would otherwise schedule a fresh one -- each pane's `kill-buffer-hook'
+  ;; re-tiles while `tmux-control--tiled' is still set.  Mirrors
+  ;; `tmux-control--teardown-tiling'.
+  (when tmux-control--retile-timer
+    (cancel-timer tmux-control--retile-timer)
+    (setq tmux-control--retile-timer nil))
+  ;; Suppress those per-pane re-tile schedules while killing the pane buffers.
+  (let ((tmux-control--killing-pane t))
+    (when tmux-control--panes
+      (dolist (np tmux-control--panes)
+        (when (buffer-live-p (cdr np))
+          (let ((kill-buffer-query-functions nil))
+            (kill-buffer (cdr np)))))
+      (setq tmux-control--panes nil)))
   (let ((self (current-buffer)))
     (dolist (entry tmux-control--window-buffers)
       (let ((buf (cdr entry)))


### PR DESCRIPTION
## What

Two bounded timer leaks on teardown paths (found by a lifecycle audit during the live remote bug-hunt) plus one dead function. The architecture is otherwise very defensive here — these are the only teardown timer-hygiene gaps found.

- **`tmux-control--kill-process`** cancelled the command watchdog but not the **re-tile timer**, and killed the tiled pane buffers without binding `tmux-control--killing-pane`. So each pane's `kill-buffer-hook` scheduled a fresh re-tile against the controller being torn down — leaking a timer that retains the dead controller until it fires (~0.06s). Now cancels the re-tile timer and suppresses per-pane re-tile scheduling, mirroring `tmux-control--teardown-tiling`.
- **Scrollback pager** armed a 0.3s resize-debounce timer with no `kill-buffer-hook` to cancel it, so a pager killed within the debounce window (resize → `q`) leaked the timer holding the dead buffer. Adds `tmux-control--scrollback-cancel-resize-timer` on the pager's `kill-buffer-hook`.
- **Deletes `tmux-control--stop-live-process`** — zero callers; would have leaked the watchdog/re-tile timers if ever wired up.

Both leaks are bounded and self-clearing (the callbacks no-op on the dead buffer), but they needlessly inflate `timer-list` on teardown bursts (the chaos soak's timer-growth invariant).

## Testing

Regression tests for both cancels (reverting the source fails exactly those two). **176/176 ERT**, clean byte-compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
