### PR TITLE
security: escape % in attacker-derived mode/header-line fields

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -1906,6 +1906,37 @@ each wrapped in an evolving prompt line and a status bar.")
       (let ((last-command-event ?0)) (tmux-control-select-window-by-key))
       (should (equal got "0")))))
 
+(ert-deftest tmux-control-test-mode-line-safe-doubles-percent ()
+  (should (equal (tmux-control--mode-line-safe "a%b") "a%%b"))
+  (should (equal (tmux-control--mode-line-safe "%999m") "%%999m"))
+  (should (null (tmux-control--mode-line-safe nil))))
+
+(ert-deftest tmux-control-test-window-tab-bar-escapes-percent ()
+  ;; SECURITY: a window name (attacker-influenced) reaches the header line, an
+  ;; :eval result whose %-constructs the mode-line engine expands. A name like
+  ;; "%b%f" must be doubled to "%%b%%f" so the engine shows it literally rather
+  ;; than leaking the buffer name / visited file.
+  ;; (format-mode-line returns "" in batch, so assert on the produced string.)
+  (with-temp-buffer
+    (setq-local tmux-control--windows '((:index "0" :name "%b%f" :active t)))
+    (let* ((tmux-control--tiled nil)
+           (raw (substring-no-properties (tmux-control--window-tab-bar))))
+      (should (string-match-p "%%b%%f" raw))
+      ;; no lone "%b" / "%f" that the engine would expand
+      (should-not (string-match-p "[^%]%[bf]" raw)))))
+
+(ert-deftest tmux-control-test-pane-mode-line-escapes-percent ()
+  ;; SECURITY: the pane id, command, and (app-settable, via OSC 2) title all
+  ;; reach the mode line; each "%" must be doubled -- a field width like %999m
+  ;; would otherwise pad to a huge string (a DoS at %999999999m).
+  (with-temp-buffer
+    (setq-local tmux-control--active-pane "%3")
+    (setq-local tmux-control--pane-info '(:cmd "x%n" :title "%999m"))
+    (let ((raw (substring-no-properties (tmux-control--pane-mode-line))))
+      (should (string-match-p "%%3" raw))
+      (should (string-match-p "x%%n" raw))
+      (should (string-match-p "%%999m" raw)))))
+
 (ert-deftest tmux-control-test-flock-other-frame-ordering ()
   ;; flock-other-frame: with a prefix it connects all first, then focuses the
   ;; dedicated frame and flocks; without a prefix it skips connect-all.

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -2074,6 +2074,15 @@ session names are per-server, so a bare \"0\" is ambiguous across hosts."
           (if (and host (not (string-empty-p host))) host "local")
           session))
 
+(defun tmux-control--mode-line-safe (string)
+  "Return STRING safe to place in a mode-line/header-line `:eval' result.
+Doubles `%' so an attacker- or program-supplied tmux name, title, or command
+\(any of which may contain `%') is shown literally instead of being taken as a
+mode-line %-construct.  Without this, pane/window content could spoof the
+displayed session/window identity, leak buffer or file state via constructs
+like %b/%f, or hang Emacs with a huge field width such as %999999999m."
+  (and string (replace-regexp-in-string "%" "%%" string)))
+
 (defun tmux-control--tab-mouse-face ()
   "Return a fresh `highlight'-equivalent face for a tab's `mouse-face'.
 Header-line mouse highlighting spans the maximal run of text sharing one
@@ -2138,7 +2147,8 @@ The session NAME is plain and a bright `●' marks that it wants attention;
 clicking switches to it."
   (let* ((sid (buffer-local-value 'tmux-control--session buffer))
          (host (buffer-local-value 'tmux-control--host buffer))
-         (tok (concat " " (propertize sid 'face 'tmux-control-tab-session)
+         (tok (concat " " (propertize (tmux-control--mode-line-safe sid)
+                                      'face 'tmux-control-tab-session)
                       (propertize " ●" 'face 'tmux-control-tab-activity)))
          (map (make-sparse-keymap)))
     (define-key map [header-line mouse-1]
@@ -2173,7 +2183,8 @@ host/server is prefixed with that server, dimmed, once."
      (lambda (key)
        (concat
         (unless (equal key cur)
-          (propertize (format "  %s" key) 'face 'tmux-control-tab-inactive))
+          (propertize (format "  %s" (tmux-control--mode-line-safe key))
+                      'face 'tmux-control-tab-inactive))
         (mapconcat #'tmux-control--corner-session
                    (reverse (gethash key groups)) "")))
      (nreverse order) "")))
@@ -2251,7 +2262,8 @@ window list and activity state live on the controller; render from there."
               (face (cond (active 'tmux-control-tab-active)
                           (busy 'tmux-control-tab-activity)
                           (t 'tmux-control-tab-inactive)))
-              (tab (propertize (format " %s:%s%s " idx name mark)
+              (tab (propertize (format " %s:%s%s " idx
+                                       (tmux-control--mode-line-safe name) mark)
                                'face face
                                'mouse-face (tmux-control--tab-mouse-face)
                                'help-echo (format "Switch to tmux window %s (%s)"
@@ -2270,8 +2282,10 @@ is plain; a nil or empty host is the local server, shown as \"local:\" so the
 server is always named (see `tmux-control--connection-name')."
   (let* ((host tmux-control--host)
          (hl (if (and host (not (string-empty-p host))) host "local"))
-         (s (concat (propertize (format " %s:" hl) 'face 'tmux-control-tab-inactive)
-                    (propertize tmux-control--session 'face 'tmux-control-tab-session))))
+         (s (concat (propertize (format " %s:" (tmux-control--mode-line-safe hl))
+                                'face 'tmux-control-tab-inactive)
+                    (propertize (tmux-control--mode-line-safe tmux-control--session)
+                                'face 'tmux-control-tab-session))))
     (propertize s 'help-echo
                 (format "tmux session %s"
                         (tmux-control--connection-name host tmux-control--session)))))
