### PR TITLE
security: ignore pane-driven clipboard (OSC 52) by default

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -1926,6 +1926,15 @@ each wrapped in an evolving prompt line and a status bar.")
       (let ((last-command-event ?0)) (tmux-control-select-window-by-key))
       (should (equal got "0")))))
 
+(ert-deftest tmux-control-test-selection-function-gated ()
+  ;; SECURITY: pane-driven OSC 52 clipboard manipulation is ignored unless the
+  ;; user opts in, so untrusted pane output cannot poison/read the kill-ring.
+  (let ((tmux-control-allow-clipboard-write nil))
+    (should (eq (tmux-control--selection-function) #'ignore)))
+  (when (fboundp 'eat--manipulate-kill-ring)
+    (let ((tmux-control-allow-clipboard-write t))
+      (should (eq (tmux-control--selection-function) #'eat--manipulate-kill-ring)))))
+
 (ert-deftest tmux-control-test-mode-line-safe-doubles-percent ()
   (should (equal (tmux-control--mode-line-safe "a%b") "a%%b"))
   (should (equal (tmux-control--mode-line-safe "%999m") "%%999m"))

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -392,7 +392,10 @@ overwrite what you next paste (clipboard poisoning) -- or read your kill-ring
 back out.  Off by default: pane-driven clipboard manipulation is ignored.
 Set non-nil to allow it (the underlying Eat behavior), e.g. for a trusted
 local session where copying pane output to the system clipboard is wanted."
-  :type 'boolean)
+  :type 'boolean
+  ;; Risky: a file-/dir-local variable in an untrusted repo must not be able
+  ;; to silently re-enable pane-driven clipboard access.
+  :risky t)
 
 (defcustom tmux-control-session-activity t
   "Non-nil flags other connected sessions that have unseen output.

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -383,6 +383,17 @@ a tmux session, and the natural companion to `tmux-control-next-window' and
 friends.  Set to nil to hide it."
   :type 'boolean)
 
+(defcustom tmux-control-allow-clipboard-write nil
+  "Non-nil lets a tmux pane drive the Emacs kill-ring / clipboard (OSC 52).
+A program running in any pane can emit an OSC 52 escape to set (or read) the
+selection.  With tmux-control pointed at remote, possibly shared or
+agent-driven servers, that means untrusted pane output could silently
+overwrite what you next paste (clipboard poisoning) -- or read your kill-ring
+back out.  Off by default: pane-driven clipboard manipulation is ignored.
+Set non-nil to allow it (the underlying Eat behavior), e.g. for a trusted
+local session where copying pane output to the system clipboard is wanted."
+  :type 'boolean)
+
 (defcustom tmux-control-session-activity t
   "Non-nil flags other connected sessions that have unseen output.
 When you are looking at one session and another connected session produces
@@ -3471,10 +3482,18 @@ so the tmux-control keys get out of the way; the mode line shows
     (setf (eat-term-parameter tmux-control--terminal 'ring-bell-function)
           (if (fboundp 'eat--bell) #'eat--bell #'ignore))
     (setf (eat-term-parameter tmux-control--terminal 'manipulate-selection-function)
-          (if (fboundp 'eat--manipulate-kill-ring)
-              #'eat--manipulate-kill-ring
-            #'ignore))
+          (tmux-control--selection-function))
     (tmux-control--disable-line-numbers)))
+
+(defun tmux-control--selection-function ()
+  "Return the Eat `manipulate-selection-function' for a pane terminal.
+Ignores pane-driven OSC 52 clipboard manipulation unless the user opts in
+via `tmux-control-allow-clipboard-write' -- so untrusted pane output cannot
+silently poison or read the Emacs kill-ring by default."
+  (if (and tmux-control-allow-clipboard-write
+           (fboundp 'eat--manipulate-kill-ring))
+      #'eat--manipulate-kill-ring
+    #'ignore))
 
 (defun tmux-control--check-host (host)
   "Signal a `user-error' if HOST could be misread by ssh as an option.
@@ -5990,8 +6009,7 @@ it asynchronously over the control connection."
               (if (fboundp 'eat--bell) #'eat--bell #'ignore))
         (setf (eat-term-parameter tmux-control--terminal
                                   'manipulate-selection-function)
-              (if (fboundp 'eat--manipulate-kill-ring)
-                  #'eat--manipulate-kill-ring #'ignore))
+              (tmux-control--selection-function))
         (setf (eat-term-parameter tmux-control--terminal 'eat--process) process)
         (setf (eat-term-parameter tmux-control--terminal 'eat--input-process)
               process)
@@ -6445,8 +6463,7 @@ its own and routes commands through CONTROLLER."
       (setf (eat-term-parameter tmux-control--terminal 'ring-bell-function)
             (if (fboundp 'eat--bell) #'eat--bell #'ignore))
       (setf (eat-term-parameter tmux-control--terminal 'manipulate-selection-function)
-            (if (fboundp 'eat--manipulate-kill-ring)
-                #'eat--manipulate-kill-ring #'ignore))
+            (tmux-control--selection-function))
       (setf (eat-term-parameter tmux-control--terminal 'eat--process) process)
       (setf (eat-term-parameter tmux-control--terminal 'eat--input-process) process)
       (setf (eat-term-parameter tmux-control--terminal 'eat--output-process) process)


### PR DESCRIPTION
The last confirmed audit finding (you gave me the call on this one). A program in any pane can emit an **OSC 52** escape to set (or read) the selection, so untrusted pane output could silently **overwrite what you next paste** (clipboard poisoning) or **read your kill-ring** back out — a real vector since tmux-control points at remote, shared, and agent-driven servers.

**Fix:** gate it behind a new defcustom `tmux-control-allow-clipboard-write` (**default nil**). A single `tmux-control--selection-function` returns `#'ignore` unless you opt in (which restores Eat's `eat--manipulate-kill-ring` behavior). Applied at all three terminal-init sites.

This is a behavior change — by default a pane can no longer touch your clipboard — chosen as the security-correct default and matching the opt-in pattern of `tmux-control-auto-heal-drift`. Flip the option on for a trusted local session where copying pane output to the system clipboard is wanted.

## Verification
Failing-first test `tmux-control-test-selection-function-gated` (ignore by default; Eat's function when opted in). 200/200 ERT green, clean byte-compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
