### PR TITLE
security: validate reply pane ids; cap the input accumulator

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -1296,6 +1296,26 @@ each wrapped in an evolving prompt line and a status bar.")
     (should (equal (plist-get p :cmd) ""))
     (should (equal (plist-get p :title) ""))))
 
+(ert-deftest tmux-control-test-parse-window-state-validates-pane-id ()
+  ;; SECURITY: the pane id comes from the untrusted reply stream and is later
+  ;; used as a command TARGET; only a canonical "%N" is accepted, so a crafted
+  ;; id is dropped rather than smuggled into a command.
+  (let* ((fields (lambda (id)
+                   (mapconcat #'identity
+                              (list "LAY" id "0" "0" "80" "24" "1" "0" "0" "1"
+                                    "bash" "title")
+                              "\t")))
+         (panes (cdr (tmux-control--parse-window-state
+                      (list (funcall fields "%2")
+                            (funcall fields "%3; kill-server")
+                            (funcall fields "%4 -t evil")
+                            (funcall fields "@5")))))) ; window id, not a pane id
+    (should (assoc "%2" panes))
+    (should-not (assoc "%3; kill-server" panes))
+    (should-not (assoc "%4 -t evil" panes))
+    (should-not (assoc "@5" panes))
+    (should (= (length panes) 1))))
+
 (ert-deftest tmux-control-test-parse-window-state-tab-in-title ()
   ;; `pane_title' is the last field, but an app can set a title containing a
   ;; literal TAB (OSC 2).  It must be preserved whole, not truncated to its

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -429,11 +429,15 @@ option, so the option and the face do not share a symbol.")
 (defvar-local tmux-control--accumulator "")
 
 (defconst tmux-control--max-pending-line (* 16 1024 1024)
-  "Cap (bytes) on the unparsed tail of the control-mode stream.
-Control-mode replies are newline-terminated; a remote that streams without a
-newline would otherwise grow `tmux-control--accumulator' without bound and
-exhaust Emacs memory.  A single legitimate line never approaches this, so on
-overflow the malformed pending data is dropped.")
+  "Cap (characters) on the buffered control-mode stream.
+Control-mode replies are short and newline-terminated; a remote that streams
+without a newline -- or one absurdly long line -- would otherwise grow
+`tmux-control--accumulator' without bound and exhaust Emacs memory.  The cap
+is enforced as soon as a chunk is appended, so neither the missing-newline
+case nor a single giant line can balloon it; legitimate buffered data never
+approaches this, so on overflow the malformed data is dropped.  Characters,
+not bytes, because the accumulator is a string (`length' is O(1) on the hot
+filter path); for the mostly-ASCII control stream the two are close.")
 (defvar-local tmux-control--display-dirty nil
   "Non-nil when Eat output has been fed but not yet redisplayed.
 Set by `tmux-control--feed-terminal' and cleared by
@@ -4267,6 +4271,15 @@ Lines are compared by their width-insensitive match keys."
     (with-current-buffer (process-buffer process)
       (setq tmux-control--accumulator
             (concat tmux-control--accumulator chunk))
+      ;; Bound the buffered stream up front: a remote that never sends a
+      ;; newline -- or one absurdly long line -- would otherwise exhaust
+      ;; memory.  Enforcing the cap here (before extracting lines) covers both
+      ;; the missing-newline tail and a single giant newline-terminated line;
+      ;; a real control-mode line never approaches it, so drop the malformed
+      ;; buffer rather than process or keep it.
+      (when (> (length tmux-control--accumulator)
+               tmux-control--max-pending-line)
+        (setq tmux-control--accumulator ""))
       (let ((start 0)
             line-end
             ;; Capture follow-windows before any output is fed this pass, so
@@ -4281,12 +4294,6 @@ Lines are compared by their width-insensitive match keys."
           (setq start (1+ line-end)))
         (setq tmux-control--accumulator
               (substring tmux-control--accumulator start))
-        ;; Bound the unparsed tail: a remote that never sends a newline would
-        ;; otherwise grow it without limit (memory DoS).  A real control-mode
-        ;; line is tiny, so an over-cap pending fragment is malformed -- drop it.
-        (when (> (length tmux-control--accumulator)
-                 tmux-control--max-pending-line)
-          (setq tmux-control--accumulator ""))
         ;; Feed any output still batched at the end of the chunk, then do a
         ;; single redisplay -- not one per %output message.  In tiling mode
         ;; the controller renders nothing itself; it flushes each pane's

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -427,6 +427,13 @@ option, so the option and the face do not share a symbol.")
 (defvar-local tmux-control--process nil)
 (defvar-local tmux-control--terminal nil)
 (defvar-local tmux-control--accumulator "")
+
+(defconst tmux-control--max-pending-line (* 16 1024 1024)
+  "Cap (bytes) on the unparsed tail of the control-mode stream.
+Control-mode replies are newline-terminated; a remote that streams without a
+newline would otherwise grow `tmux-control--accumulator' without bound and
+exhaust Emacs memory.  A single legitimate line never approaches this, so on
+overflow the malformed pending data is dropped.")
 (defvar-local tmux-control--display-dirty nil
   "Non-nil when Eat output has been fed but not yet redisplayed.
 Set by `tmux-control--feed-terminal' and cleared by
@@ -4274,6 +4281,12 @@ Lines are compared by their width-insensitive match keys."
           (setq start (1+ line-end)))
         (setq tmux-control--accumulator
               (substring tmux-control--accumulator start))
+        ;; Bound the unparsed tail: a remote that never sends a newline would
+        ;; otherwise grow it without limit (memory DoS).  A real control-mode
+        ;; line is tiny, so an over-cap pending fragment is malformed -- drop it.
+        (when (> (length tmux-control--accumulator)
+                 tmux-control--max-pending-line)
+          (setq tmux-control--accumulator ""))
         ;; Feed any output still batched at the end of the chunk, then do a
         ;; single redisplay -- not one per %output message.  In tiling mode
         ;; the controller renders nothing itself; it flushes each pane's
@@ -6293,7 +6306,12 @@ Pure, so the reply shape is unit-testable without a live tmux."
   (let ((layout nil) (panes nil))
     (dolist (line lines)
       (let ((f (split-string line "\t")))
-        (when (>= (length f) 12)
+        ;; The pane id (field 1) comes straight from the untrusted reply stream
+        ;; and is later used as a command TARGET (send-input, select-pane,
+        ;; capture); accept only a canonical "%N" so a hostile/buggy server
+        ;; cannot smuggle a crafted target.  A real tmux pane id is always %N.
+        (when (and (>= (length f) 12)
+                   (string-match-p "\\`%[0-9]+\\'" (nth 1 f)))
           (unless layout (setq layout (nth 0 f)))
           (push (cons (nth 1 f)
                       (list :left (string-to-number (nth 2 f))


### PR DESCRIPTION
Two findings from the security audit on the **untrusted control-mode reply stream** (a hostile or compromised tmux server controls it entirely).

## Pane-id injection (HIGH)
`tmux-control--parse-window-state` took the pane id straight from the `list-panes` reply and used it downstream as a command **target** (`send-input`, `select-pane`, capture). A crafted id (e.g. `%3; kill-server`, `%4 -t evil`) could be smuggled into a command.

**Fix:** accept only a canonical `%N` at the parse boundary; non-conforming pane lines are dropped. A real tmux pane id is always `%N`.

## Unbounded accumulator → memory DoS (LOW)
`tmux-control--filter` appends each chunk to `tmux-control--accumulator` and only releases complete, newline-terminated lines. A remote that never sends a newline grows it without bound.

**Fix:** cap the unparsed tail at `tmux-control--max-pending-line` (16 MiB) and drop it on overflow; a legitimate control-mode line never approaches that.

## Verification
Failing-first test `tmux-control-test-parse-window-state-validates-pane-id` (valid `%N` kept; `%3; kill-server`, `%4 -t evil`, and a window id `@5` all rejected). 199/199 ERT green, clean byte-compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
