### PR TITLE
Warn once when the controlled tmux has alternate-screen off (#102)

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -833,6 +833,39 @@ each wrapped in an evolving prompt line and a status bar.")
   (should (equal (tmux-control--interpret-alt-screen-reply '("") t)
                  '(:honored . t))))
 
+(ert-deftest tmux-control-test-alt-screen-warning-throttled ()
+  ;; Issue #102: one warning per connection when alternate-screen is off,
+  ;; never when honored, never when suppressed.
+  (let (warnings)
+    (cl-letf (((symbol-function 'display-warning)
+               (lambda (&rest _) (push t warnings))))
+      ;; honored -> no warning
+      (with-temp-buffer
+        (setq-local tmux-control--alt-screen-honored t)
+        (setq-local tmux-control--alt-screen-warned nil)
+        (let ((tmux-control-warn-on-alternate-screen-off t))
+          (tmux-control--maybe-warn-alternate-screen-off))
+        (should (null warnings)))
+      ;; off + enabled -> exactly one warning across repeated refreshes
+      (with-temp-buffer
+        (setq-local tmux-control--alt-screen-honored nil)
+        (setq-local tmux-control--alt-screen-warned nil)
+        (setq-local tmux-control--host nil)
+        (setq-local tmux-control--session "s")
+        (let ((tmux-control-warn-on-alternate-screen-off t))
+          (tmux-control--maybe-warn-alternate-screen-off)
+          (tmux-control--maybe-warn-alternate-screen-off))
+        (should (= (length warnings) 1))
+        (should tmux-control--alt-screen-warned))
+      ;; suppressed -> never
+      (setq warnings nil)
+      (with-temp-buffer
+        (setq-local tmux-control--alt-screen-honored nil)
+        (setq-local tmux-control--alt-screen-warned nil)
+        (let ((tmux-control-warn-on-alternate-screen-off nil))
+          (tmux-control--maybe-warn-alternate-screen-off))
+        (should (null warnings))))))
+
 (ert-deftest tmux-control-test-alt-screen-effective-p ()
   ;; Truly on the alternate screen only when tmux honors it AND Eat reports
   ;; it.  The phantom case (Eat says alt, tmux says not honored) is nil.

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -233,7 +233,7 @@ frame boundary and drop volatile per-frame lines with
   :type 'integer)
 
 (defcustom tmux-control-warn-on-alternate-screen-off t
-  "Non-nil warns once when the controlled tmux has `alternate-screen off'.
+  "Non-nil means warn once when the controlled tmux has `alternate-screen off'.
 With that option off, full-screen TUIs (Copilot CLI, vim, less, htop...)
 repaint onto the normal screen, so their frames pile up in pane history and
 the live view / scrollback fills with overlapping copies -- a confusing,

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -232,6 +232,17 @@ frame boundary and drop volatile per-frame lines with
   "Maximum line window used to merge repeated redraw chunks in scrollback view."
   :type 'integer)
 
+(defcustom tmux-control-warn-on-alternate-screen-off t
+  "Non-nil warns once when the controlled tmux has `alternate-screen off'.
+With that option off, full-screen TUIs (Copilot CLI, vim, less, htop...)
+repaint onto the normal screen, so their frames pile up in pane history and
+the live view / scrollback fills with overlapping copies -- a confusing,
+silent failure that is easy to misdiagnose.  When tmux-control sees the
+active window does not honor alternate-screen it emits a single warning per
+connection recommending `setw -g alternate-screen on' (or, if the setting is
+intentional, `tmux-control-compact-scrollback').  Set to nil to suppress."
+  :type 'boolean)
+
 (defcustom tmux-control-scrollback-frame-start-regexp nil
   "Regexp matching the top line of a repeated full-screen redraw, or nil.
 
@@ -610,6 +621,11 @@ tmux keeps the pane on its normal screen even while an application
 requests the alternate screen, so Eat's alternate-display state is a
 phantom and must be ignored.  Refreshed over the control connection
 whenever the active pane changes.")
+
+(defvar-local tmux-control--alt-screen-warned nil
+  "Non-nil once this connection warned about `alternate-screen off'.
+Throttles `tmux-control-warn-on-alternate-screen-off' to one warning per
+connection (held on the controller).")
 
 ;; Per-window render buffers (`tmux-control-window-buffers').  The connect
 ;; buffer keeps the process and session state and renders its own tmux
@@ -1628,6 +1644,26 @@ tmux runs with `alternate-screen off'."
     (tmux-control--send-command
      (format "show-options -wv -t %s alternate-screen" tmux-control--active-pane)
      :alt-screen-opt)))
+
+(defun tmux-control--maybe-warn-alternate-screen-off ()
+  "Warn once if the active window does not honor `alternate-screen'.
+Throttled per connection via `tmux-control--alt-screen-warned'; gated on
+`tmux-control-warn-on-alternate-screen-off'.  Call after
+`tmux-control--alt-screen-honored' is refreshed."
+  (when (and tmux-control-warn-on-alternate-screen-off
+             (not tmux-control--alt-screen-honored)
+             (not tmux-control--alt-screen-warned))
+    (setq tmux-control--alt-screen-warned t)
+    (display-warning
+     'tmux-control
+     (format
+      "The controlled tmux (%s) has `alternate-screen off'.  Full-screen TUIs \
+(Copilot CLI, vim, less...) will repaint into pane history and produce \
+repeated/garbled scrollback.  Consider `setw -g alternate-screen on' on the \
+host; if the setting is intentional, enable `tmux-control-compact-scrollback'.  \
+Set `tmux-control-warn-on-alternate-screen-off' to nil to silence this."
+      (tmux-control--connection-name tmux-control--host tmux-control--session))
+     :warning)))
 
 (defun tmux-control--window-choices ()
   "Return an alist of (DISPLAY . INDEX) for the current session's windows."
@@ -4750,10 +4786,12 @@ swallowed as content and the reply queue would desynchronize."
              ;; from the global-window default.
              (tmux-control--send-command "show-options -gwv alternate-screen"
                                          :alt-screen-opt-global)
-           (setq tmux-control--alt-screen-honored (cdr res)))))
+           (setq tmux-control--alt-screen-honored (cdr res))
+           (tmux-control--maybe-warn-alternate-screen-off))))
       (:alt-screen-opt-global
        (setq tmux-control--alt-screen-honored
-             (cdr (tmux-control--interpret-alt-screen-reply output t))))
+             (cdr (tmux-control--interpret-alt-screen-reply output t)))
+       (tmux-control--maybe-warn-alternate-screen-off))
       (:version
        (setq tmux-control--capture-trailing-p
              (tmux-control--capture-n-supported-p


### PR DESCRIPTION
Closes #102.

With `alternate-screen off`, full-screen TUIs (Copilot CLI, vim, less, htop…) repaint onto the **normal** screen, so their frames pile up in pane history and the live view / scrollback fills with overlapping copies — a confusing, silent failure (the reported incident took a long session to trace to a stale remote `setw -g alternate-screen off`).

The detection already existed (`tmux-control--alt-screen-honored`); this **acts** on it. When the active window doesn't honor alternate-screen, emit a **single `display-warning` per connection** recommending `alternate-screen on` (or `tmux-control-compact-scrollback` if the setting is intentional).

- Throttled by a per-connection flag (`tmux-control--alt-screen-warned`, on the controller).
- Gated by `tmux-control-warn-on-alternate-screen-off` (default `t`).
- **No extra round trips** — hooked onto the existing `:alt-screen-opt` / `:alt-screen-opt-global` reply handlers.

Meets all four acceptance criteria. Failing-first test `tmux-control-test-alt-screen-warning-throttled` (warns once when off; never when honored; suppressed by the option). 202/202 ERT green, clean byte-compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
