### PR TITLE
security: defuse command injection via names (newline) and ssh host (-option)

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -56,7 +56,24 @@
   ;; A double quote is backslash-escaped.
   (should (equal (tmux-control--quote-tmux-arg "has\"quote") "\"has\\\"quote\""))
   ;; A backslash is doubled.
-  (should (equal (tmux-control--quote-tmux-arg "back\\slash") "\"back\\\\slash\"")))
+  (should (equal (tmux-control--quote-tmux-arg "back\\slash") "\"back\\\\slash\""))
+  ;; SECURITY: control characters are stripped. Control mode is line-based, so
+  ;; a newline in a name would otherwise break out of the quoted argument and
+  ;; inject a second control-mode command (e.g. run-shell = RCE on the host).
+  (should (equal (tmux-control--quote-tmux-arg "a\nrun-shell foo") "\"arun-shell foo\""))
+  (should (equal (tmux-control--quote-tmux-arg "a\r\tb\0c") "\"abc\""))
+  ;; ...and a normal name is untouched.
+  (should (equal (tmux-control--quote-tmux-arg "my proj") "\"my proj\"")))
+
+(ert-deftest tmux-control-test-check-host-rejects-option-like ()
+  ;; SECURITY: an ssh destination starting with `-' is read by ssh as an option
+  ;; (e.g. -oProxyCommand=...), which runs a local command -> local RCE. Reject.
+  (should (equal (tmux-control--check-host "dev") "dev"))
+  (should (equal (tmux-control--check-host "user@host.example") "user@host.example"))
+  (should (equal (tmux-control--check-host nil) nil))
+  (should-error (tmux-control--check-host "-oProxyCommand=touch /tmp/pwned")
+                :type 'user-error)
+  (should-error (tmux-control--check-host "-Fevil") :type 'user-error))
 
 (ert-deftest tmux-control-test-window-target-quotes-session ()
   ;; A session name with a space must be quoted so tmux's control-mode parser

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -73,7 +73,9 @@
   (should (equal (tmux-control--check-host nil) nil))
   (should-error (tmux-control--check-host "-oProxyCommand=touch /tmp/pwned")
                 :type 'user-error)
-  (should-error (tmux-control--check-host "-Fevil") :type 'user-error))
+  (should-error (tmux-control--check-host "-Fevil") :type 'user-error)
+  ;; A non-nil, non-string host is rejected rather than reaching the process layer.
+  (should-error (tmux-control--check-host 42) :type 'user-error))
 
 (ert-deftest tmux-control-test-window-target-quotes-session ()
   ;; A session name with a space must be quoted so tmux's control-mode parser

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -3457,9 +3457,14 @@ An ssh destination beginning with `-' (e.g. \"-oProxyCommand=...\",
 \"-F<file>\", \"-i<file>\") is taken as an OPTION, not a hostname, and
 OpenSSH runs a ProxyCommand locally via /bin/sh before connecting -- so a
 crafted host string would be local code execution in the user's context.
-A real host or ssh alias never starts with `-'.  Returns HOST when safe."
-  (when (and host (stringp host) (string-prefix-p "-" host))
-    (user-error "Refusing ssh host that looks like an option: %S" host))
+A real host or ssh alias never starts with `-'.  Returns HOST when safe;
+nil (a local connection) passes through, and any non-nil, non-string value
+is rejected rather than silently reaching the process layer."
+  (when host
+    (unless (stringp host)
+      (user-error "Invalid ssh host (not a string): %S" host))
+    (when (string-prefix-p "-" host)
+      (user-error "Refusing ssh host that looks like an option: %S" host)))
   host)
 
 (defun tmux-control--command (host socket-name session)

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -891,7 +891,7 @@ text (creating a new session) when they do not."
         (let ((text (if (and host (not (string-empty-p host)))
                         (tmux-control--call
                          "ssh"
-                         (list host
+                         (list (tmux-control--check-host host)
                                (concat tmux-control-remote-tmux-socket-setup
                                        " && "
                                        (tmux-control--tmux-command-string args))))
@@ -1661,8 +1661,19 @@ prompt."
   index)
 
 (defun tmux-control--quote-tmux-arg (string)
-  "Return STRING quoted for the tmux command parser."
-  (concat "\"" (replace-regexp-in-string "[\"\\]" "\\\\\\&" string) "\""))
+  "Return STRING quoted for the tmux command parser.
+Control characters are stripped first.  Control mode is line-based, and a
+double-quoted argument does not neutralize a newline, so a newline (or
+other C0/DEL) in a name would break out of the quoted argument and let an
+attacker- or agent-supplied name inject a SECOND control-mode command
+\(e.g. `run-shell', i.e. code execution on the tmux host).  tmux does not
+permit control characters in these names, so removing them only defuses
+hostile input and never alters a legitimate name."
+  (concat "\""
+          (replace-regexp-in-string
+           "[\"\\]" "\\\\\\&"
+           (replace-regexp-in-string "[\0-\37\177]" "" string))
+          "\""))
 
 (defun tmux-control--quote-tmux-name (name)
   "Quote NAME for a tmux command that FORMAT-EXPANDS its argument.
@@ -3440,13 +3451,24 @@ so the tmux-control keys get out of the way; the mode line shows
             #'ignore))
     (tmux-control--disable-line-numbers)))
 
+(defun tmux-control--check-host (host)
+  "Signal a `user-error' if HOST could be misread by ssh as an option.
+An ssh destination beginning with `-' (e.g. \"-oProxyCommand=...\",
+\"-F<file>\", \"-i<file>\") is taken as an OPTION, not a hostname, and
+OpenSSH runs a ProxyCommand locally via /bin/sh before connecting -- so a
+crafted host string would be local code execution in the user's context.
+A real host or ssh alias never starts with `-'.  Returns HOST when safe."
+  (when (and host (stringp host) (string-prefix-p "-" host))
+    (user-error "Refusing ssh host that looks like an option: %S" host))
+  host)
+
 (defun tmux-control--command (host socket-name session)
   "Return process command for HOST, SOCKET-NAME, and SESSION."
   (let ((tmux-args `("tmux" "-L" ,socket-name "-C"
                      "new-session" "-A" "-s" ,session)))
     (if (or (null host) (string-empty-p host))
         tmux-args
-      (list "ssh" host
+      (list "ssh" (tmux-control--check-host host)
             (concat tmux-control-remote-tmux-socket-setup
                     "; exec "
                     (mapconcat #'shell-quote-argument tmux-args " "))))))


### PR DESCRIPTION
Two **RCE-class** findings from the security audit (each skeptic-verified for reachability + exploitability).

## 1. Control-mode command injection via a newline in a name
Control mode is line-based, and tmux's double-quoting does **not** neutralize a newline. A session/window name containing `\n` breaks out of the quoted argument and injects a **second** tmux command — e.g. `run-shell <cmd>` runs an arbitrary shell command on the tmux host (the remote SSH box). The quoting helpers handled spaces/quotes/`#` but not control characters.

**Fix:** strip C0/DEL control characters in `tmux-control--quote-tmux-arg` — the single chokepoint behind `--quote-tmux-name` and `--window-target`. tmux doesn't permit control characters in these names, so this only defuses hostile input and never alters a legitimate name.

## 2. Local code execution via an option-like ssh host
`host` is passed as the ssh destination, so a value beginning with `-` (e.g. `-oProxyCommand=touch /tmp/pwned`, `-F<file>`, `-i<file>`) is read by ssh as an **option** — and OpenSSH runs a ProxyCommand locally via `/bin/sh` before connecting → **local** code execution from an attacker/agent-supplied host string.

**Fix:** new `tmux-control--check-host` rejects a host starting with `-` (`user-error`), wired into `tmux-control--command` and `tmux-control--list-sessions`; every downstream ssh call uses the connection's already-validated host.

## Verification
Failing-first tests: `tmux-control-test-quote-tmux-arg` (newline/control-char stripping, legit names untouched) and `tmux-control-test-check-host-rejects-option-like`. 195/195 ERT green, clean byte-compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
