### PR TITLE
Skip the resize round trips when the requested size is unchanged

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -2679,6 +2679,39 @@ output), :calls (side-effect invocations in order), :active-pane,
           (kill-buffer sb)
           (kill-buffer live))))))
 
+(ert-deftest tmux-control-test-resize-skips-unchanged ()
+  ;; Emacs core fires the window-size hook on many redisplays where the size
+  ;; did not change; a same-size resize must not re-send refresh-client or
+  ;; re-query the pane size (the redundant remote round trips).  A real size
+  ;; change still fires.
+  (let ((sent '()) (refreshed 0))
+    (cl-letf (((symbol-function 'tmux-control--send-command)
+               (lambda (cmd &optional _k) (push cmd sent)))
+              ((symbol-function 'tmux-control--refresh-pane-size)
+               (lambda () (cl-incf refreshed)))
+              ((symbol-function 'tmux-control--apply-eat-size) (lambda (_w _h) nil))
+              ((symbol-function 'tmux-control--wb-controller)
+               (lambda () (current-buffer))))
+      (with-temp-buffer
+        (let ((tmux-control-window-buffers nil))
+          (setq-local tmux-control--requested-client-size nil)
+          ;; First resize: cache nil -> fires.
+          (tmux-control--resize 120 40)
+          (should (= refreshed 1))
+          (should (cl-some (lambda (c) (string-match-p "refresh-client -C 120x40" c))
+                           sent))
+          (should (equal tmux-control--requested-client-size '(120 . 40)))
+          ;; Same size again: skipped (no round trips).
+          (setq sent nil)
+          (tmux-control--resize 120 40)
+          (should (= refreshed 1))
+          (should (null sent))
+          ;; A real change: fires again.
+          (tmux-control--resize 100 30)
+          (should (= refreshed 2))
+          (should (cl-some (lambda (c) (string-match-p "refresh-client -C 100x30" c))
+                           sent)))))))
+
 (ert-deftest tmux-control-test-pinned-size-warns-once-and-recovers ()
   ;; tmux silently refusing our size requests (window-size manual after any
   ;; resize-window, or a competing client) must be surfaced: one probe+warn

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -5158,32 +5158,38 @@ may keep the pane at another size (for example when another, larger client
 is attached under `window-size latest').  `tmux-control--refresh-pane-size'
 then reconciles the Eat grid with the pane's real size so cursor-addressed
 redraws stay aligned."
-  (when (and tmux-control--terminal (eat-term-live-p tmux-control--terminal))
-    (let ((inhibit-read-only t))
-      (eat-term-resize tmux-control--terminal width height)
-      (eat-term-redisplay tmux-control--terminal)
-      (when (fboundp 'eat--synchronize-scroll-windows)
-        (tmux-control--keep-cursor-visible
-         (eat--synchronize-scroll-windows)))))
-  (tmux-control--send-command (format "refresh-client -C %dx%d" width height))
-  ;; Remember what we asked for, so the :pane-size reconciliation can
-  ;; notice tmux NOT following (a pinned window-size, a competing client)
-  ;; and say so instead of silently snapping the grid back.
-  (with-current-buffer (tmux-control--wb-controller)
-    (setq tmux-control--requested-client-size (cons width height)))
-  ;; refresh-client sizes the CLIENT, so tmux resizes every window to it;
-  ;; keep the sibling window render buffers' grids in step so background
-  ;; output renders at the size tmux is actually emitting for.
-  (when tmux-control-window-buffers
-    (let ((self (current-buffer)))
-      (with-current-buffer (tmux-control--wb-controller)
-        (dolist (entry tmux-control--window-buffers)
-          (let ((buf (cdr entry)))
-            (when (and (buffer-live-p buf)
-                       (not (eq buf self)))
-              (with-current-buffer buf
-                (tmux-control--apply-eat-size width height))))))))
-  (tmux-control--refresh-pane-size))
+  ;; The local grid resize is idempotent -- a no-op when the size is unchanged.
+  (tmux-control--apply-eat-size width height)
+  (let ((ctrl (tmux-control--wb-controller)))
+    ;; The remote round trips -- `refresh-client -C' and the pane-size
+    ;; reconciliation query -- only when the requested CLIENT size actually
+    ;; changed.  Emacs core invokes the window-size hook on many redisplays
+    ;; where the size did not change; each such call otherwise costs ~2 round
+    ;; trips on a remote link.  The first call after connect or a window switch
+    ;; has a nil cache and still fires, and an external pane-size change arrives
+    ;; via %layout-change (which runs `tmux-control--refresh-pane-size' on its
+    ;; own), so this drops only genuine no-ops.
+    (unless (equal (cons width height)
+                   (buffer-local-value 'tmux-control--requested-client-size ctrl))
+      (tmux-control--send-command (format "refresh-client -C %dx%d" width height))
+      ;; Remember what we asked for, so the :pane-size reconciliation can
+      ;; notice tmux NOT following (a pinned window-size, a competing client)
+      ;; and say so instead of silently snapping the grid back.
+      (with-current-buffer ctrl
+        (setq tmux-control--requested-client-size (cons width height)))
+      ;; refresh-client sizes the CLIENT, so tmux resizes every window to it;
+      ;; keep the sibling window render buffers' grids in step so background
+      ;; output renders at the size tmux is actually emitting for.
+      (when tmux-control-window-buffers
+        (let ((self (current-buffer)))
+          (with-current-buffer ctrl
+            (dolist (entry tmux-control--window-buffers)
+              (let ((buf (cdr entry)))
+                (when (and (buffer-live-p buf)
+                           (not (eq buf self)))
+                  (with-current-buffer buf
+                    (tmux-control--apply-eat-size width height))))))))
+      (tmux-control--refresh-pane-size))))
 
 (defun tmux-control--apply-eat-size (width height)
   "Resize the Eat grid to WIDTH by HEIGHT when it differs from the current.


### PR DESCRIPTION
## What

Emacs core fires the window-size hook (`tmux-control--adjust-window-size`) on many redisplays — buffer display, split/delete, window-configuration changes — not just real size changes. `tmux-control--resize` then **unconditionally** sent `refresh-client -C` **and** queried the pane size (`--refresh-pane-size`) — **~2 round trips** each time (≈200ms at 100ms RTT), even when nothing changed, and amplified per session in a multi-window/flock frame.

Guard the round trips on the cached `--requested-client-size`: skip `refresh-client` + the pane-size reconciliation when the requested client size equals what we last asked tmux for. The local Eat grid resize stays (via the idempotent `--apply-eat-size`).

## Safety

- First resize after connect / a window switch: cache is nil → not equal → **fires**.
- An external pane-size change (another client, a pin) arrives via `%layout-change`, which runs `--refresh-pane-size` **independently** — so it's still caught.
- Only genuine no-ops are dropped.

## Testing

- **Live-verified**: real frame resizes still make the grid follow tmux (MATCH at 120/160/130-wide).
- Unit test: a same-size resize sends nothing; a real change fires. Reverting the source fails it. **180/180 ERT**, clean byte-compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
