### PR TITLE
Guard the corner/switcher against a killed session

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -1803,6 +1803,21 @@ each wrapped in an evolving prompt line and a status bar.")
       ;; ...but not the SAME object, so the highlight stops at the boundary.
       (should-not (eq mf1 mf2)))))
 
+(ert-deftest tmux-control-test-switch-to-flagged-buffer-handles-killed ()
+  ;; A corner entry / switcher captures a controller buffer that may be killed
+  ;; before the user clicks (server died, manual kill). Switching to it must
+  ;; report it, not signal "Selecting deleted buffer".
+  (let ((dead (generate-new-buffer "*tmux-control:local:gone*"))
+        (msg nil))
+    (kill-buffer dead)                     ; now a dead buffer object
+    (cl-letf (((symbol-function 'message) (lambda (fmt &rest args)
+                                            (setq msg (apply #'format fmt args))))
+              ((symbol-function 'pop-to-buffer)
+               (lambda (&rest _) (error "should not be reached for a dead buffer"))))
+      ;; Must not error, and should tell the user it's gone.
+      (tmux-control--switch-to-flagged-buffer dead)
+      (should (string-match-p "gone" msg)))))
+
 (ert-deftest tmux-control-test-flock-other-frame-ordering ()
   ;; flock-other-frame: with a prefix it connects all first, then focuses the
   ;; dedicated frame and flocks; without a prefix it skips connect-all.

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -2070,6 +2070,17 @@ otherwise both would collapse to \"local\"."
         (format "%s/%s" h socket)
       h)))
 
+(defun tmux-control--switch-to-flagged-buffer (buffer)
+  "Switch to the session shown in BUFFER, or report it if it is gone.
+The corner and the switcher capture a controller buffer that the user may
+act on moments later; the session can be killed in between (server died,
+manual kill), so guard liveness rather than signalling \"Selecting deleted
+buffer\"."
+  (if (buffer-live-p buffer)
+      (let ((display-buffer-overriding-action '((display-buffer-same-window))))
+        (pop-to-buffer (tmux-control--session-display-buffer buffer)))
+    (message "tmux-control: that session is gone")))
+
 (defun tmux-control--corner-session (buffer)
   "Return a clickable corner token for the flagged session in BUFFER.
 The session NAME is plain and a bright `●' marks that it wants attention;
@@ -2082,8 +2093,7 @@ clicking switches to it."
     (define-key map [header-line mouse-1]
       (lambda (_event)
         (interactive "e")
-        (let ((display-buffer-overriding-action '((display-buffer-same-window))))
-          (pop-to-buffer (tmux-control--session-display-buffer buffer)))))
+        (tmux-control--switch-to-flagged-buffer buffer)))
     (propertize tok
                 'mouse-face (tmux-control--tab-mouse-face)
                 'help-echo (format "Switch to session %s (unseen output)"
@@ -2125,7 +2135,7 @@ With one such session, go straight there; with several, pick by name."
     (cond
      ((null bufs) (message "tmux-control: no other session has unseen output"))
      ((null (cdr bufs))
-      (pop-to-buffer (tmux-control--session-display-buffer (car bufs))))
+      (tmux-control--switch-to-flagged-buffer (car bufs)))
      (t (let* ((choices (mapcar
                          (lambda (b)
                            (cons (tmux-control--connection-name
@@ -2136,8 +2146,8 @@ With one such session, go straight there; with several, pick by name."
                (pick (completing-read "Switch to session: "
                                       (mapcar #'car choices) nil t)))
           (when (assoc pick choices)
-            (pop-to-buffer (tmux-control--session-display-buffer
-                            (cdr (assoc pick choices))))))))))
+            ;; The buffer can be killed while the minibuffer is open.
+            (tmux-control--switch-to-flagged-buffer (cdr (assoc pick choices)))))))))
 
 (defun tmux-control--corner-collapsed (n)
   "Return a collapsed corner: a bright count of N sessions wanting attention.


### PR DESCRIPTION
Found by an adversarial bug-hunt workflow (verified, ~0.7 confidence) against today's new header code.

The right-corner session tokens (`tmux-control--corner-session`) and `tmux-control-switch-to-flagged` capture a controller buffer the user acts on moments later. That session can be killed in between (server died, manual kill, reconnect teardown), so clicking a stale corner entry — or picking one that dies while the switcher minibuffer is open — signalled **"Selecting deleted buffer"**.

Fix: route both through a new `tmux-control--switch-to-flagged-buffer` that checks `buffer-live-p` and otherwise reports "that session is gone".

Failing-first test added. 190/190 ERT green, clean byte-compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
