### PR TITLE
Bump version to 0.3.0

### DIFF
--- a/tmux-control.el
+++ b/tmux-control.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2026  Clay Sheaff
 
 ;; Author: Clay Sheaff
-;; Version: 0.2.1
+;; Version: 0.3.0
 ;; Package-Requires: ((emacs "29.1") (eat "0.9.4"))
 ;; Keywords: terminals, tmux
 ;; URL: https://github.com/csheaff/tmux-control


### PR DESCRIPTION
Minor bump: a new **opt-in** feature (`tmux-control-auto-heal-drift`, default off) plus two remote-performance improvements (skip no-op resize round trips; non-blocking in-band untile) since 0.2.1. No behavior change by default.

184/184 ERT, clean byte-compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)