### PR TITLE
Store the activity quiet-window deadline on the controller

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -1839,6 +1839,25 @@ each wrapped in an evolving prompt line and a status bar.")
       (tmux-control--switch-to-flagged-buffer dead)
       (should (string-match-p "gone" msg)))))
 
+(ert-deftest tmux-control-test-quiet-activity-targets-controller ()
+  ;; The quiet-window deadline is read on the controller (the %output path runs
+  ;; there), so it must be WRITTEN on the controller even when a command calls
+  ;; --quiet-activity from a per-window render buffer -- otherwise the burst it
+  ;; suppresses would spuriously flag windows.
+  (let ((ctrl (generate-new-buffer "*tmux-control:local:ctrl*"))
+        (render (generate-new-buffer "*tmux-control:local:render*")))
+    (unwind-protect
+        (progn
+          (with-current-buffer ctrl (setq-local tmux-control--activity-quiet-until 0))
+          (with-current-buffer render
+            (setq-local tmux-control--controller ctrl)
+            (setq-local tmux-control--activity-quiet-until 0)
+            (tmux-control--quiet-activity 5))
+          ;; Deadline landed on the controller, not the render buffer.
+          (should (> (buffer-local-value 'tmux-control--activity-quiet-until ctrl) 0))
+          (should (= (buffer-local-value 'tmux-control--activity-quiet-until render) 0)))
+      (kill-buffer ctrl) (kill-buffer render))))
+
 (ert-deftest tmux-control-test-flock-other-frame-ordering ()
   ;; flock-other-frame: with a prefix it connects all first, then focuses the
   ;; dedicated frame and flocks; without a prefix it skips connect-all.

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -1855,7 +1855,14 @@ each wrapped in an evolving prompt line and a status bar.")
             (tmux-control--quiet-activity 5))
           ;; Deadline landed on the controller, not the render buffer.
           (should (> (buffer-local-value 'tmux-control--activity-quiet-until ctrl) 0))
-          (should (= (buffer-local-value 'tmux-control--activity-quiet-until render) 0)))
+          (should (= (buffer-local-value 'tmux-control--activity-quiet-until render) 0))
+          ;; A stale (killed) controller must not signal "Selecting deleted
+          ;; buffer" -- guard liveness and no-op.
+          (with-current-buffer render
+            (let ((dead (generate-new-buffer "*tmux-control:local:dead*")))
+              (kill-buffer dead)
+              (setq-local tmux-control--controller dead)
+              (tmux-control--quiet-activity 5))))   ; must not error
       (kill-buffer ctrl) (kill-buffer render))))
 
 (ert-deftest tmux-control-test-flock-other-frame-ordering ()

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -1973,8 +1973,10 @@ path reads it (`tmux-control--note-pane-activity' /
 A command may call this from a per-window render buffer, so writing it on the
 current buffer would land it where the gate is never read -- and the burst it
 was meant to suppress would flag windows anyway."
-  (with-current-buffer (tmux-control--wb-controller)
-    (setq tmux-control--activity-quiet-until (+ (float-time) (or secs 0.8)))))
+  (let ((ctrl (tmux-control--wb-controller)))
+    (when (buffer-live-p ctrl)
+      (with-current-buffer ctrl
+        (setq tmux-control--activity-quiet-until (+ (float-time) (or secs 0.8)))))))
 
 (defun tmux-control--note-pane-activity (pane)
   "Flag PANE's window as having unseen output when it is not the current one.

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -1965,8 +1965,16 @@ Called around client-driven full repaints -- connect, window switch, resize --
 so the resulting prompt/redraw burst in every pane does not flag every window
 as if its agent had done something.  The burst can trail the triggering event
 by a few hundred ms (the refresh-client round-trip plus a prompt redraw), so
-the window is deliberately generous."
-  (setq tmux-control--activity-quiet-until (+ (float-time) (or secs 0.8))))
+the window is deliberately generous.
+
+The deadline is stored on the CONTROLLER, because that is where the %output
+path reads it (`tmux-control--note-pane-activity' /
+`tmux-control--note-session-activity' run in the controller's process filter).
+A command may call this from a per-window render buffer, so writing it on the
+current buffer would land it where the gate is never read -- and the burst it
+was meant to suppress would flag windows anyway."
+  (with-current-buffer (tmux-control--wb-controller)
+    (setq tmux-control--activity-quiet-until (+ (float-time) (or secs 0.8)))))
 
 (defun tmux-control--note-pane-activity (pane)
   "Flag PANE's window as having unseen output when it is not the current one.


### PR DESCRIPTION
Found by an adversarial bug-hunt workflow (verified, ~0.77 confidence).

`tmux-control--quiet-activity` wrote `tmux-control--activity-quiet-until` on the **current buffer**, but the readers (`tmux-control--note-pane-activity` / `tmux-control--note-session-activity`) run in the **controller's** process filter (`tmux-control--batch-pane-output`). With per-window render buffers (the default), a window-switch/resize command invoked from a render buffer set the deadline *there*, where the gate is never read — so the post-switch/post-resize repaint burst the quiet window exists to suppress would spuriously flag background windows/sessions anyway.

Fix: write the deadline on the controller (`tmux-control--wb-controller`). For callers already in the controller it's a no-op.

Failing-first test added. 190/190 ERT green, clean byte-compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
