### PR TITLE
Keyboard window jumps (C-c N / C-c C-w / C-c TAB) + real scrollback l exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ attaches, typing a new name creates it.
 - **Windows as tabs** in a header-line tab bar, prefixed with a persistent
   `host:session` label so you always know which server and session you are
   looking at, with an activity **dot** on
-  background windows; flip them like browser tabs (`C-c C-n` / `C-c C-p`).
+  background windows; flip them like browser tabs (`C-c C-n` / `C-c C-p`),
+  jump straight to one with `C-c 0`…`C-c 9`, or pick from a chooser (`C-c C-w`).
   Each visited window keeps its own scrollback across flips and **keeps
   streaming in the background** — flip back and see everything it printed
   while you were away.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -37,10 +37,12 @@ bound in the live buffer; the rest are `M-x`, bind them to taste):
   (`tmux-control-previous-window`) flip to the next or previous window in the
   session, wrapping around — like a terminal's next/previous-tab keys, with no
   menu and without rearranging your Emacs windows (a code buffer beside the
-  live view stays put).  `M-x tmux-control-last-window` toggles back to the
-  window you came from.  These delegate to tmux's own
-  `next-window`/`previous-window`/`last-window`, so they follow the session's
-  window order and any other attached client stays in sync.
+  live view stays put).  `C-c TAB` (`tmux-control-last-window`) toggles back to
+  the window you came from — the alt-tab of windows.  Jump straight to a window
+  by number with `C-c 0` … `C-c 9`, or pick from the visual chooser with
+  `C-c C-w` (`tmux-control-select-window`).  These delegate to tmux's own
+  `next-window`/`previous-window`/`last-window`/`select-window`, so they follow
+  the session's window order and any other attached client stays in sync.
 
   **Each visited window keeps its own buffer** (`tmux-control-window-buffers`,
   default on): a switch swaps buffers instead of repainting one in place, so
@@ -205,7 +207,7 @@ along and the live view repaints on the chosen pane.
 - `C-c |` (`tmux-control-split-pane-right`) — split side by side, the new pane
   on the right.
 - `C-c -` (`tmux-control-split-pane-below`) — split stacked, the new pane below.
-- `M-x tmux-control-kill-pane` — close the active pane (with confirmation).
+- `C-c x` (`tmux-control-kill-pane`) — close the active pane (with confirmation).
 
 A split runs tmux's own `split-window` over the control connection and, by
 default, enters the tiled view (below) so both panes show at once — otherwise

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -1865,6 +1865,28 @@ each wrapped in an evolving prompt line and a status bar.")
               (tmux-control--quiet-activity 5))))   ; must not error
       (kill-buffer ctrl) (kill-buffer render))))
 
