### PR TITLE
Disambiguate the cross-session activity strip by host

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -1685,7 +1685,8 @@ each wrapped in an evolving prompt line and a status bar.")
   ;; identical "0"s and you cannot tell which host wants attention.
   (let ((a (generate-new-buffer "*tmux-control:hostA:0*"))
         (b (generate-new-buffer "*tmux-control:hostB:0*"))
-        (loc (generate-new-buffer "*tmux-control:local:0*")))
+        (loc (generate-new-buffer "*tmux-control:local:0*"))
+        (empty (generate-new-buffer "*tmux-control:emptyhost:0*")))
     (unwind-protect
         (progn
           (with-current-buffer a
@@ -1703,18 +1704,30 @@ each wrapped in an evolving prompt line and a status bar.")
             (setq-local tmux-control--host nil)   ; local connection
             (setq-local tmux-control--process 'live)
             (setq-local tmux-control--session-activity t))
+          (with-current-buffer empty
+            (setq-local tmux-control--session "le")
+            (setq-local tmux-control--host "")    ; empty host is also local
+            (setq-local tmux-control--process 'live)
+            (setq-local tmux-control--session-activity t))
           (cl-letf (((symbol-function 'process-live-p) (lambda (p) (eq p 'live))))
-            ;; Render the strip from a fourth (current) buffer so all three
-            ;; flagged ones are "other".
+            ;; Render the strip from another (current) buffer so all flagged
+            ;; ones are "other".
             (with-temp-buffer
               (setq-local tmux-control--session "viewer")
               (let* ((tmux-control-session-activity t)
                      (strip (tmux-control--session-strip)))
-                (should (string-match-p "hostA" strip))
-                (should (string-match-p "hostB" strip))
-                ;; The two remotes are distinguishable, not two bare "0"s.
-                (should-not (string-match-p "●0.*●0" strip))))))
-      (kill-buffer a) (kill-buffer b) (kill-buffer loc))))
+                ;; Remotes use the exact "host:session" format.
+                (should (string-match-p "●hostA:0" strip))
+                (should (string-match-p "●hostB:0" strip))
+                ;; The local chip stays unprefixed (a bare session name).
+                (should (string-match-p "●0\\(?:\\'\\| \\)" strip))
+                ;; An empty-string host is local too -- no "●:le", no bare
+                ;; colon prefix.
+                (should (string-match-p "●le\\(?:\\'\\| \\)" strip))
+                (should-not (string-match-p "●:" strip))
+                ;; The two remote "0"s are distinguishable, not two bare "●0".
+                (should-not (string-match-p "●0 .*●0" strip))))))
+      (kill-buffer a) (kill-buffer b) (kill-buffer loc) (kill-buffer empty))))
 
 (ert-deftest tmux-control-test-flock-other-frame-ordering ()
   ;; flock-other-frame: with a prefix it connects all first, then focuses the

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -1679,6 +1679,43 @@ each wrapped in an evolving prompt line and a status bar.")
                 (should-not tmux-control--session-activity)))))   ; self-cleared
       (kill-buffer self) (kill-buffer other) (kill-buffer quiet))))
 
