### PR TITLE
Header line: split "here" (left) from "elsewhere" (named right corner)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,13 @@ attaches, typing a new name creates it.
   streaming in the background** — flip back and see everything it printed
   while you were away.
 - **Switch between sessions** on the host in place (`C-c C-s`) — each tmux
-  session is its own buffer with its own scrollback and tabs — with a dot
-  flagging another session that wants you, or tile **every session at once**
-  in a live grid (`C-c C-f`, experimental).
+  session is its own buffer with its own scrollback and tabs. Other connected
+  sessions with unseen output are **named in the right corner** of the header
+  (grouped by server, so a host is shown once and only when it differs from
+  the one you're viewing) — you see *which* session wants you, not just that
+  one does; click a name (or `M-x tmux-control-switch-to-flagged`) to jump
+  there. Or tile **every session at once** in a live grid (`C-c C-f`,
+  experimental).
 - **Scrollback** as ordinary Emacs text (`C-c C-e`) — opens instantly however
   deep the history (loaded lazily, extended as you scroll), faithful by
   default, with opt-in compaction of repeated full-screen redraws (toggle with

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -1647,9 +1647,9 @@ each wrapped in an evolving prompt line and a status bar.")
         (tmux-control--note-session-activity)
         (should-not tmux-control--session-activity)))))    ; quiet → no flag
 
-(ert-deftest tmux-control-test-session-strip-lists-others-and-clears-self ()
-  ;; The strip names other flagged sessions (not unflagged ones, not self) and
-  ;; clears the current session's own flag (you are looking at it).
+(ert-deftest tmux-control-test-session-corner-lists-others-and-clears-self ()
+  ;; The corner names other flagged sessions (not unflagged ones, not self),
+  ;; and composing the header clears the current session's own flag.
   (let ((self (generate-new-buffer "*tmux-control:local:self*"))
         (other (generate-new-buffer "*tmux-control:local:other*"))
         (quiet (generate-new-buffer "*tmux-control:local:quiet*")))
@@ -1672,21 +1672,25 @@ each wrapped in an evolving prompt line and a status bar.")
           (cl-letf (((symbol-function 'process-live-p) (lambda (p) (eq p 'live))))
             (with-current-buffer self
               (let* ((tmux-control-session-activity t)
-                     (strip (tmux-control--session-strip)))
-                (should (string-match-p "other" strip))   ; flagged other listed
-                (should-not (string-match-p "quiet" strip)) ; unflagged omitted
-                (should-not (string-match-p "self" strip))  ; self omitted
-                (should-not tmux-control--session-activity)))))   ; self-cleared
+                     (tmux-control-window-tab-bar nil)
+                     (corner (tmux-control--corner-render
+                              (tmux-control--flagged-other-session-buffers))))
+                (should (string-match-p "other" corner))    ; flagged other listed
+                (should-not (string-match-p "quiet" corner)) ; unflagged omitted
+                (should-not (string-match-p "self" corner))  ; self omitted
+                ;; Composing the header clears self's own flag (you see it).
+                (tmux-control--header-line)
+                (should-not tmux-control--session-activity)))))
       (kill-buffer self) (kill-buffer other) (kill-buffer quiet))))
 
