### PR TITLE
Header line: per-tab hover highlight; name local connections explicitly

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -1719,20 +1719,20 @@ each wrapped in an evolving prompt line and a status bar.")
                 ;; Remotes use the exact "host:session" format.
                 (should (string-match-p "●hostA:0" strip))
                 (should (string-match-p "●hostB:0" strip))
-                ;; The local chip stays unprefixed (a bare session name).
-                (should (string-match-p "●0\\(?:\\'\\| \\)" strip))
-                ;; An empty-string host is local too -- no "●:le", no bare
-                ;; colon prefix.
-                (should (string-match-p "●le\\(?:\\'\\| \\)" strip))
+                ;; The local chip is named "local:session", not a bare "0".
+                (should (string-match-p "●local:0" strip))
+                ;; An empty-string host is local too -- "local:le", never
+                ;; "●:le".
+                (should (string-match-p "●local:le" strip))
                 (should-not (string-match-p "●:" strip))
-                ;; The two remote "0"s are distinguishable, not two bare "●0".
-                (should-not (string-match-p "●0 .*●0" strip))))))
+                ;; No bare "●0" anywhere -- every chip is server-qualified.
+                (should-not (string-match-p "●0\\(?:\\'\\| \\)" strip))))))
       (kill-buffer a) (kill-buffer b) (kill-buffer loc) (kill-buffer empty))))
 
 (ert-deftest tmux-control-test-session-label-names-host-and-session ()
   ;; The persistent header label names the current connection: HOST:SESSION
-  ;; for a remote, a bare session name for the local server (nil or empty
-  ;; host), and it appears in the composed header line.
+  ;; for a remote, local:SESSION for the local server (nil or empty host),
+  ;; and it appears in the composed header line.
   (with-temp-buffer
     (setq-local tmux-control--host "aurora")
     (setq-local tmux-control--session "0")
@@ -1742,18 +1742,16 @@ each wrapped in an evolving prompt line and a status bar.")
       (should (string-match-p "aurora:0" (tmux-control--session-label)))
       ;; ...and it actually makes it into the header line.
       (should (string-match-p "aurora:0" (tmux-control--header-line)))))
-  ;; Empty-string host is local -> bare session, no colon prefix.
+  ;; Empty-string host is local -> "local:SESSION".
   (with-temp-buffer
     (setq-local tmux-control--host "")
     (setq-local tmux-control--session "work")
-    (let ((lbl (tmux-control--session-label)))
-      (should (string-match-p "work" lbl))
-      (should-not (string-match-p ":" lbl))))
+    (should (string-match-p "local:work" (tmux-control--session-label))))
   ;; nil host is local too.
   (with-temp-buffer
     (setq-local tmux-control--host nil)
     (setq-local tmux-control--session "0")
-    (should-not (string-match-p ":" (tmux-control--session-label))))
+    (should (string-match-p "local:0" (tmux-control--session-label))))
   ;; Disabled -> no label in the header line.
   (with-temp-buffer
     (setq-local tmux-control--host "aurora")
@@ -1762,6 +1760,24 @@ each wrapped in an evolving prompt line and a status bar.")
           (tmux-control-window-tab-bar nil)
           (tmux-control-session-activity nil))
       (should-not (string-match-p "aurora" (tmux-control--header-line))))))