+(ert-deftest tmux-control-test-session-strip-disambiguates-hosts ()
+  ;; Two different hosts whose tmux session names collide (the default "0")
+  ;; must produce distinguishable chips -- otherwise the strip shows two
+  ;; identical "0"s and you cannot tell which host wants attention.
+  (let ((a (generate-new-buffer "*tmux-control:hostA:0*"))
+        (b (generate-new-buffer "*tmux-control:hostB:0*"))
+        (loc (generate-new-buffer "*tmux-control:local:0*")))
+    (unwind-protect
+        (progn
+          (with-current-buffer a
+            (setq-local tmux-control--session "0")
+            (setq-local tmux-control--host "hostA")
+            (setq-local tmux-control--process 'live)
+            (setq-local tmux-control--session-activity t))
+          (with-current-buffer b
+            (setq-local tmux-control--session "0")
+            (setq-local tmux-control--host "hostB")
+            (setq-local tmux-control--process 'live)
+            (setq-local tmux-control--session-activity t))
+          (with-current-buffer loc
+            (setq-local tmux-control--session "0")
+            (setq-local tmux-control--host nil)   ; local connection
+            (setq-local tmux-control--process 'live)
+            (setq-local tmux-control--session-activity t))
+          (cl-letf (((symbol-function 'process-live-p) (lambda (p) (eq p 'live))))
+            ;; Render the strip from a fourth (current) buffer so all three
+            ;; flagged ones are "other".
+            (with-temp-buffer
+              (setq-local tmux-control--session "viewer")
+              (let* ((tmux-control-session-activity t)
+                     (strip (tmux-control--session-strip)))
+                (should (string-match-p "hostA" strip))
+                (should (string-match-p "hostB" strip))
+                ;; The two remotes are distinguishable, not two bare "0"s.
+                (should-not (string-match-p "●0.*●0" strip))))))
+      (kill-buffer a) (kill-buffer b) (kill-buffer loc))))
+
 (ert-deftest tmux-control-test-flock-other-frame-ordering ()
   ;; flock-other-frame: with a prefix it connects all first, then focuses the
   ;; dedicated frame and flocks; without a prefix it skips connect-all.

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -1997,11 +1997,18 @@ flagged one in its strip."
 (defun tmux-control--session-strip-tab (buffer)
   "Return a clickable header-line tab for the flagged session in BUFFER."
   (let* ((name (buffer-local-value 'tmux-control--session buffer))
-         (tab (propertize (format " ●%s" name)
+         (host (buffer-local-value 'tmux-control--host buffer))
+         ;; tmux session names are per-server, so every host's default
+         ;; session is "0"; prefix the host so two hosts' "0"s (or a host
+         ;; and the local server) are distinguishable rather than two
+         ;; identical chips.
+         (label (if host (format "%s:%s" host name) name))
+         (tab (propertize (format " ●%s" label)
                           'face 'tmux-control-tab-activity
                           'mouse-face 'highlight
-                          'help-echo (format "Switch to session %s (unseen output)"
-                                             name)))
+                          'help-echo (format "Switch to session %s%s (unseen output)"
+                                             name
+                                             (if host (format " on %s" host) ""))))
          (map (make-sparse-keymap)))
     (define-key map [header-line mouse-1]
       (lambda (_event)

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -1997,7 +1997,10 @@ flagged one in its strip."
 (defun tmux-control--session-strip-tab (buffer)
   "Return a clickable header-line tab for the flagged session in BUFFER."
   (let* ((name (buffer-local-value 'tmux-control--session buffer))
-         (host (buffer-local-value 'tmux-control--host buffer))
+         (raw-host (buffer-local-value 'tmux-control--host buffer))
+         ;; A nil or empty host is the local server (matches the connect
+         ;; path); only a real host gets a prefix.
+         (host (and raw-host (not (string-empty-p raw-host)) raw-host))
          ;; tmux session names are per-server, so every host's default
          ;; session is "0"; prefix the host so two hosts' "0"s (or a host
          ;; and the local server) are distinguishable rather than two


### PR DESCRIPTION
## Problem

Connecting to multiple hosts at once made the top-left session activity strip "get funny" — sometimes two `●0` chips lit up and you couldn't tell them apart (reported by Clay).

Root cause: `tmux-control--session-strip-tab` labeled each chip with **only the tmux session name**. tmux session names are per-server, so every freshly-started tmux names its first session `0`. Two hosts — or a host plus your local server — both produce a session `0`, rendered as two identical `●0` chips. The underlying connections are distinct (identity is the `host:socket:session` triple); only the label threw away the distinguishing part. It's an ambiguity bug, not a literal duplicate.

## Fix

Prefix the chip and its tooltip with the host:

```
●0 ●0   →   ●aurora:0 ●beta:0     (two hosts)
●0 ●0   →   ●0 ●aurora:0          (local + one host)
```

- Remote chips read `●host:session`; local stays `●session` (unchanged).
- Tooltip now reads "Switch to session 0 on aurora (unseen output)".

One-line change in `tmux-control--session-strip-tab` ([tmux-control.el](../blob/main/tmux-control.el)).

## Verification

- Failing-first test `tmux-control-test-session-strip-disambiguates-hosts` (two remote `0`s + a local `0`; asserts hosts appear and there aren't two bare `●0`s).
- **185/185 ERT green**, clean byte-compile (`byte-compile-error-on-warn`).
- Exercised the real `--session-strip` path headlessly for the reported scenario → renders ` ●aurora:0 ●beta:0 ●0` (was ` ●0 ●0 ●0`). GUI screenshot not possible (no Emacs server running at the time), but this drives the exact production code path.

## Note (out of scope)

The buffer name is `tmux-control:HOST:SESSION` — it omits the socket, so two connections to the *same* host with the same session name but different sockets reuse one buffer via `get-buffer-create` (can't be live simultaneously). Unrelated to this multi-host report; left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)