-(ert-deftest tmux-control-test-session-strip-disambiguates-hosts ()
-  ;; Two different hosts whose tmux session names collide (the default "0")
-  ;; must produce distinguishable chips -- otherwise the strip shows two
-  ;; identical "0"s and you cannot tell which host wants attention.
+(ert-deftest tmux-control-test-session-corner-groups-by-server ()
+  ;; The corner groups flagged sessions by SERVER: a host is named once and
+  ;; only when it differs from the one you are viewing, so sessions on your
+  ;; own (current) server show bare names while other hosts are prefixed.
   (let ((a (generate-new-buffer "*tmux-control:hostA:0*"))
         (b (generate-new-buffer "*tmux-control:hostB:0*"))
         (loc (generate-new-buffer "*tmux-control:local:0*"))
-        (empty (generate-new-buffer "*tmux-control:emptyhost:0*")))
+        (empty (generate-new-buffer "*tmux-control:emptyhost:le*")))
     (unwind-protect
         (progn
           (with-current-buffer a
@@ -1701,7 +1705,7 @@ each wrapped in an evolving prompt line and a status bar.")
             (setq-local tmux-control--session-activity t))
           (with-current-buffer loc
             (setq-local tmux-control--session "0")
-            (setq-local tmux-control--host nil)   ; local connection
+            (setq-local tmux-control--host nil)   ; local, same server as viewer
             (setq-local tmux-control--process 'live)
             (setq-local tmux-control--session-activity t))
           (with-current-buffer empty
@@ -1710,24 +1714,42 @@ each wrapped in an evolving prompt line and a status bar.")
             (setq-local tmux-control--process 'live)
             (setq-local tmux-control--session-activity t))
           (cl-letf (((symbol-function 'process-live-p) (lambda (p) (eq p 'live))))
-            ;; Render the strip from another (current) buffer so all flagged
-            ;; ones are "other".
+            ;; Viewer is a local session, so "local" is the CURRENT server.
             (with-temp-buffer
               (setq-local tmux-control--session "viewer")
-              (let* ((tmux-control-session-activity t)
-                     (strip (tmux-control--session-strip)))
-                ;; Remotes use the exact "host:session" format.
-                (should (string-match-p "●hostA:0" strip))
-                (should (string-match-p "●hostB:0" strip))
-                ;; The local chip is named "local:session", not a bare "0".
-                (should (string-match-p "●local:0" strip))
-                ;; An empty-string host is local too -- "local:le", never
-                ;; "●:le".
-                (should (string-match-p "●local:le" strip))
-                (should-not (string-match-p "●:" strip))
-                ;; No bare "●0" anywhere -- every chip is server-qualified.
-                (should-not (string-match-p "●0\\(?:\\'\\| \\)" strip))))))
+              (setq-local tmux-control--host nil)
+              (let ((corner (tmux-control--corner-render
+                             (tmux-control--flagged-other-session-buffers))))
+                ;; Remote servers are named (once), local server is NOT (it's
+                ;; the current server -- no redundant prefix).
+                (should (string-match-p "hostA" corner))
+                (should (string-match-p "hostB" corner))
+                (should-not (string-match-p "local" corner))
+                ;; Each remote "0" sits under its host label; the local
+                ;; siblings ("0" and "le") show bare.
+                (should (string-match-p "hostA[^●]*0" corner))
+                (should (string-match-p "hostB[^●]*0" corner))
+                (should (string-match-p "le" corner))
+                (should-not (string-match-p "●:" corner))))))
       (kill-buffer a) (kill-buffer b) (kill-buffer loc) (kill-buffer empty))))
