### PR TITLE
Show a persistent host:session label in the header line

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ attaches, typing a new name creates it.
 - **Live view of a tmux window**, rendered through [Eat](https://codeberg.org/akib/emacs-eat)
   — a normal Emacs buffer you move, search, and copy in, with no nested
   terminal and no tmux chrome.
-- **Windows as tabs** in a header-line tab bar, with an activity **dot** on
+- **Windows as tabs** in a header-line tab bar, prefixed with a persistent
+  `host:session` label so you always know which server and session you are
+  looking at, with an activity **dot** on
   background windows; flip them like browser tabs (`C-c C-n` / `C-c C-p`).
   Each visited window keeps its own scrollback across flips and **keeps
   streaming in the background** — flip back and see everything it printed

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -1729,6 +1729,40 @@ each wrapped in an evolving prompt line and a status bar.")
                 (should-not (string-match-p "●0 .*●0" strip))))))
       (kill-buffer a) (kill-buffer b) (kill-buffer loc) (kill-buffer empty))))
 
+(ert-deftest tmux-control-test-session-label-names-host-and-session ()
+  ;; The persistent header label names the current connection: HOST:SESSION
+  ;; for a remote, a bare session name for the local server (nil or empty
+  ;; host), and it appears in the composed header line.
+  (with-temp-buffer
+    (setq-local tmux-control--host "aurora")
+    (setq-local tmux-control--session "0")
+    (let ((tmux-control-session-label t)
+          (tmux-control-window-tab-bar nil)
+          (tmux-control-session-activity nil))
+      (should (string-match-p "aurora:0" (tmux-control--session-label)))
+      ;; ...and it actually makes it into the header line.
+      (should (string-match-p "aurora:0" (tmux-control--header-line)))))
+  ;; Empty-string host is local -> bare session, no colon prefix.
+  (with-temp-buffer
+    (setq-local tmux-control--host "")
+    (setq-local tmux-control--session "work")
+    (let ((lbl (tmux-control--session-label)))
+      (should (string-match-p "work" lbl))
+      (should-not (string-match-p ":" lbl))))
+  ;; nil host is local too.
+  (with-temp-buffer
+    (setq-local tmux-control--host nil)
+    (setq-local tmux-control--session "0")
+    (should-not (string-match-p ":" (tmux-control--session-label))))
+  ;; Disabled -> no label in the header line.
+  (with-temp-buffer
+    (setq-local tmux-control--host "aurora")
+    (setq-local tmux-control--session "0")
+    (let ((tmux-control-session-label nil)
+          (tmux-control-window-tab-bar nil)
+          (tmux-control-session-activity nil))
+      (should-not (string-match-p "aurora" (tmux-control--header-line))))))
+
 (ert-deftest tmux-control-test-flock-other-frame-ordering ()
   ;; flock-other-frame: with a prefix it connects all first, then focuses the
   ;; dedicated frame and flocks; without a prefix it skips connect-all.

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -399,9 +399,12 @@ for a remote connection, just SESSION for the local server.  Set to nil to
 hide it."
   :type 'boolean)
 
-(defface tmux-control-session-label
+(defface tmux-control-tab-session
   '((t :inherit mode-line-emphasis))
-  "Face for the current-session HOST:SESSION label in the header line.")
+  "Face for the current-session HOST:SESSION label in the header line.
+Named in the `tmux-control-tab-*' family rather than after the
+`tmux-control-session-label' option, so the option and the face do not
+share a symbol.")
 
 (defface tmux-control-tab-active
   '((t :inherit highlight :weight bold))
@@ -2126,7 +2129,7 @@ A nil or empty host is the local server, shown as just the session name
          (session tmux-control--session)
          (text (if remote (format "%s:%s" host session) session)))
     (propertize (format " %s" text)
-                'face 'tmux-control-session-label
+                'face 'tmux-control-tab-session
                 'help-echo (format "tmux %s session %s"
                                    (if remote host "local") session))))
 
