### PR TITLE
Quote the session in the list-windows / list-panes refreshers

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -92,6 +92,27 @@
     (should (string-prefix-p "list-panes -t \"my proj\": -F \""
                              (tmux-control--window-state-command)))))
 
+(ert-deftest tmux-control-test-refresh-window-targets-quote-session ()
+  ;; The in-band list-windows / list-panes refreshers (which feed the tab bar
+  ;; and the pane->window output routing map) must quote the session, like every
+  ;; other control-mode target.  A spaced session name otherwise makes tmux's
+  ;; parser split the argument ("too many arguments") so the window list never
+  ;; populates and routing breaks.
+  (let (cmds)
+    (cl-letf (((symbol-function 'tmux-control--send-command)
+               (lambda (cmd &rest _) (push cmd cmds)))
+              ((symbol-function 'process-live-p) (lambda (_) t)))
+      (with-temp-buffer
+        (setq-local tmux-control--session "my proj")
+        (setq-local tmux-control--process 'live)
+        (let ((tmux-control-window-tab-bar t))
+          (tmux-control--refresh-windows)
+          (tmux-control--refresh-pane-window-map))
+        (should (= (length cmds) 2))
+        (dolist (c cmds)
+          (should (string-match-p "-t \"my proj\":" c))
+          (should-not (string-match-p "-t my proj" c)))))))
+
 (ert-deftest tmux-control-test-fallback-control-target-quotes-session ()
   ;; The connect-window fallback target (send-keys/paste before the pane id
   ;; is known) must quote the session for the control-mode parser, while the

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -1888,7 +1888,7 @@ is left untouched."
              (process-live-p tmux-control--process))
     (tmux-control--send-command
      (format "list-windows -t %s -F '#{window_index}\t#{window_name}\t#{window_active}\t#{window_bell_flag}\t#{window_id}'"
-             tmux-control--session)
+             (tmux-control--window-target tmux-control--session))
      :windows)))
 
 (defun tmux-control--refresh-pane-window-map ()
@@ -1897,7 +1897,7 @@ is left untouched."
              (process-live-p tmux-control--process))
     (tmux-control--send-command
      (format "list-panes -s -t %s -F '#{pane_id}\t#{window_index}\t#{window_id}'"
-             tmux-control--session)
+             (tmux-control--window-target tmux-control--session))
      :pane-window)))
 
 (defun tmux-control--update-windows (lines)


### PR DESCRIPTION
Found by an adversarial bug-hunt workflow (two independent finders, ~0.9 confidence), same class as the quoting sweeps in #73/#75/#76.

`tmux-control--refresh-windows` and `tmux-control--refresh-pane-window-map` interpolated the **raw** session into `list-windows -t %s` / `list-panes -s -t %s`, unlike every other control-mode target in the file (which goes through `tmux-control--window-target` / `tmux-control--quote-tmux-arg`). A session whose name contains a space or a tmux/parser special makes tmux split the argument ("too many arguments"), so the window list never populates (empty/wrong tab bar) and the pane→window output-routing map is never built. These two targets were the missed spots.

Fix: quote via `tmux-control--window-target` (yields `"SESSION":`), exactly as #75 did for the layout query.

Failing-first test added. 190/190 ERT green, clean byte-compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