+
+(ert-deftest tmux-control-test-server-label-disambiguates-socket ()
+  ;; The default socket reads as just "local"; a non-default socket is
+  ;; appended so two local servers don't both collapse to "local".
+  (should (equal (tmux-control--server-label nil tmux-control-default-socket-name)
+                 "local"))
+  (should (equal (tmux-control--server-label "" tmux-control-default-socket-name)
+                 "local"))
+  (should (equal (tmux-control--server-label nil "scratch") "local/scratch"))
+  (should (equal (tmux-control--server-label "aurora" tmux-control-default-socket-name)
+                 "aurora"))
+  (should (equal (tmux-control--server-label "aurora" "work") "aurora/work")))
+
+(ert-deftest tmux-control-test-corner-collapses-to-count ()
+  ;; When the named corner won't fit, it collapses to a bright count.
+  (let ((c (tmux-control--corner-collapsed 3)))
+    (should (string-match-p "●3" (substring-no-properties c)))
+    (should (get-text-property (1- (length c)) 'keymap c))))
 
 (ert-deftest tmux-control-test-session-label-names-host-and-session ()
   ;; The persistent header label names the current connection: HOST:SESSION

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -1741,6 +1741,8 @@ each wrapped in an evolving prompt line and a status bar.")
   (should (equal (tmux-control--server-label "" tmux-control-default-socket-name)
                  "local"))
   (should (equal (tmux-control--server-label nil "scratch") "local/scratch"))
+  ;; An empty socket is absent, not a non-default server (no "local/").
+  (should (equal (tmux-control--server-label nil "") "local"))
   (should (equal (tmux-control--server-label "aurora" tmux-control-default-socket-name)
                  "aurora"))
   (should (equal (tmux-control--server-label "aurora" "work") "aurora/work")))

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -384,11 +384,12 @@ friends.  Set to nil to hide it."
 (defcustom tmux-control-session-activity t
   "Non-nil flags other connected sessions that have unseen output.
 When you are looking at one session and another connected session produces
-output, its name appears with a dot at the left of the header line -- the
-session-level \"which one wants me?\" signal, the companion to the window
-tab bar's per-window dot.  The strip is empty when no other session has
-unseen output, so an idle setup shows no extra chrome; click a name to
-switch to it.  Set to nil to disable."
+output, its NAME appears with a bright dot in the right corner of the header
+line -- the session-level \"which one wants me?\" signal, grouped by server
+so a host is named once and only when it differs from the one you are
+viewing.  The corner is empty when no other session has unseen output, so an
+idle setup shows no extra chrome; click a name (or use
+`tmux-control-switch-to-flagged') to switch to it.  Set to nil to disable."
   :type 'boolean)
 
 (defcustom tmux-control-session-label t
@@ -400,11 +401,13 @@ hide it."
   :type 'boolean)
 
 (defface tmux-control-tab-session
-  '((t :inherit mode-line-emphasis))
-  "Face for the current-session HOST:SESSION label in the header line.
-Named in the `tmux-control-tab-*' family rather than after the
-`tmux-control-session-label' option, so the option and the face do not
-share a symbol.")
+  '((t :inherit default))
+  "Face for the current session NAME in the header line.
+Plain by default: the session name is a neutral fact, not an alert, so it
+carries no color of its own (the host prefix is dimmed and the active
+window is highlighted -- those carry the meaning).  Named in the
+`tmux-control-tab-*' family rather than after the `tmux-control-session-label'
+option, so the option and the face do not share a symbol.")
 
 (defface tmux-control-tab-active
   '((t :inherit highlight :weight bold))
@@ -2027,25 +2030,6 @@ tabs lights them all up at once.  A fresh (non-`eq') value per tab bounds
 the highlight to the single tab under the mouse."
   (list :inherit 'highlight))
 
-(defun tmux-control--session-strip-tab (buffer)
-  "Return a clickable header-line tab for the flagged session in BUFFER."
-  (let* ((name (buffer-local-value 'tmux-control--session buffer))
-         (host (buffer-local-value 'tmux-control--host buffer))
-         (label (tmux-control--connection-name host name))
-         (tab (propertize (format " ●%s" label)
-                          'face 'tmux-control-tab-activity
-                          'mouse-face (tmux-control--tab-mouse-face)
-                          'help-echo (format "Switch to session %s (unseen output)"
-                                             label)))
-         (map (make-sparse-keymap)))
-    (define-key map [header-line mouse-1]
-      (lambda (_event)
-        (interactive "e")
-        (let ((display-buffer-overriding-action '((display-buffer-same-window))))
-          (pop-to-buffer (tmux-control--session-display-buffer buffer)))))
-    (put-text-property 0 (length tab) 'keymap map tab)
-    tab))
-
 (defun tmux-control--flagged-other-session-buffers ()
   "Live session buffers other than the current one that have unseen output.
 Tests the activity flag first so most buffers are rejected by one cheap
@@ -2064,21 +2048,107 @@ redisplay."
         (push b flagged)))
     (sort flagged (lambda (a b) (string< (buffer-name a) (buffer-name b))))))
 
-(defun tmux-control--session-strip ()
-  "Header-line segment naming other connected sessions with unseen output.
-Empty when none (so an idle setup shows no extra chrome) and in the tiled
-view.  Rendered in the visible session's header line; clears this session's
-own flag (held on its controller) as a side effect, since you are looking
-at it."
-  (if (or (not tmux-control-session-activity) tmux-control--tiled)
-      ""
-    (let ((ctrl (tmux-control--wb-controller)))
-      (when (and (buffer-live-p ctrl)
-                 (buffer-local-value 'tmux-control--session-activity ctrl))
-        (with-current-buffer ctrl
-          (setq tmux-control--session-activity nil))))
-    (mapconcat #'tmux-control--session-strip-tab
-               (tmux-control--flagged-other-session-buffers) "")))
+(defun tmux-control--clear-self-activity ()
+  "Clear this session's own unseen-output flag (held on its controller).
+You are looking at it, so it does not belong in the corner of its own header."
+  (let ((ctrl (tmux-control--wb-controller)))
+    (when (and (buffer-live-p ctrl)
+               (buffer-local-value 'tmux-control--session-activity ctrl))
+      (with-current-buffer ctrl
+        (setq tmux-control--session-activity nil)))))
+
+(defun tmux-control--server-label (host socket)
+  "Return the display label for the tmux server on HOST via SOCKET.
+A nil or empty HOST is the local server (\"local\").  The socket is appended
+only when it is not the default, so the common single-server case stays
+clean but two local servers (or two sockets on one host) stay distinct --
+otherwise both would collapse to \"local\"."
+  (let ((h (if (and host (not (string-empty-p host))) host "local")))
+    (if (and socket (not (equal socket tmux-control-default-socket-name)))
+        (format "%s/%s" h socket)
+      h)))
+
+(defun tmux-control--corner-session (buffer)
+  "Return a clickable corner token for the flagged session in BUFFER.
+The session NAME is plain and a bright `●' marks that it wants attention;
+clicking switches to it."
+  (let* ((sid (buffer-local-value 'tmux-control--session buffer))
+         (host (buffer-local-value 'tmux-control--host buffer))
+         (tok (concat " " (propertize sid 'face 'tmux-control-tab-session)
+                      (propertize " ●" 'face 'tmux-control-tab-activity)))
+         (map (make-sparse-keymap)))
+    (define-key map [header-line mouse-1]
+      (lambda (_event)
+        (interactive "e")
+        (let ((display-buffer-overriding-action '((display-buffer-same-window))))
+          (pop-to-buffer (tmux-control--session-display-buffer buffer)))))
+    (propertize tok
+                'mouse-face (tmux-control--tab-mouse-face)
+                'help-echo (format "Switch to session %s (unseen output)"
+                                   (tmux-control--connection-name host sid))
+                'keymap map)))
+
+(defun tmux-control--corner-render (buffers)
+  "Render the corner: other sessions in BUFFERS that want attention.
+Grouped by SERVER so a host is named once, and only when it differs from
+the server you are currently viewing -- so a sibling session on your own
+server shows just its name (no redundant host), while a session on another
+host/server is prefixed with that server, dimmed, once."
+  (let* ((cur (cons (tmux-control--server-label tmux-control--host
+                                                tmux-control--socket-name)
+                    t))
+         (order '())
+         (groups (make-hash-table :test 'equal)))
+    (dolist (b buffers)
+      (let ((key (tmux-control--server-label
+                  (buffer-local-value 'tmux-control--host b)
+                  (buffer-local-value 'tmux-control--socket-name b))))
+        (unless (member key order) (setq order (append order (list key))))
+        (puthash key (cons b (gethash key groups)) groups)))
+    (mapconcat
+     (lambda (key)
+       (concat
+        (unless (equal key (car cur))
+          (propertize (format "  %s" key) 'face 'tmux-control-tab-inactive))
+        (mapconcat #'tmux-control--corner-session
+                   (reverse (gethash key groups)) "")))
+     order "")))
+
+(defun tmux-control-switch-to-flagged ()
+  "Switch to one of the other sessions that has unseen output.
+With one such session, go straight there; with several, pick by name."
+  (interactive)
+  (let ((bufs (tmux-control--flagged-other-session-buffers)))
+    (cond
+     ((null bufs) (message "tmux-control: no other session has unseen output"))
+     ((null (cdr bufs))
+      (pop-to-buffer (tmux-control--session-display-buffer (car bufs))))
+     (t (let* ((choices (mapcar
+                         (lambda (b)
+                           (cons (tmux-control--connection-name
+                                  (buffer-local-value 'tmux-control--host b)
+                                  (buffer-local-value 'tmux-control--session b))
+                                 b))
+                         bufs))
+               (pick (completing-read "Switch to session: "
+                                      (mapcar #'car choices) nil t)))
+          (when (assoc pick choices)
+            (pop-to-buffer (tmux-control--session-display-buffer
+                            (cdr (assoc pick choices))))))))))
+
+(defun tmux-control--corner-collapsed (n)
+  "Return a collapsed corner: a bright count of N sessions wanting attention.
+Used when the named corner would not fit the window; clicking opens the
+switcher."
+  (let ((dot (propertize (format " ●%d" n)
+                         'face 'tmux-control-tab-activity
+                         'mouse-face (tmux-control--tab-mouse-face)
+                         'help-echo (format "%d other session%s with unseen output -- click to switch"
+                                            n (if (= n 1) "" "s"))))
+        (map (make-sparse-keymap)))
+    (define-key map [header-line mouse-1]
+      (lambda (_event) (interactive "e") (tmux-control-switch-to-flagged)))
+    (propertize dot 'keymap map)))
 
 (defun tmux-control--tab-keymap (index)
   "Return a header-line keymap that switches to window INDEX on a click."
@@ -2131,33 +2201,52 @@ window list and activity state live on the controller; render from there."
 
 (defun tmux-control--session-label ()
   "Return the current connection's HOST:SESSION label for the header line.
-A nil or empty host is the local server, shown as \"local:SESSION\" so the
-label always names the server explicitly (see `tmux-control--connection-name')."
-  (let ((text (tmux-control--connection-name tmux-control--host
-                                             tmux-control--session)))
-    (propertize (format " %s" text)
-                'face 'tmux-control-tab-session
-                'help-echo (format "tmux session %s" text))))
+The host is DIMMED (context you orient by, not act on) and the session NAME
+is plain; a nil or empty host is the local server, shown as \"local:\" so the
+server is always named (see `tmux-control--connection-name')."
+  (let* ((host tmux-control--host)
+         (hl (if (and host (not (string-empty-p host))) host "local"))
+         (s (concat (propertize (format " %s:" hl) 'face 'tmux-control-tab-inactive)
+                    (propertize tmux-control--session 'face 'tmux-control-tab-session))))
+    (propertize s 'help-echo
+                (format "tmux session %s"
+                        (tmux-control--connection-name host tmux-control--session)))))
 
 (defun tmux-control--header-line ()
-  "Compose the live buffer's header line.
-A persistent HOST:SESSION label naming the current connection sits with the
-window tab bar (both describe the session you are looking at), and the
-cross-session activity strip (other sessions wanting attention) sits to
-their left, with a separator only between the two groups when both are
-non-empty.  Each segment self-gates on its option, so the row is empty when
-none has anything to show."
+  "Compose the live buffer's header line as \"here\" on the left, \"elsewhere\"
+in the right corner.
+LEFT: the current connection (host:session) and its window tabs, bound by a
+dim connector -- everything about the session you are looking at.  RIGHT
+CORNER (right-aligned): other connected sessions that have unseen output,
+named and grouped by server, so you can see WHICH one wants you, not merely
+that something does.  The corner is empty when nothing elsewhere needs you,
+and collapses to a bright count when it would not fit the window.  Each part
+self-gates on its option."
+  (when (and tmux-control-session-activity (not tmux-control--tiled))
+    (tmux-control--clear-self-activity))
   (let* ((label (if (and tmux-control-session-label
                          (not tmux-control--tiled)
                          tmux-control--session)
                     (tmux-control--session-label)
                   ""))
-         (strip (tmux-control--session-strip))
          (tabs (if tmux-control-window-tab-bar (tmux-control--window-tab-bar) ""))
-         (this (concat label tabs)))
-    (if (and (> (length strip) 0) (> (length this) 0))
-        (concat strip (propertize " │" 'face 'tmux-control-tab-inactive) this)
-      (concat strip this))))
+         (connector (if (and (> (length label) 0) (> (length tabs) 0))
+                        (propertize " ›" 'face 'tmux-control-tab-inactive)
+                      ""))
+         (left (concat label connector tabs))
+         (others (if (and tmux-control-session-activity (not tmux-control--tiled))
+                     (tmux-control--flagged-other-session-buffers)
+                   nil)))
+    (if (null others)
+        left
+      (let* ((full (tmux-control--corner-render others))
+             (fits (<= (+ (string-width left) (string-width full) 2)
+                       (window-width)))
+             (corner (if fits full (tmux-control--corner-collapsed (length others)))))
+        (concat left
+                (propertize " " 'display
+                            `(space :align-to (- right ,(+ 1 (string-width corner)))))
+                corner " ")))))
 
 (defun tmux-control--scrollback-header ()
   "Header line for the scrollback view.
@@ -2181,7 +2270,10 @@ available."
                     (buffer-live-p live)
                     (with-current-buffer live
                       (tmux-control--window-tab-bar t))))
-         (head (concat label (or tabs ""))))
+         (connector (if (and (> (length label) 0) tabs (> (length tabs) 0))
+                        (propertize " ›" 'face 'tmux-control-tab-inactive)
+                      ""))
+         (head (concat label connector (or tabs ""))))
     (if (> (length head) 0)
         (concat head (propertize (format "  ⇡ scrollback  g:refresh  %s  q/RET:live "
                                          cmode)

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -401,11 +401,12 @@ hide it."
   :type 'boolean)
 
 (defface tmux-control-tab-session
-  '((t :inherit default))
+  '((t))
   "Face for the current session NAME in the header line.
 Plain by default: the session name is a neutral fact, not an alert, so it
-carries no color of its own (the host prefix is dimmed and the active
-window is highlighted -- those carry the meaning).  Named in the
+carries no attributes of its own (it inherits the header line's own face;
+the host prefix is dimmed and the active window is highlighted -- those
+carry the meaning).  Named in the
 `tmux-control-tab-*' family rather than after the `tmux-control-session-label'
 option, so the option and the face do not share a symbol.")
 
@@ -2064,7 +2065,8 @@ only when it is not the default, so the common single-server case stays
 clean but two local servers (or two sockets on one host) stay distinct --
 otherwise both would collapse to \"local\"."
   (let ((h (if (and host (not (string-empty-p host))) host "local")))
-    (if (and socket (not (equal socket tmux-control-default-socket-name)))
+    (if (and socket (not (string-empty-p socket))
+             (not (equal socket tmux-control-default-socket-name)))
         (format "%s/%s" h socket)
       h)))
 
@@ -2094,25 +2096,26 @@ Grouped by SERVER so a host is named once, and only when it differs from
 the server you are currently viewing -- so a sibling session on your own
 server shows just its name (no redundant host), while a session on another
 host/server is prefixed with that server, dimmed, once."
-  (let* ((cur (cons (tmux-control--server-label tmux-control--host
-                                                tmux-control--socket-name)
-                    t))
+  (let* ((cur (tmux-control--server-label tmux-control--host
+                                          tmux-control--socket-name))
          (order '())
          (groups (make-hash-table :test 'equal)))
     (dolist (b buffers)
       (let ((key (tmux-control--server-label
                   (buffer-local-value 'tmux-control--host b)
                   (buffer-local-value 'tmux-control--socket-name b))))
-        (unless (member key order) (setq order (append order (list key))))
+        ;; First sighting of a server seeds its (non-empty) group, so a plain
+        ;; `gethash' presence check de-dups `order' without an O(n^2) `member'.
+        (unless (gethash key groups) (push key order))
         (puthash key (cons b (gethash key groups)) groups)))
     (mapconcat
      (lambda (key)
        (concat
-        (unless (equal key (car cur))
+        (unless (equal key cur)
           (propertize (format "  %s" key) 'face 'tmux-control-tab-inactive))
         (mapconcat #'tmux-control--corner-session
                    (reverse (gethash key groups)) "")))
-     order "")))
+     (nreverse order) "")))
 
 (defun tmux-control-switch-to-flagged ()
   "Switch to one of the other sessions that has unseen output.


### PR DESCRIPTION
Reworks the header line so each region does exactly one job — the outcome of a long live-design pass (a "what would Steve Jobs do" panel + iterative screenshots in a real GUI Emacs).

## The change

```
local:demo › 0:shell 1:builder● 2:tests●                         api ●  web ●
└──────────────┬──────────────────────┘                         └──────┬─────┘
   HERE: current session › its windows                  ELSEWHERE: other sessions
                                                         with unseen output, named
```

**Left = here.** The current connection as `host:session` (host dimmed, session plain) bound by a dim `›` to its window tabs, so the windows read as belonging to *that* session and nothing else.

**Right corner = elsewhere.** Other connected sessions with unseen output, **named** (not a bare count) and right-aligned, so you see *which* session wants you. Grouped by **server**: a host is shown once and only when it differs from the one you're viewing — a sibling session on your own server shows just its name; another host is prefixed once. Two tmux servers that would both read as `local` are disambiguated by socket (`local/scratch`). The corner is empty when nothing elsewhere needs you, and collapses to a bright count when it wouldn't fit the window. Click a name (or `M-x tmux-control-switch-to-flagged`) to jump there.

This replaces the old left-side activity strip, which interleaved other sessions with the current one and read as clutter (it was the root of repeated "which windows belong to which session?" / "why is this here?" confusion during design).

## Deliberately deferred

The **done-vs-still-working** distinction (a bright named `●` for an agent waiting on you vs. a dim count of agents still churning) was the headline idea from the design panel, but it needs a reliable "waiting on you" detector. A hero signal that lies gets distrusted and ignored, so it's a separate, validated follow-up. This PR ships the proven-safe structure + naming.

## Color discipline

Every color encodes exactly one thing: **dim** = context (host, connector), **plain** = the session name, **highlight** = the active window, **warning/yellow** = wants attention (window dots + corner). `tmux-control-tab-session` is now plain (was emphasis/blue, which encoded nothing — caught during design).

## Verification

- Failing-first tests updated/added: corner lists others + clears self; corner groups by server (host once, current server unprefixed); `tmux-control--server-label` disambiguates socket; corner collapses to a count.
- **189/189 ERT green**, clean byte-compile.
- Live-verified in a real GUI Emacs against a throwaway tmux server with multiple sessions: left/right split renders, corner names real flagged sessions, narrow-frame collapse confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