@@ -2152,10 +2155,11 @@ none has anything to show."
 
 (defun tmux-control--scrollback-header ()
   "Header line for the scrollback view.
-Keeps the session's window tabs visible (read from the live buffer, for
-orientation) and appends a scroll-mode hint, so entering scrollback does not
-look like the tabs vanished.  Falls back to a plain info line when the tab bar
-is disabled or no live buffer is available."
+Keeps the current-session label and the session's window tabs visible (the
+tabs read from the live buffer, for orientation) and appends a scroll-mode
+hint, so entering scrollback does not look like the header vanished.  Falls
+back to a plain info line only when neither the label nor the tabs are
+available."
   (let* ((live tmux-control--live-buffer)
          ;; Show the CURRENT mode, then what `c' switches to, so it never
          ;; reads as if verbatim were active while compaction is on.

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -391,6 +391,18 @@ unseen output, so an idle setup shows no extra chrome; click a name to
 switch to it.  Set to nil to disable."
   :type 'boolean)
 
+(defcustom tmux-control-session-label t
+  "Non-nil shows the current host and session at the left of the header line.
+A persistent \"you are here\" label so a buffer always names which tmux
+server and session it is showing, beside the window tab bar: HOST:SESSION
+for a remote connection, just SESSION for the local server.  Set to nil to
+hide it."
+  :type 'boolean)
+
+(defface tmux-control-session-label
+  '((t :inherit mode-line-emphasis))
+  "Face for the current-session HOST:SESSION label in the header line.")
+
 (defface tmux-control-tab-active
   '((t :inherit highlight :weight bold))
   "Face for the current window's tab in the `tmux-control' tab bar.")
@@ -959,7 +971,8 @@ session (tmux attaches if it exists, otherwise creates it)."
       ;; Header line: the window tab bar and/or the cross-session activity
       ;; strip (independent features sharing one row).  Both must ignore the
       ;; connect seed's repaint burst, so quiet activity for either.
-      (when (or tmux-control-window-tab-bar tmux-control-session-activity)
+      (when (or tmux-control-window-tab-bar tmux-control-session-activity
+                tmux-control-session-label)
         (setq-local header-line-format '(:eval (tmux-control--header-line)))
         ;; The connect seed repaints every pane; don't let that flag everything.
         (tmux-control--quiet-activity 1.5))
@@ -2104,17 +2117,38 @@ window list and activity state live on the controller; render from there."
      tmux-control--windows
      ""))))
 