+(ert-deftest tmux-control-test-window-jump-keys-bound ()
+  ;; The window-jump keys are bound in BOTH the override map (high precedence,
+  ;; over Eat) and the major-mode map, and `l' really exits scrollback.
+  (dolist (map (list tmux-control--override-map tmux-control-mode-map))
+    (should (eq (lookup-key map (kbd "C-c C-w")) 'tmux-control-select-window))
+    (should (eq (lookup-key map (kbd "C-c TAB")) 'tmux-control-last-window))
+    (should (eq (lookup-key map (kbd "C-c x")) 'tmux-control-kill-pane))
+    (should (eq (lookup-key map (kbd "C-c 0")) 'tmux-control-select-window-by-key))
+    (should (eq (lookup-key map (kbd "C-c 7")) 'tmux-control-select-window-by-key)))
+  (should (eq (lookup-key tmux-control-scrollback-mode-map (kbd "l"))
+              'tmux-control-live)))
+
+(ert-deftest tmux-control-test-select-window-by-key-uses-digit ()
+  ;; The digit that invoked the command is the window index it switches to.
+  (let (got)
+    (cl-letf (((symbol-function 'tmux-control-select-window)
+               (lambda (idx) (setq got idx))))
+      (let ((last-command-event ?5)) (tmux-control-select-window-by-key))
+      (should (equal got "5"))
+      (let ((last-command-event ?0)) (tmux-control-select-window-by-key))
+      (should (equal got "0")))))
+
 (ert-deftest tmux-control-test-flock-other-frame-ordering ()
   ;; flock-other-frame: with a prefix it connects all first, then focuses the
   ;; dedicated frame and flocks; without a prefix it skips connect-all.

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -664,6 +664,13 @@ kills, which are deliberate.")
     (define-key map (kbd "C-c C-r") #'tmux-control-reconnect)
     (define-key map (kbd "C-c C-s") #'tmux-control-select-session)
     (define-key map (kbd "C-c C-f") #'tmux-control-toggle-flock)
+    ;; Window jumps: a chooser, "last window" (alt-tab), and direct C-c N.
+    (define-key map (kbd "C-c C-w") #'tmux-control-select-window)
+    (define-key map (kbd "C-c TAB") #'tmux-control-last-window)
+    (define-key map (kbd "C-c x") #'tmux-control-kill-pane)
+    (dotimes (i 10)
+      (define-key map (kbd (format "C-c %d" i))
+        #'tmux-control-select-window-by-key))
     ;; Split the active pane: `|' is the side-by-side divider, `-' the stacked
     ;; one (the popular tmux `.conf' rebinding).
     (define-key map (kbd "C-c |") #'tmux-control-split-pane-right)
@@ -756,6 +763,13 @@ the cross-session activity strip (see `tmux-control-session-activity').")
     (define-key map (kbd "C-c C-r") #'tmux-control-reconnect)
     (define-key map (kbd "C-c C-s") #'tmux-control-select-session)
     (define-key map (kbd "C-c C-f") #'tmux-control-toggle-flock)
+    ;; Window jumps: a chooser, "last window" (alt-tab), and direct C-c N.
+    (define-key map (kbd "C-c C-w") #'tmux-control-select-window)
+    (define-key map (kbd "C-c TAB") #'tmux-control-last-window)
+    (define-key map (kbd "C-c x") #'tmux-control-kill-pane)
+    (dotimes (i 10)
+      (define-key map (kbd (format "C-c %d" i))
+        #'tmux-control-select-window-by-key))
     (define-key map (kbd "C-c |") #'tmux-control-split-pane-right)
     (define-key map (kbd "C-c -") #'tmux-control-split-pane-below)
     ;; A bare ESC press should reach the pane immediately; see
@@ -817,6 +831,9 @@ the cross-session activity strip (see `tmux-control-session-activity').")
     (define-key map (kbd "C-c C-e") #'tmux-control-live)
     (define-key map (kbd "RET") #'tmux-control-live)
     (define-key map (kbd "q") #'tmux-control-live)
+    ;; The scrollback header advertises `l' as a return-to-live exit; bind it
+    ;; so it is real, not an accident of self-insert fall-through.
+    (define-key map (kbd "l") #'tmux-control-live)
     (define-key map [escape] #'tmux-control-live)
     (define-key map [wheel-down] #'tmux-control-scrollback-wheel-down)
     (define-key map [double-wheel-down] #'tmux-control-scrollback-wheel-down)
@@ -1725,6 +1742,17 @@ When INDEX is given non-interactively, switch to it directly."
     (tmux-control--do-select-window
      (tmux-control--normalize-window-index
       (tmux-control--read-window-index "Window: "))))))
+
+(defun tmux-control-select-window-by-key ()
+  "Switch to the tmux window whose index is the digit key that invoked this.
+Bound to \\`C-c 0' .. \\`C-c 9' for direct, iTerm/browser-style window jumps;
+falls back to the interactive chooser when not invoked by a digit (e.g. via
+\\[execute-extended-command])."
+  (interactive)
+  (if (and (integerp last-command-event) (<= ?0 last-command-event ?9))
+      (tmux-control-select-window
+       (number-to-string (- last-command-event ?0)))
+    (call-interactively #'tmux-control-select-window)))
 
 (defun tmux-control--do-select-window (index)
   "Select tmux window INDEX in the current buffer's session.


### PR DESCRIPTION
From the Jobs design review (non-header surfaces): the obvious navigation gestures existed in the code but only as cycle keys (`C-c C-n`/`C-c C-p`) or `M-x`. This binds them so windows are directly keyboard-addressable.

- **`C-c 0` … `C-c 9`** — jump straight to window N (new `tmux-control-select-window-by-key` reads the invoking digit; falls back to the chooser if invoked without one). The iTerm/browser move.
- **`C-c C-w`** — `tmux-control-select-window` (the visual chooser was `M-x`-only).
- **`C-c TAB`** — `tmux-control-last-window` (alt-tab of windows; was unbound).
- **`C-c x`** — `tmux-control-kill-pane` (symmetric with the `C-c |` / `C-c -` splits; already confirms).
- **`l`** in the scrollback pager → `tmux-control-live`, so the header's advertised `q/l/RET:live` exit is real (it was unbound).

Bound in both the override map (precedence over Eat) and the major-mode map.

## Verification
Live in a real GUI Emacs: `C-c 3` switched the current window to `"3"`; digit dispatch and last-window toggle (`2`→`1`→back to `2`) confirmed. Unit tests for the bindings + digit dispatch. 194/194 ERT green, clean byte-compile. Docs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
