### PR TITLE
Discard a tiled pane's stale output batch on %pause reseed

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -195,6 +195,29 @@
     (should seeded)
     (should (member "refresh-client -A \"%0:continue\"" sent))))
 
+(ert-deftest tmux-control-test-handle-pause-tiled-discards-stale-batch ()
+  ;; In tiling mode a %pause reseeds the paused pane's own buffer
+  ;; synchronously; its pre-pause output batch must be discarded, or
+  ;; `tmux-control--flush-tiled-panes' (end of chunk) replays that stale
+  ;; backlog over the fresh seed -- the very thing %pause means to skip.
+  (let ((panebuf (generate-new-buffer " *tc-pane*"))
+        (seeded nil) (sent '()))
+    (unwind-protect
+        (cl-letf (((symbol-function 'tmux-control--seed-pane-buffer-sync)
+                   (lambda (b) (setq seeded b)))
+                  ((symbol-function 'tmux-control--send-command)
+                   (lambda (cmd &optional _kind) (push cmd sent))))
+          (with-current-buffer panebuf
+            (setq-local tmux-control--output-batch (list "stale" "output")))
+          (with-temp-buffer
+            (setq-local tmux-control--tiled t
+                        tmux-control--panes (list (cons "%4" panebuf)))
+            (tmux-control--handle-pause "%4"))
+          (should (eq seeded panebuf))
+          (should (null (buffer-local-value 'tmux-control--output-batch panebuf)))
+          (should (member "refresh-client -A \"%4:continue\"" sent)))
+      (kill-buffer panebuf))))
+
 ;;; UTF-8 stream reassembly (multibyte characters tmux split across messages).
 
 (ert-deftest tmux-control-test-utf8-complete-len ()

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -4516,6 +4516,12 @@ tmux to continue so live output resumes from the present."
    (tmux-control--tiled
     (let ((buf (cdr (assoc pane tmux-control--panes))))
       (when (buffer-live-p buf)
+        ;; Drop output batched for this pane before the pause: the synchronous
+        ;; reseed below captures tmux's current screen, which already reflects
+        ;; it, so leaving the batch for `tmux-control--flush-tiled-panes' (end
+        ;; of chunk) would paint that stale backlog over the fresh seed --
+        ;; defeating the point of %pause, which is to skip the dropped backlog.
+        (with-current-buffer buf (setq tmux-control--output-batch nil))
         (tmux-control--seed-pane-buffer-sync buf))))
    ;; A pane mirrored by a sibling window render buffer resyncs there.
    ((when-let* ((entry (and tmux-control-window-buffers


### PR DESCRIPTION
## What

In tiling mode, `%pause` for a pane reseeds that pane's render buffer **synchronously** (`tmux-control--handle-pause`), but left the pane's `tmux-control--output-batch` — pre-pause output accumulated earlier in the same filter chunk — in place. `tmux-control--flush-tiled-panes` then replayed it at end-of-chunk, painting that stale backlog **over the fresh seed** — the exact dropped backlog `%pause` exists to skip.

Fix: discard the paused pane's batch before reseeding. The synchronous reseed already captures tmux's current screen, which reflects that output.

## Reachability

Only with flow control on (`tmux-control-pause-after` — opt-in, default nil, and rarely engages even on a healthy remote link per earlier findings), so verified by **unit test** rather than live. The single-pane `%pause` path is unaffected (it reseeds async, after the controller's batch has already flushed).

## Testing

Regression test (reverting the source fails it). **178/178 ERT**, clean byte-compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