+(defun tmux-control--session-label ()
+  "Return the current connection's HOST:SESSION label for the header line.
+A nil or empty host is the local server, shown as just the session name
+\(matching the connect path and the activity strip)."
+  (let* ((host tmux-control--host)
+         (remote (and host (not (string-empty-p host))))
+         (session tmux-control--session)
+         (text (if remote (format "%s:%s" host session) session)))
+    (propertize (format " %s" text)
+                'face 'tmux-control-session-label
+                'help-echo (format "tmux %s session %s"
+                                   (if remote host "local") session))))
+
 (defun tmux-control--header-line ()
   "Compose the live buffer's header line.
-The cross-session activity strip (other sessions wanting attention) sits to
-the left of the window tab bar, with a separator only between the two when
-both are non-empty; each self-gates on its option, so the row is empty when
-neither has anything to show."
-  (let ((strip (tmux-control--session-strip))
-        (tabs (if tmux-control-window-tab-bar (tmux-control--window-tab-bar) "")))
-    (if (and (> (length strip) 0) (> (length tabs) 0))
-        (concat strip (propertize " │" 'face 'tmux-control-tab-inactive) tabs)
-      (concat strip tabs))))
+A persistent HOST:SESSION label naming the current connection sits with the
+window tab bar (both describe the session you are looking at), and the
+cross-session activity strip (other sessions wanting attention) sits to
+their left, with a separator only between the two groups when both are
+non-empty.  Each segment self-gates on its option, so the row is empty when
+none has anything to show."
+  (let* ((label (if (and tmux-control-session-label
+                         (not tmux-control--tiled)
+                         tmux-control--session)
+                    (tmux-control--session-label)
+                  ""))
+         (strip (tmux-control--session-strip))
+         (tabs (if tmux-control-window-tab-bar (tmux-control--window-tab-bar) ""))
+         (this (concat label tabs)))
+    (if (and (> (length strip) 0) (> (length this) 0))
+        (concat strip (propertize " │" 'face 'tmux-control-tab-inactive) this)
+      (concat strip this))))
 
 (defun tmux-control--scrollback-header ()
   "Header line for the scrollback view.
@@ -2128,12 +2162,18 @@ is disabled or no live buffer is available."
          (cmode (if tmux-control-compact-scrollback
                     "compacted·c:verbatim"
                   "verbatim·c:compact"))
+         ;; The scrollback buffer carries its own host/session, so the label
+         ;; orients you the same way the live header does.
+         (label (if (and tmux-control-session-label tmux-control--session)
+                    (tmux-control--session-label)
+                  ""))
          (tabs (and tmux-control-window-tab-bar
                     (buffer-live-p live)
                     (with-current-buffer live
-                      (tmux-control--window-tab-bar t)))))
-    (if (and tabs (> (length tabs) 0))
-        (concat tabs (propertize (format "  ⇡ scrollback  g:refresh  %s  q/RET:live "
+                      (tmux-control--window-tab-bar t))))
+         (head (concat label (or tabs ""))))
+    (if (> (length head) 0)
+        (concat head (propertize (format "  ⇡ scrollback  g:refresh  %s  q/RET:live "
                                          cmode)
                                  'face 'tmux-control-tab-inactive))
       (format " %s socket:%s session:%s target:%s    g:refresh  %s  q/l/RET:live"
@@ -5746,7 +5786,8 @@ it asynchronously over the control connection."
         ;; "no process" -- alarming for a perfectly live view.  Keep the
         ;; rest (the [semi-char] mode indicator), drop the status.
         (setq mode-line-process (remove ":%s" mode-line-process))
-        (when (or tmux-control-window-tab-bar tmux-control-session-activity)
+        (when (or tmux-control-window-tab-bar tmux-control-session-activity
+                tmux-control-session-label)
           (setq-local header-line-format
                       '(:eval (tmux-control--header-line))))
         (add-hook 'kill-buffer-hook


### PR DESCRIPTION
## Motivation

With several connections open (two remotes + local), the header line named the session's tmux *windows* as tabs but never the **session or host itself** — so a buffer gave no persistent cue for which server/session you were looking at. The identity lived only in the buffer name (mode line / `C-x b`). The one host-bearing header element — the cross-session activity strip — only appears when a *background* session has unseen output, which made "when am I supposed to see the host?" feel arbitrary (reported by Clay).

## Change

Add an always-on `host:session` label at the left of the window tab bar:

```
 ●beta:0 │ aurora:0 0:bash 1:vim     (on aurora, beta has unseen output)
 0 0:zsh                             (on local, idle)
```

- New defcustom `tmux-control-session-label` (default on).
- `HOST:SESSION` for a remote; a bare session name for the local server (nil/empty host) — matches the connect path and the activity strip's convention.
- The current-session label sits with its own window tabs (both describe the session on screen); the cross-session activity chips sit to their left, with the `│` separator only when both groups are present.
- New face `tmux-control-session-label` (inherits `mode-line-emphasis`).
- Mirrored into the scrollback header so that view orients you the same way.
- Header line now installs when *any* of the three header options is on.

## Verification

- Failing-first test `tmux-control-test-session-label-names-host-and-session` (remote → `host:session`; nil/empty host → bare session, no colon; disabled → absent from the header).
- **186/186 ERT green**, clean byte-compile.
- Rendered the real `--header-line` headlessly (GUI Emacs not running) → the layouts shown above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)