+
+(ert-deftest tmux-control-test-tab-bar-mouse-face-is-per-tab ()
+  ;; Header-line mouse highlighting spans the maximal contiguous run of text
+  ;; sharing one `eq' mouse-face value, so adjacent tabs must carry distinct
+  ;; values -- otherwise hovering one window lights up the whole bar.
+  (with-temp-buffer
+    (setq-local tmux-control--windows
+                '((:index "0" :name "bash" :active t)
+                  (:index "1" :name "vim"  :active nil)))
+    (let* ((bar (tmux-control--window-tab-bar))
+           (mf1 (get-text-property 1 'mouse-face bar))
+           (chg (next-single-property-change 1 'mouse-face bar))
+           (mf2 (and chg (get-text-property chg 'mouse-face bar))))
+      ;; Both tabs carry a mouse-face...
+      (should mf1)
+      (should mf2)
+      ;; ...but not the SAME object, so the highlight stops at the boundary.
+      (should-not (eq mf1 mf2)))))
 
 (ert-deftest tmux-control-test-flock-other-frame-ordering ()
   ;; flock-other-frame: with a prefix it connects all first, then focuses the

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -2010,24 +2010,33 @@ flagged one in its strip."
     (setq tmux-control--session-activity t)
     (force-mode-line-update t)))
 
+(defun tmux-control--connection-name (host session)
+  "Return SESSION qualified by its server, as HOST:SESSION.
+A nil or empty HOST is the local server and reads as \"local:SESSION\", so
+a local connection is named explicitly rather than shown bare -- tmux
+session names are per-server, so a bare \"0\" is ambiguous across hosts."
+  (format "%s:%s"
+          (if (and host (not (string-empty-p host))) host "local")
+          session))
+
+(defun tmux-control--tab-mouse-face ()
+  "Return a fresh `highlight'-equivalent face for a tab's `mouse-face'.
+Header-line mouse highlighting spans the maximal run of text sharing one
+`eq' `mouse-face' value, so reusing the symbol `highlight' across adjacent
+tabs lights them all up at once.  A fresh (non-`eq') value per tab bounds
+the highlight to the single tab under the mouse."
+  (list :inherit 'highlight))
+
 (defun tmux-control--session-strip-tab (buffer)
   "Return a clickable header-line tab for the flagged session in BUFFER."
   (let* ((name (buffer-local-value 'tmux-control--session buffer))
-         (raw-host (buffer-local-value 'tmux-control--host buffer))
-         ;; A nil or empty host is the local server (matches the connect
-         ;; path); only a real host gets a prefix.
-         (host (and raw-host (not (string-empty-p raw-host)) raw-host))
-         ;; tmux session names are per-server, so every host's default
-         ;; session is "0"; prefix the host so two hosts' "0"s (or a host
-         ;; and the local server) are distinguishable rather than two
-         ;; identical chips.
-         (label (if host (format "%s:%s" host name) name))
+         (host (buffer-local-value 'tmux-control--host buffer))
+         (label (tmux-control--connection-name host name))
          (tab (propertize (format " ●%s" label)
                           'face 'tmux-control-tab-activity
-                          'mouse-face 'highlight
-                          'help-echo (format "Switch to session %s%s (unseen output)"
-                                             name
-                                             (if host (format " on %s" host) ""))))
+                          'mouse-face (tmux-control--tab-mouse-face)
+                          'help-echo (format "Switch to session %s (unseen output)"
+                                             label)))
          (map (make-sparse-keymap)))
     (define-key map [header-line mouse-1]
       (lambda (_event)
@@ -2110,7 +2119,7 @@ window list and activity state live on the controller; render from there."
                           (t 'tmux-control-tab-inactive)))
               (tab (propertize (format " %s:%s%s " idx name mark)
                                'face face
-                               'mouse-face 'highlight
+                               'mouse-face (tmux-control--tab-mouse-face)
                                'help-echo (format "Switch to tmux window %s (%s)"
                                                   idx name))))
          (unless no-keymap
@@ -2122,16 +2131,13 @@ window list and activity state live on the controller; render from there."
 
 (defun tmux-control--session-label ()
   "Return the current connection's HOST:SESSION label for the header line.
-A nil or empty host is the local server, shown as just the session name
-\(matching the connect path and the activity strip)."
-  (let* ((host tmux-control--host)
-         (remote (and host (not (string-empty-p host))))
-         (session tmux-control--session)
-         (text (if remote (format "%s:%s" host session) session)))
+A nil or empty host is the local server, shown as \"local:SESSION\" so the
+label always names the server explicitly (see `tmux-control--connection-name')."
+  (let ((text (tmux-control--connection-name tmux-control--host
+                                             tmux-control--session)))
     (propertize (format " %s" text)
                 'face 'tmux-control-tab-session
-                'help-echo (format "tmux %s session %s"
-                                   (if remote host "local") session))))
+                'help-echo (format "tmux session %s" text))))
 
 (defun tmux-control--header-line ()
   "Compose the live buffer's header line.


### PR DESCRIPTION
Two header-line issues Clay noticed, fixed together.

## 1. Hovering a tab highlighted the whole bar

Header-line mouse highlighting spans the maximal *contiguous run of text sharing one `eq` `mouse-face` value*. Every window tab (and every activity chip) used the same symbol `'highlight`, so the entire run of tabs was a single region — hover one window and they all lit up.

**Fix:** each tab/chip gets a fresh, non-`eq` `mouse-face` value (`tmux-control--tab-mouse-face`, an anonymous `(:inherit highlight)` so it looks identical), so `next-single-property-change` finds a boundary at each tab and the highlight stops at the one under the mouse.

## 2. Local connections now read `local:session`

Remotes showed `host:session` but a local connection showed a bare session name (e.g. `0`). Now the local server is named explicitly as `local:session`, matching the remote format and removing the bare-name ambiguity. Shared naming factored into `tmux-control--connection-name`, used by both the session label and the activity strip.

```
 ●beta:0 │ aurora:0 0:bash 1:vim     (remote)
 0 0:zsh        →   local:0 0:zsh    (local, now labeled)
```

## Verification

- Failing-first test `tmux-control-test-tab-bar-mouse-face-is-per-tab` (asserts adjacent tabs carry distinct, non-`eq` `mouse-face` values); updated the strip/label tests for the `local:session` form.
- **187/187 ERT green**, clean byte-compile.
- Confirmed the old shared-`'highlight` behavior collapses to one region (`next-single-property-change` → nil) and the new values break it per tab; rendered the real header → `local:0` labeling shown above. GUI Emacs wasn't running, so no live screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