@@ -6339,12 +6353,13 @@ where Eat's own reflow could have drifted from tmux's grid.")
 Leads with the pane id (so teammates in a split window are easy to tell
 apart), then the running command and, when distinct, the pane title."
   (let* ((info tmux-control--pane-info)
-         ;; Pane ids contain "%", which is a mode-line format construct, so
-         ;; double it to display literally.
-         (pane (replace-regexp-in-string
-                "%" "%%" (or tmux-control--active-pane "?")))
-         (cmd (plist-get info :cmd))
-         (title (plist-get info :title)))
+         ;; The pane id (always contains "%"), the running command, and the
+         ;; pane title (an app sets it freely via OSC 2) all reach the mode
+         ;; line, so each must have its "%" doubled or it is taken as a
+         ;; %-construct (see `tmux-control--mode-line-safe').
+         (pane (tmux-control--mode-line-safe (or tmux-control--active-pane "?")))
+         (cmd (tmux-control--mode-line-safe (plist-get info :cmd)))
+         (title (tmux-control--mode-line-safe (plist-get info :title))))
     (concat " "
             (propertize (format "[%s]" pane) 'face 'mode-line-emphasis)
             (when (and cmd (not (string-empty-p cmd))) (concat " " cmd))


### PR DESCRIPTION
Audit finding (skeptic-verified): window names, the **pane title** (set freely by any program via OSC 2), `pane_current_command`, and the host/session label all flow **raw** into mode-line / header-line `:eval` results — where Emacs's redisplay engine expands `%`-constructs. The code already doubled `%` for the pane id, but **nowhere else** (the lone exception was the giveaway).

A crafted name/title could therefore:
- **spoof** the displayed session/window/pane identity (you act on the wrong one),
- **leak** buffer/file state into the UI (`%b` buffer name, `%f` visited file, `%F` frame title), or
- **hang Emacs** via a huge field width — a title of `%999999999m` expands to a ~1-billion-char string (DoS).

**Fix:** add `tmux-control--mode-line-safe` (doubles `%`) and apply it to every attacker-derived field reaching a mode/header-line: window name (`--window-tab-bar`), host + session (`--session-label`), session name (`--corner-session`), server label (`--corner-render`), and `:cmd`/`:title` + the pane id (now via the helper) in `--pane-mode-line`.

## Verification
Failing-first tests: `--mode-line-safe` doubling; `--window-tab-bar` and `--pane-mode-line` escape `%` in names/titles (asserted on the produced string, since `format-mode-line` returns "" in batch). 198/198 ERT green, clean byte-compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
