### PR TITLE
Preserve a literal TAB in a pane title when parsing window state

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -1233,6 +1233,20 @@ each wrapped in an evolving prompt line and a status bar.")
     (should (equal (plist-get p :cmd) ""))
     (should (equal (plist-get p :title) ""))))
 
+(ert-deftest tmux-control-test-parse-window-state-tab-in-title ()
+  ;; `pane_title' is the last field, but an app can set a title containing a
+  ;; literal TAB (OSC 2).  It must be preserved whole, not truncated to its
+  ;; pre-TAB fragment, and the pane must not be dropped or mis-counted.
+  (let* ((line (mapconcat #'identity
+                          '("LAY" "%0" "0" "0" "80" "24" "1"
+                            "5" "6" "1" "bash" "a\tb\tc")
+                          "\t"))
+         (panes (cdr (tmux-control--parse-window-state (list line))))
+         (p (cdr (assoc "%0" panes))))
+    (should (= (length panes) 1))
+    (should (equal (plist-get p :cmd) "bash"))
+    (should (equal (plist-get p :title) "a\tb\tc"))))
+
 (ert-deftest tmux-control-test-build-tiling-callback-aborts-when-cleared ()
   ;; The build is async: a teardown (untile, disconnect) during an in-flight
   ;; layout query clears `tmux-control--tiling-build-active', and the reply

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -5877,7 +5877,12 @@ Pure, so the reply shape is unit-testable without a live tmux."
                             :cursor-visible
                             (tmux-control--cursor-visible-from-flag (nth 9 f))
                             :cmd (nth 10 f)
-                            :title (nth 11 f)))
+                            ;; `pane_title' is the last field, but an app can set
+                            ;; an arbitrary title (OSC 2) including a literal TAB;
+                            ;; rejoin any TAB-split fragments so the title is not
+                            ;; truncated to its pre-TAB piece (and the pane is not
+                            ;; mis-counted).
+                            :title (string-join (nthcdr 11 f) "\t")))
                 panes))))
     (cons layout (nreverse panes))))
 


### PR DESCRIPTION
## What

Hardens `tmux-control--parse-window-state` against a literal TAB in a pane title.

The in-band `list-panes` reply is TAB-delimited (12 fields, `#{pane_title}` last). An application can set an arbitrary pane title via OSC 2, including a literal TAB — which added fields and truncated `:title` to its pre-TAB fragment (and could shift the pane count). Since the title is the last field, rejoin `nthcdr 11` instead of taking `nth 11`.

## Testing

Regression test (a title `a⇥b⇥c` round-trips whole; reverting the source fails it). **176/176 ERT**, clean byte-compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
