### PR TITLE
Security: Dependabot, OpenSSF Scorecard, SECURITY.md, pinned CI actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# Keep GitHub Actions (the CI supply chain) patched and pinned.
+# Dependabot opens PRs to bump the actions this repo uses and flags any with
+# known vulnerabilities. There is no package ecosystem to track for the Emacs
+# Lisp itself (Eat is pulled by the user's straight/package.el), so only the
+# workflow actions are managed here.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         emacs-version: ['29.1', '30.1']
         tmux: ['distro', '3.6a']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # Pinned to a commit SHA: the action only publishes a moving master.
       - uses: purcell/setup-emacs@509bfe03ba1ffddb67b3c6d9eaaeb96b45182cc7

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,44 @@
+# OpenSSF Scorecard: scores this repo's supply-chain / CI security posture
+# (pinned dependencies, token permissions, dangerous workflow patterns, etc.)
+# and uploads results to the Security tab's code-scanning view. Free for public
+# repos. Actions are pinned to commit SHAs (with the human tag in a comment);
+# Dependabot keeps them current.
+name: Scorecard supply-chain security
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '23 5 * * 1'   # weekly, Monday 05:23 UTC
+  push:
+    branches: [ main ]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write   # upload the SARIF result
+      id-token: write          # publish results to the OpenSSF API
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+      - name: Upload SARIF artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: scorecard-sarif
+          path: results.sarif
+          retention-days: 5
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -19,6 +19,8 @@ jobs:
     name: Scorecard analysis
     runs-on: ubuntu-latest
     permissions:
+      contents: read           # checkout (job-level permissions replace the
+                               # workflow default, so name it explicitly)
       security-events: write   # upload the SARIF result
       id-token: write          # publish results to the OpenSSF API
     steps:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Please report security issues **privately** via GitHub's
+[**Report a vulnerability**](https://github.com/csheaff/tmux-control/security/advisories/new)
+button on the repository's Security tab (private vulnerability reporting),
+rather than opening a public issue. This is a single-maintainer project, so
+response is best-effort, but security reports are prioritized.
+
+## Supported versions
+
+`tmux-control` is a rolling single-file package; fixes land on the `main`
+branch. Please test against `main` before reporting.
+
+## Threat model / what to look for
+
+`tmux-control` sits between Emacs and a tmux server that is often **remote
+(SSH)** and may be shared or driven by automated agents. The inputs that an
+attacker could influence — and therefore the areas most worth scrutiny — are:
+
+- **Names and titles** — tmux session, window, and pane names/titles, and the
+  host/socket strings. These are interpolated into control-mode commands and
+  into `ssh`/`call-process` argv. The primary risk class is **command /
+  argument injection** when a name is not quoted for tmux's parser or for the
+  shell (see the `tmux-control--quote-tmux-arg` / `--window-target` helpers and
+  their call sites).
+- **The control-mode reply/notification stream** — `%output`, `%begin`/`%end`/
+  `%error`, `%layout-change`, `list-windows`/`list-panes` replies, etc. A
+  hostile or buggy remote controls this stream entirely; parsing must not crash,
+  hang, grow unbounded, or evaluate attacker data.
+- **Pane content and escape sequences** fed into the Eat terminal emulator, and
+  **remote file paths** (e.g. `pane_current_path`) used for `default-directory`.
+
+If you find a way for any of the above to achieve code execution, command
+injection, unsafe file access, data exfiltration, or a crash/hang of Emacs,
+that is in scope — please report it.
+
+## Automated checks
+
+This repository runs Dependabot (GitHub Actions supply chain) and OpenSSF
+Scorecard, and has GitHub secret scanning with push protection enabled.


### PR DESCRIPTION
You're right that this package is a plausible target: it builds shell/ssh/tmux commands from names an attacker could influence (the quoting bugs we keep fixing are exactly that class) and parses a fully attacker-controlled remote control-mode stream. This adds the free GitHub-side checks for the **supply chain and CI** surface.

## What's added
- **`.github/dependabot.yml`** — weekly `github-actions` updates, so the CI actions stay patched and any with known CVEs are flagged automatically.
- **`.github/workflows/scorecard.yml`** — OpenSSF Scorecard scores supply-chain / workflow posture (pinned deps, token permissions, dangerous-workflow patterns) and uploads SARIF to the Security tab. All actions pinned to commit SHAs (human tag in a comment).
- **Pinned `actions/checkout`** to its commit SHA in `ci.yml` (was `@v4`).
- **`SECURITY.md`** — private-reporting instructions + the threat model (command/argument injection via names; the untrusted reply stream).

## Also enabled on the repo (settings, not in this diff)
Private vulnerability reporting, Dependabot vulnerability alerts + automated security fixes. (Secret scanning + push protection were already on.)

## Honest scope note
**CodeQL does not support Emacs Lisp**, so there's no off-the-shelf SAST for the `.el` itself. The real protection for the package logic is (a) the quoting discipline (`tmux-control--quote-tmux-arg` / `--window-target` and consistent use at call sites) and (b) a dedicated security audit of the injection/parsing surface, which I ran separately — findings will come as their own fix PRs. This PR hardens the supply chain and CI; that audit hardens the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
