### PR TITLE
Add opt-in auto-heal for Eat render drift (default off)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,13 @@ emulation that drops a display row when a full-screen TUI repaints, so the
 offset can accumulate over redraws; it's tracked upstream at
 [emacs-eat#263](https://codeberg.org/akib/emacs-eat/issues/263).
 
+To heal it **automatically** instead, set `tmux-control-auto-heal-drift` to
+non-nil: an idle check then compares the rendered screen to tmux's own and
+reseeds a drifted pane on its own.  It's off by default because the check costs
+one `capture-pane` round trip per burst of output (taken only when a pane is
+displayed, idle, and on the normal screen) — fine on a fast link, your call on
+a slow one; see the variable's docstring for the exact gating.
+
 ## Terminal agent frameworks
 
 Some CLI coding-agent tools run a session per agent in tmux — one **pane** per

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -3495,6 +3495,7 @@ output), :calls (side-effect invocations in order), :active-pane,
   (let ((healed 0))
     (cl-letf (((symbol-function 'tmux-control--heal-if-drifted)
                (lambda (_b) (cl-incf healed)))
+              ((symbol-function 'tmux-control--alt-screen-p) (lambda () nil))
               ((symbol-function 'tmux-control--wb-controller)
                (lambda () (current-buffer))))
       (with-temp-buffer

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -3458,6 +3458,65 @@ output), :calls (side-effect invocations in order), :active-pane,
                        '(:cursor-pos :capture)))
         (should (equal verified (list (current-buffer))))))))
 
+(ert-deftest tmux-control-test-rtrim-screen-lines ()
+  ;; Trailing blank lines drop; LEADING blanks are kept, so a one-row
+  ;; downward scroll drift (an extra leading blank) is not normalized away.
+  (should (equal (tmux-control--rtrim-screen-lines '("a  " "b" "" "  "))
+                 '("a" "b")))
+  (should (equal (tmux-control--rtrim-screen-lines '("" "a" "b"))
+                 '("" "a" "b")))
+  (should (equal (tmux-control--rtrim-screen-lines '("" "")) '())))
+
+(ert-deftest tmux-control-test-heal-if-drifted ()
+  ;; The drift heal reseeds ONLY when the rendered screen no longer matches
+  ;; tmux's capture -- a match must not reseed (no needless flicker).
+  (let ((reseeded 0))
+    (cl-letf (((symbol-function 'tmux-control--query)
+               (lambda (_cmd cb) (funcall cb '("a" "b"))))
+              ((symbol-function 'tmux-control--seed-screen)
+               (lambda () (cl-incf reseeded)))
+              ((symbol-function 'tmux-control--wb-controller)
+               (lambda () (current-buffer))))
+      (with-temp-buffer
+        (setq-local tmux-control--active-pane "%0")
+        (cl-letf (((symbol-function 'tmux-control--visible-screen-lines)
+                   (lambda (_b) '("a" "b"))))      ; matches capture
+          (tmux-control--heal-if-drifted (current-buffer))
+          (should (= reseeded 0)))
+        (cl-letf (((symbol-function 'tmux-control--visible-screen-lines)
+                   (lambda (_b) '("a" "STALE"))))  ; drifted
+          (tmux-control--heal-if-drifted (current-buffer))
+          (should (= reseeded 1)))))))
+
+(ert-deftest tmux-control-test-maybe-heal-drift-gating ()
+  ;; The idle check no-ops when the feature is off, when nothing changed
+  ;; since the last check, and when the command queue is not drained; it
+  ;; clears the dirty flag when it does run.
+  (let ((healed 0))
+    (cl-letf (((symbol-function 'tmux-control--heal-if-drifted)
+               (lambda (_b) (cl-incf healed)))
+              ((symbol-function 'tmux-control--wb-controller)
+               (lambda () (current-buffer))))
+      (with-temp-buffer
+        (cl-letf (((symbol-function 'tmux-control--displayed-render-buffers)
+                   (let ((b (current-buffer))) (lambda () (list b)))))
+          (setq-local tmux-control--render-dirty t
+                      tmux-control--command-queue nil
+                      tmux-control--collecting-command nil)
+          (let ((tmux-control-auto-heal-drift nil)) ; off -> no heal
+            (tmux-control--maybe-heal-drift)
+            (should (= healed 0)))
+          (let ((tmux-control-auto-heal-drift t))   ; on, dirty, drained -> heal
+            (tmux-control--maybe-heal-drift)
+            (should (= healed 1))
+            (should-not tmux-control--render-dirty) ; cleared
+            (tmux-control--maybe-heal-drift)        ; not dirty -> no repeat
+            (should (= healed 1))
+            (setq-local tmux-control--render-dirty t ; dirty but queue busy
+                        tmux-control--command-queue '((:x . "cmd")))
+            (tmux-control--maybe-heal-drift)
+            (should (= healed 1))))))))
+
 (ert-deftest tmux-control-test-controller-window-close-goes-homeless ()
   ;; When the CONTROLLER's own window closes (an agent's task window it
   ;; was homed on), the buffer survives -- it owns the process -- but its

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -135,6 +135,45 @@ error) and never pause."
   :type '(choice (const :tag "Off (stream everything)" nil)
                  (integer :tag "Seconds behind before pausing")))
 
+(defvar tmux-control--heal-timer nil
+  "The shared idle timer driving `tmux-control-auto-heal-drift'.")
+
+(defcustom tmux-control-auto-heal-drift nil
+  "When non-nil, auto-repaint the live view if it drifts from tmux's screen.
+Eat (the terminal emulator tmux-control renders through) can accumulate a
+scroll/content divergence from a pane's true screen over a long stream of
+incremental `%output' -- an upstream Eat issue -- which shows as a stale or
+\"scrambled\" frame until the next reseed.  Enabling this arms an idle check
+that compares the rendered screen to tmux's `capture-pane' and, when they
+differ on an otherwise-quiet pane, repaints from the capture (the same heal
+as \\[tmux-control-clear-and-repaint], applied automatically).
+
+Off by default: the check costs one in-band `capture-pane' round trip, taken
+only when a tmux-control buffer is displayed, Emacs has been idle for
+`tmux-control-auto-heal-interval', the pane received output since the last
+check, its command queue is drained, and it is on the normal screen (not a
+full-screen application, which repaints itself and does not drift).  So an
+idle session costs nothing, and a busy remote shell costs at most one capture
+per burst-then-idle.  Enable it if the occasional stale frame bothers you."
+  :type 'boolean
+  :group 'tmux-control
+  :set (lambda (sym val)
+         (set-default sym val)
+         (when val (tmux-control--ensure-heal-timer))))
+
+(defcustom tmux-control-auto-heal-interval 2.0
+  "Seconds of Emacs idle before `tmux-control-auto-heal-drift' checks a pane."
+  :type 'number
+  :group 'tmux-control
+  :set (lambda (sym val)
+         (set-default sym val)
+         ;; Re-arm with the new interval if the heal timer is already running.
+         (when (and (timerp tmux-control--heal-timer)
+                    (memq tmux-control--heal-timer timer-idle-list))
+           (cancel-timer tmux-control--heal-timer)
+           (setq tmux-control--heal-timer nil)
+           (tmux-control--ensure-heal-timer))))
+
 (defcustom tmux-control-scrollback-join-wrapped-lines nil
   "Non-nil means join soft-wrapped pane lines in scrollback captures.
 Joining (`capture-pane -J') glues rows tmux wrapped back into single
@@ -939,7 +978,11 @@ session (tmux attaches if it exists, otherwise creates it)."
         (tmux-control--send-command
          (format "refresh-client -f pause-after=%d" tmux-control-pause-after)))
       (tmux-control--disable-line-numbers)
-      (tmux-control--ensure-heal-timer))
+      ;; Arm the drift-heal idle timer only when the feature is on, so a user
+      ;; who never enables it has no extra background timer; Customize toggles
+      ;; it live via the option's `:set'.
+      (when tmux-control-auto-heal-drift
+        (tmux-control--ensure-heal-timer)))
     buffer))
 
 (defun tmux-control--session-live-buffer (host session)
@@ -4418,38 +4461,9 @@ swallowed as content and the reply queue would desynchronize."
 ;; `tmux-control-auto-heal-drift' is on, an idle timer compares the rendered
 ;; screen to tmux's `capture-pane' and repaints from it on a real divergence.
 ;; Off by default; one in-band capture per burst-then-idle, only for a
-;; displayed, normal-screen pane.
-
-(defcustom tmux-control-auto-heal-drift nil
-  "When non-nil, auto-repaint the live view if it drifts from tmux's screen.
-Eat (the terminal emulator tmux-control renders through) can accumulate a
-scroll/content divergence from a pane's true screen over a long stream of
-incremental `%output' -- an upstream Eat issue -- which shows as a stale or
-\"scrambled\" frame until the next reseed.  Enabling this arms an idle check
-that compares the rendered screen to tmux's `capture-pane' and, when they
-differ on an otherwise-quiet pane, repaints from the capture (the same heal
-as \\[tmux-control-clear-and-repaint], applied automatically).
-
-Off by default: the check costs one in-band `capture-pane' round trip, taken
-only when a tmux-control buffer is displayed, Emacs has been idle for
-`tmux-control-auto-heal-interval', the pane received output since the last
-check, its command queue is drained, and it is on the normal screen (not a
-full-screen application, which repaints itself and does not drift).  So an
-idle session costs nothing, and a busy remote shell costs at most one capture
-per burst-then-idle.  Enable it if the occasional stale frame bothers you."
-  :type 'boolean
-  :group 'tmux-control
-  :set (lambda (sym val)
-         (set-default sym val)
-         (when val (tmux-control--ensure-heal-timer))))
-
-(defcustom tmux-control-auto-heal-interval 2.0
-  "Seconds of Emacs idle before `tmux-control-auto-heal-drift' checks a pane."
-  :type 'number
-  :group 'tmux-control)
-
-(defvar tmux-control--heal-timer nil
-  "The shared idle timer driving `tmux-control-auto-heal-drift'.")
+;; displayed, normal-screen pane.  The `tmux-control-auto-heal-drift' /
+;; `tmux-control-auto-heal-interval' options and the timer variable are defined
+;; up top with the other options; the heal machinery follows here.
 
 (defun tmux-control--ensure-heal-timer ()
   "Arm the shared drift-heal idle timer once (idempotent).
@@ -4493,10 +4507,12 @@ pane in-band and repaint only if the rendered screen no longer matches."
     (dolist (buf (tmux-control--displayed-render-buffers))
       (with-current-buffer buf
         (when (and tmux-control--render-dirty
-                   (let ((term tmux-control--terminal))
-                     (not (and term
-                               (fboundp 'eat-term-in-alternative-display-p)
-                               (eat-term-in-alternative-display-p term))))
+                   ;; Skip a pane truly on the alternate screen: a full-screen
+                   ;; app repaints itself and does not drift.  `--alt-screen-p'
+                   ;; honors tmux's alternate-screen option, so a phantom
+                   ;; alt-screen (Eat in alt-display while tmux is not) is NOT
+                   ;; skipped -- that one can drift and should heal.
+                   (not (tmux-control--alt-screen-p))
                    (let ((ctrl (tmux-control--wb-controller)))
                      (and (buffer-live-p ctrl)
                           (with-current-buffer ctrl

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -376,6 +376,11 @@ Set by `tmux-control--feed-terminal' and cleared by
   "Reverse-order list of decoded %output payloads awaiting a single feed.
 Accumulated by `tmux-control--handle-line' and drained by
 `tmux-control--flush-output-batch'.")
+(defvar-local tmux-control--render-dirty nil
+  "Non-nil after %output has been fed since the last drift check.
+The opt-in `tmux-control-auto-heal-drift' check skips a buffer whose render
+has not changed, so an idle pane costs no round trip; set when output is
+flushed (`tmux-control--flush-output-batch'), cleared when the check runs.")
 (defvar-local tmux-control--utf8-carry ""
   "Unibyte bytes of an incomplete trailing UTF-8 sequence held for the next feed.
 tmux can split a multibyte character across two %output messages; the
@@ -933,7 +938,8 @@ session (tmux attaches if it exists, otherwise creates it)."
         ;; notifies with %pause instead of streaming an unbounded backlog.
         (tmux-control--send-command
          (format "refresh-client -f pause-after=%d" tmux-control-pause-after)))
-      (tmux-control--disable-line-numbers))
+      (tmux-control--disable-line-numbers)
+      (tmux-control--ensure-heal-timer))
     buffer))
 
 (defun tmux-control--session-live-buffer (host session)
@@ -4026,6 +4032,9 @@ per message."
   (when tmux-control--output-batch
     (let ((out (apply #'concat (nreverse tmux-control--output-batch))))
       (setq tmux-control--output-batch nil)
+      ;; Mark the render changed so the opt-in drift check (idle) knows this
+      ;; pane is worth re-examining; an idle pane with no output stays clean.
+      (setq tmux-control--render-dirty t)
       (tmux-control--feed-terminal out))))
 
 (defun tmux-control--batch-pane-output (pane payload)
@@ -4400,6 +4409,140 @@ swallowed as content and the reply queue would desynchronize."
          (mapconcat #'identity (nreverse output) "\n")
          tmux-control--seed-cursor
          tmux-control--seed-cursor-visible))))))
+
+;;;; Optional auto-heal of render drift
+;;
+;; Eat can accumulate a one-row scroll/content divergence from a pane's true
+;; screen over a long incremental %output stream (an upstream Eat issue),
+;; which `tmux-control--verify-seed' -- cursor-only -- does not catch.  When
+;; `tmux-control-auto-heal-drift' is on, an idle timer compares the rendered
+;; screen to tmux's `capture-pane' and repaints from it on a real divergence.
+;; Off by default; one in-band capture per burst-then-idle, only for a
+;; displayed, normal-screen pane.
+
+(defcustom tmux-control-auto-heal-drift nil
+  "When non-nil, auto-repaint the live view if it drifts from tmux's screen.
+Eat (the terminal emulator tmux-control renders through) can accumulate a
+scroll/content divergence from a pane's true screen over a long stream of
+incremental `%output' -- an upstream Eat issue -- which shows as a stale or
+\"scrambled\" frame until the next reseed.  Enabling this arms an idle check
+that compares the rendered screen to tmux's `capture-pane' and, when they
+differ on an otherwise-quiet pane, repaints from the capture (the same heal
+as \\[tmux-control-clear-and-repaint], applied automatically).
+
+Off by default: the check costs one in-band `capture-pane' round trip, taken
+only when a tmux-control buffer is displayed, Emacs has been idle for
+`tmux-control-auto-heal-interval', the pane received output since the last
+check, its command queue is drained, and it is on the normal screen (not a
+full-screen application, which repaints itself and does not drift).  So an
+idle session costs nothing, and a busy remote shell costs at most one capture
+per burst-then-idle.  Enable it if the occasional stale frame bothers you."
+  :type 'boolean
+  :group 'tmux-control
+  :set (lambda (sym val)
+         (set-default sym val)
+         (when val (tmux-control--ensure-heal-timer))))
+
+(defcustom tmux-control-auto-heal-interval 2.0
+  "Seconds of Emacs idle before `tmux-control-auto-heal-drift' checks a pane."
+  :type 'number
+  :group 'tmux-control)
+
+(defvar tmux-control--heal-timer nil
+  "The shared idle timer driving `tmux-control-auto-heal-drift'.")
+
+(defun tmux-control--ensure-heal-timer ()
+  "Arm the shared drift-heal idle timer once (idempotent).
+The timer lives for the Emacs session but is a cheap no-op whenever
+`tmux-control-auto-heal-drift' is nil or nothing is displayed."
+  (unless (and (timerp tmux-control--heal-timer)
+               (memq tmux-control--heal-timer timer-idle-list))
+    (setq tmux-control--heal-timer
+          (run-with-idle-timer (max 0.3 tmux-control-auto-heal-interval) t
+                               #'tmux-control--maybe-heal-drift))))
+
+(defun tmux-control--rtrim-screen-lines (lines)
+  "Right-trim each of LINES and drop TRAILING blank lines (leading kept).
+Leading blanks are preserved so a one-row scroll drift -- the exact Eat
+divergence this heals -- is not normalized away."
+  (let ((ls (nreverse (mapcar #'string-trim-right lines))))
+    (while (and ls (string-empty-p (car ls)))
+      (setq ls (cdr ls)))
+    (nreverse ls)))
+
+(defun tmux-control--displayed-render-buffers ()
+  "Live tmux-control render buffers currently visible on the selected frame."
+  (let (bufs)
+    (dolist (win (window-list nil 'no-minibuffer))
+      (let ((b (window-buffer win)))
+        (when (and (buffer-live-p b)
+                   (not (memq b bufs))
+                   (with-current-buffer b
+                     (and (derived-mode-p 'tmux-control-mode)
+                          tmux-control--active-pane
+                          (process-live-p tmux-control--process))))
+          (push b bufs))))
+    bufs))
+
+(defun tmux-control--maybe-heal-drift ()
+  "Idle check for `tmux-control-auto-heal-drift': reseed a drifted pane.
+For each displayed render buffer that received output since its last check,
+is on the normal screen, and whose command queue is drained, capture the
+pane in-band and repaint only if the rendered screen no longer matches."
+  (when tmux-control-auto-heal-drift
+    (dolist (buf (tmux-control--displayed-render-buffers))
+      (with-current-buffer buf
+        (when (and tmux-control--render-dirty
+                   (let ((term tmux-control--terminal))
+                     (not (and term
+                               (fboundp 'eat-term-in-alternative-display-p)
+                               (eat-term-in-alternative-display-p term))))
+                   (let ((ctrl (tmux-control--wb-controller)))
+                     (and (buffer-live-p ctrl)
+                          (with-current-buffer ctrl
+                            (and (null tmux-control--command-queue)
+                                 (not tmux-control--collecting-command))))))
+          (setq tmux-control--render-dirty nil)
+          (tmux-control--heal-if-drifted buf))))))
+
+(defun tmux-control--visible-screen-lines (buffer)
+  "Return BUFFER's Eat visible screen as right-trimmed plain-text lines.
+Invisible padding cells (the second half of a wide glyph) are dropped so a
+wide character does not read as spurious trailing space, matching tmux's
+`capture-pane'; trailing blank lines are trimmed, leading ones kept."
+  (with-current-buffer buffer
+    (when (and tmux-control--terminal (eat-term-live-p tmux-control--terminal))
+      (let ((beg (eat-term-display-beginning tmux-control--terminal))
+            (end (eat-term-end tmux-control--terminal))
+            (out nil))
+        (let ((i beg))
+          (while (< i end)
+            (unless (get-text-property i 'invisible)
+              (push (char-after i) out))
+            (setq i (1+ i))))
+        (tmux-control--rtrim-screen-lines
+         (split-string (apply #'string (nreverse out)) "\n"))))))
+
+(defun tmux-control--heal-if-drifted (buffer)
+  "Capture BUFFER's pane in-band; reseed it only if its render has drifted."
+  (let ((target buffer)
+        (pane (buffer-local-value 'tmux-control--active-pane buffer))
+        (ctrl (with-current-buffer buffer (tmux-control--wb-controller))))
+    (when (and pane (buffer-live-p ctrl))
+      (with-current-buffer ctrl
+        (tmux-control--query
+         (format "capture-pane -p -t %s" pane)
+         (lambda (lines)
+           (when (and (buffer-live-p target)
+                      (equal pane (buffer-local-value 'tmux-control--active-pane
+                                                      target)))
+             (let ((cap (tmux-control--rtrim-screen-lines (or lines '())))
+                   (eat (tmux-control--visible-screen-lines target)))
+               ;; Only reseed on a real divergence: a match means the
+               ;; incremental stream is still aligned, so no needless repaint.
+               (when (and eat (not (equal eat cap)))
+                 (with-current-buffer target
+                   (tmux-control--seed-screen)))))))))))
 
 (defun tmux-control--seed-screen ()
   "Seed the Eat buffer with the current tmux pane contents.


### PR DESCRIPTION
## What

Opt-in mitigation for the upstream Eat render-desync ([#70](https://github.com/csheaff/tmux-control/issues/70)) — the one real-world fidelity gap left after this session's bug-hunt.

Eat accumulates a one-row scroll/content divergence from a pane's true screen over a long incremental `%output` stream. `tmux-control--verify-seed` catches only *cursor* drift, so a content divergence with a matching cursor persists until a manual `clear-and-repaint`, resize, or window visit.

New **`tmux-control-auto-heal-drift`** (default **nil**): an idle timer compares each displayed, normal-screen render buffer's screen to tmux's `capture-pane` and reseeds **only on a real divergence**.

## Why it's cheap (and off by default)

The check runs only when **all** of: the feature is on, output occurred since the last check (a per-buffer dirty flag set in `--flush-output-batch`), the command queue is drained, the pane is on the **normal screen** (full-screen apps repaint themselves and don't drift), and Emacs has been idle for `tmux-control-auto-heal-interval` (default 2s). So an idle session costs nothing; a busy remote shell costs at most one in-band `capture-pane` per output-burst-then-idle. A match never reseeds → **no flicker** on an aligned screen.

The comparison keeps **leading** blank lines (trims only trailing), so the one-row downward scroll drift this targets isn't normalized away.

## Testing

- **Live-verified** on a remote session: with the feature off, injected grid corruption persists; with it on, the idle check detected the divergence and reseeded back to MATCH.
- Unit tests for the trailing-trim, the reseed-only-on-drift decision, and the idle gating (reverting the source fails exactly those 3). **182/182 ERT**, clean byte-compile.

Default-off, so zero behavior change unless explicitly enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
