### PR TITLE
Bump version to 0.2.1

### DIFF
--- a/tmux-control.el
+++ b/tmux-control.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2026  Clay Sheaff
 
 ;; Author: Clay Sheaff
-;; Version: 0.2.0
+;; Version: 0.2.1
 ;; Package-Requires: ((emacs "29.1") (eat "0.9.4"))
 ;; Keywords: terminals, tmux
 ;; URL: https://github.com/csheaff/tmux-control


### PR DESCRIPTION
## What

Bumps `Version: 0.2.0` → `0.2.1`, capping the bug-fix batch from this session's live remote (SSH) bug-hunt and five subsystem audits. All changes since 0.2.0 are backwards-compatible fixes:

- **#75** — Quote session names in the remaining control-mode targets (window-state/tiling query, connect-window send-keys/paste fallback, `#` in rename/new-window names).
- **#76** — Quote the scrollback pager's in-band capture/history targets.
- **#77** — Cancel the re-tile and pager-resize timers on teardown; drop dead code.
- **#78** — Preserve a literal TAB in a pane title when parsing window state.
- **#79** — Discard a tiled pane's stale output batch on `%pause` reseed.

No behavior change in this PR (header only). 178/178 ERT, clean byte-compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
