### PR TITLE
Make untile re-resolve the pane and seed in-band, not via blocking ssh

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -1772,6 +1772,31 @@ each wrapped in an evolving prompt line and a status bar.")
           (should (equal committed "b")))       ; committed b
       (kill-buffer bbuf))))
 
+(ert-deftest tmux-control-test-untile-resolves-pane-in-band ()
+  ;; Untile must re-resolve the active pane and seed over the live control
+  ;; connection (in-band, async) -- NOT via a blocking out-of-band ssh
+  ;; display-message, which freezes Emacs for a full SSH round trip on remote.
+  (let ((queries '()) (seeded 0) (ran-tmux nil))
+    (cl-letf (((symbol-function 'tmux-control--teardown-tiling) #'ignore)
+              ((symbol-function 'tmux-control--write-terminal) #'ignore)
+              ((symbol-function 'tmux-control--resize-to-window) #'ignore)
+              ((symbol-function 'tmux-control--run-tmux)
+               (lambda (_args) (setq ran-tmux t) ""))
+              ((symbol-function 'tmux-control--query)
+               (lambda (cmd cb) (push cmd queries) (funcall cb '("%7"))))
+              ((symbol-function 'tmux-control--seed-screen)
+               (lambda () (cl-incf seeded))))
+      (with-temp-buffer
+        (setq-local tmux-control--tiled t
+                    tmux-control--controller nil
+                    tmux-control--active-pane "%0"
+                    tmux-control-window-tab-bar nil)
+        (tmux-control-untile)
+        (should-not ran-tmux)                ; no blocking out-of-band ssh
+        (should (cl-some (lambda (q) (string-match-p "pane_id" q)) queries))
+        (should (equal tmux-control--active-pane "%7")) ; reply applied
+        (should (= seeded 1))))))            ; seeded in the callback
+
 ;;; Tiling preserves a foreign (non-tmux) window sharing the frame.
 
 (ert-deftest tmux-control-test-our-tiling-window-p ()

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -6656,17 +6656,16 @@ panes against a now-smaller Emacs window."
       (user-error "Not tiling"))
     (tmux-control--teardown-tiling controller)
     (with-current-buffer controller
-      ;; Hard-clear the terminal (it still holds the frozen pre-tiling screen)
-      ;; and size the grid to the window, so the returning single-pane view
-      ;; starts from one clean screen.
+      ;; Hard-clear the frozen pre-tiling screen immediately, so the returning
+      ;; single-pane view starts blank rather than showing stale tiled content.
       (tmux-control--write-terminal "\e[3J\e[H\e[2J")
-      (tmux-control--resize-to-window)
       ;; Re-resolve the session's real active pane (the cached one can be stale
-      ;; after window switches) and seed it -- both over the live control
-      ;; connection (in-band, non-blocking).  The previous out-of-band ssh
-      ;; `display-message' plus a synchronous capture froze Emacs for one or
-      ;; two full SSH round trips -- a fresh, unmultiplexed connection -- on
-      ;; every untile of a remote session.
+      ;; after window switches), THEN resize and seed -- all over the live
+      ;; control connection (in-band, non-blocking).  The previous out-of-band
+      ;; ssh `display-message' plus a synchronous capture froze Emacs for one
+      ;; or two full SSH round trips -- a fresh, unmultiplexed connection -- on
+      ;; every untile of a remote session.  Resizing AFTER the pane is resolved
+      ;; keeps the resize-time pane-size reconciliation on the right pane.
       (tmux-control--query
        "display-message -p \"#{pane_id}\""
        (lambda (lines)
@@ -6675,6 +6674,7 @@ panes against a now-smaller Emacs window."
              (let ((pane (and lines (string-trim (car lines)))))
                (when (and pane (string-match-p "\\`%[0-9]+\\'" pane))
                  (setq tmux-control--active-pane pane)))
+             (tmux-control--resize-to-window)
              (tmux-control--seed-screen)
              ;; The tab bar's window/activity state was not tracked while
              ;; tiled; refresh it for the returning single-pane view.

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -6656,27 +6656,32 @@ panes against a now-smaller Emacs window."
       (user-error "Not tiling"))
     (tmux-control--teardown-tiling controller)
     (with-current-buffer controller
-      ;; Re-query the session's real active pane synchronously (the cached
-      ;; one can be stale after window switches) BEFORE anything repaints, so
-      ;; every subsequent seed and any live %output route to the right pane.
-      (let ((pane (ignore-errors
-                    (string-trim
-                     (tmux-control--run-tmux
-                      (list "display-message" "-p" "#{pane_id}"))))))
-        (when (and pane (string-match-p "\\`%[0-9]+\\'" pane))
-          (setq tmux-control--active-pane pane)))
-      (tmux-control--resize-to-window)
-      ;; Hard-clear the terminal (it still holds the frozen pre-tiling
-      ;; screen) and paint the active pane synchronously, so the single-pane
-      ;; view is exactly one clean screen rather than old content plus new.
+      ;; Hard-clear the terminal (it still holds the frozen pre-tiling screen)
+      ;; and size the grid to the window, so the returning single-pane view
+      ;; starts from one clean screen.
       (tmux-control--write-terminal "\e[3J\e[H\e[2J")
-      (tmux-control--seed-pane-buffer-sync controller)
-      ;; The tab bar's window/activity state was not tracked while tiled;
-      ;; refresh it for the returning single-pane view.
-      (when tmux-control-window-tab-bar
-        (tmux-control--quiet-activity)
-        (tmux-control--refresh-windows)
-        (tmux-control--refresh-pane-window-map)))))
+      (tmux-control--resize-to-window)
+      ;; Re-resolve the session's real active pane (the cached one can be stale
+      ;; after window switches) and seed it -- both over the live control
+      ;; connection (in-band, non-blocking).  The previous out-of-band ssh
+      ;; `display-message' plus a synchronous capture froze Emacs for one or
+      ;; two full SSH round trips -- a fresh, unmultiplexed connection -- on
+      ;; every untile of a remote session.
+      (tmux-control--query
+       "display-message -p \"#{pane_id}\""
+       (lambda (lines)
+         (when (buffer-live-p controller)
+           (with-current-buffer controller
+             (let ((pane (and lines (string-trim (car lines)))))
+               (when (and pane (string-match-p "\\`%[0-9]+\\'" pane))
+                 (setq tmux-control--active-pane pane)))
+             (tmux-control--seed-screen)
+             ;; The tab bar's window/activity state was not tracked while
+             ;; tiled; refresh it for the returning single-pane view.
+             (when tmux-control-window-tab-bar
+               (tmux-control--quiet-activity)
+               (tmux-control--refresh-windows)
+               (tmux-control--refresh-pane-window-map)))))))))
 
 (defun tmux-control-toggle-tiling ()
   "Toggle between the tiled multi-pane view and the single-pane view.


### PR DESCRIPTION
## What

`tmux-control-untile` re-queried the active pane with an out-of-band `tmux-control--run-tmux` (display-message) **and** then captured synchronously (`--seed-pane-buffer-sync`) — each a **blocking** call that spins up a fresh, unmultiplexed ssh connection, freezing Emacs for one or two full SSH round trips on every untile of a remote session.

Do both over the live control connection instead: clear + size the grid immediately (so the view starts clean), then query the pane id **in-band** (`--query`) and seed it (`--seed-screen`) in the callback. Untile is now **non-blocking**.

## Testing

- **Live-verified**: tile a 2-pane window, untile → clean single-pane view on the correct active pane (oracle MATCH), `--tiled` cleared.
- Unit test asserts the pane is resolved via `--query` (not the blocking `--run-tmux`) and seeded in the callback. **180/180 ERT**, clean byte-compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)