### PR TITLE
Flock self-heal: re-grid when a session joins or dies

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -2012,6 +2012,39 @@ each wrapped in an evolving prompt line and a status bar.")
       (should (string-match-p "x%%n" raw))
       (should (string-match-p "%%999m" raw)))))
 
+(ert-deftest tmux-control-test-any-frame-flocked-p ()
+  (let ((f (selected-frame)))
+    (unwind-protect
+        (progn
+          (set-frame-parameter f 'tmux-control--flock nil)
+          (should-not (tmux-control--any-frame-flocked-p))
+          (set-frame-parameter f 'tmux-control--flock t)
+          (should (tmux-control--any-frame-flocked-p)))
+      (set-frame-parameter f 'tmux-control--flock nil))))
+
+(ert-deftest tmux-control-test-schedule-reflock-gated-and-debounced ()
+  ;; Re-grid is scheduled only when a frame is flocked, and only once per burst.
+  (let ((real (run-with-idle-timer 999 nil #'ignore)))
+    (unwind-protect
+        (progn
+          ;; flocked: schedules once, then debounces while a timer is pending
+          (let ((tmux-control--reflock-timer nil) (calls 0))
+            (cl-letf (((symbol-function 'tmux-control--any-frame-flocked-p) (lambda () t))
+                      ((symbol-function 'run-with-idle-timer)
+                       (lambda (&rest _) (cl-incf calls) real)))
+              (tmux-control--schedule-reflock)
+              (should (= calls 1))
+              (tmux-control--schedule-reflock)   ; timer pending -> no second schedule
+              (should (= calls 1))))
+          ;; not flocked: never schedules (the common, zero-cost path)
+          (let ((tmux-control--reflock-timer nil) (calls 0))
+            (cl-letf (((symbol-function 'tmux-control--any-frame-flocked-p) (lambda () nil))
+                      ((symbol-function 'run-with-idle-timer)
+                       (lambda (&rest _) (cl-incf calls) real)))
+              (tmux-control--schedule-reflock)
+              (should (= calls 0)))))
+      (cancel-timer real))))
+
 (ert-deftest tmux-control-test-flock-other-frame-ordering ()
   ;; flock-other-frame: with a prefix it connects all first, then focuses the
   ;; dedicated frame and flocks; without a prefix it skips connect-all.

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -2013,13 +2013,14 @@ each wrapped in an evolving prompt line and a status bar.")
       (should (string-match-p "%%999m" raw)))))
 
 (ert-deftest tmux-control-test-any-frame-flocked-p ()
+  ;; Observe only our own frame, so an unrelated flocked frame (e.g. running
+  ;; ERT interactively) cannot skew the result.
   (let ((f (selected-frame)))
-    (unwind-protect
-        (progn
-          (set-frame-parameter f 'tmux-control--flock nil)
-          (should-not (tmux-control--any-frame-flocked-p))
-          (set-frame-parameter f 'tmux-control--flock t)
-          (should (tmux-control--any-frame-flocked-p)))
+    (cl-letf (((symbol-function 'frame-list) (lambda () (list f))))
+      (set-frame-parameter f 'tmux-control--flock nil)
+      (should-not (tmux-control--any-frame-flocked-p))
+      (set-frame-parameter f 'tmux-control--flock t)
+      (should (tmux-control--any-frame-flocked-p))
       (set-frame-parameter f 'tmux-control--flock nil))))
 
 (ert-deftest tmux-control-test-schedule-reflock-gated-and-debounced ()

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -1285,7 +1285,6 @@ their screens seed asynchronously, like any connect."
         (unless (tmux-control--session-live-buffer host session)
           (tmux-control-connect host socket session))))))
 
-;;;###autoload
 (defvar tmux-control--reflock-timer nil
   "Idle timer that re-grids flocked frames after a connect/disconnect.")
 
@@ -1326,6 +1325,7 @@ deaths) into one idle re-grid."
     (setq tmux-control--reflock-timer
           (run-with-idle-timer 0.1 nil #'tmux-control--reflock))))
 
+;;;###autoload
 (defun tmux-control-flock (&optional connect-all)
   "Show every connected tmux session at once, one per cell, all live.
 Each cell is an ordinary session buffer (its mode line and window tab bar

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -1104,6 +1104,8 @@ session (tmux attaches if it exists, otherwise creates it)."
       ;; it live via the option's `:set'.
       (when tmux-control-auto-heal-drift
         (tmux-control--ensure-heal-timer)))
+    ;; If a frame is showing the flock, let a newly-connected session join it.
+    (tmux-control--schedule-reflock)
     buffer))
 
 (defun tmux-control--session-live-buffer (host session)
@@ -1284,6 +1286,46 @@ their screens seed asynchronously, like any connect."
           (tmux-control-connect host socket session))))))
 
 ;;;###autoload
+(defvar tmux-control--reflock-timer nil
+  "Idle timer that re-grids flocked frames after a connect/disconnect.")
+
+(defun tmux-control--any-frame-flocked-p ()
+  "Return non-nil when some live frame is showing the flock view."
+  (cl-some (lambda (f)
+             (and (frame-live-p f) (frame-parameter f 'tmux-control--flock)))
+           (frame-list)))
+
+(defun tmux-control--reflock ()
+  "Re-grid every flocked frame to the current set of live sessions.
+Keeps the dashboard from going stale when a session joins (a connect) or
+leaves (a death): a new session gains a cell, a dead one's frozen cell is
+dropped.  Preserves which cell you were in, and runs only from the idle
+timer so it never rearranges windows mid-keystroke."
+  (setq tmux-control--reflock-timer nil)
+  (let ((buffers (tmux-control--live-session-buffers)))
+    (when buffers
+      (dolist (frame (frame-list))
+        (when (and (frame-live-p frame)
+                   (frame-parameter frame 'tmux-control--flock))
+          (with-selected-frame frame
+            (let ((focus (window-buffer (frame-selected-window frame))))
+              (tmux-control--flock-grid buffers)
+              (tmux-control--flock-resize-all)
+              ;; Restore focus to the cell you were in, if it is still shown.
+              (let ((w (get-buffer-window focus frame)))
+                (when (window-live-p w)
+                  (set-frame-selected-window frame w))))))))))
+
+(defun tmux-control--schedule-reflock ()
+  "Debounced re-grid of flocked frames.
+A no-op when no frame is flocked, so the common (un-flocked) connect and
+disconnect paths cost nothing; coalesces a burst (connect-all, several
+deaths) into one idle re-grid."
+  (when (and (tmux-control--any-frame-flocked-p)
+             (not (timerp tmux-control--reflock-timer)))
+    (setq tmux-control--reflock-timer
+          (run-with-idle-timer 0.1 nil #'tmux-control--reflock))))
+
 (defun tmux-control-flock (&optional connect-all)
   "Show every connected tmux session at once, one per cell, all live.
 Each cell is an ordinary session buffer (its mode line and window tab bar
@@ -5994,19 +6036,27 @@ never steals the window the user is looking at."
           ;; tmux session survived cannot be known from here -- a dropped
           ;; link leaves it running, a killed server does not -- so the
           ;; message is conditional.)
-          (unless deliberate
-            (if (and tmux-control-auto-reconnect
-                     (< tmux-control--auto-reconnect-attempts
-                        tmux-control--auto-reconnect-max))
-                (tmux-control--schedule-auto-reconnect (current-buffer))
-              ;; No auto-reconnect (off, or the budget is spent): announce and
-              ;; leave the one-key recovery.  Reset a spent budget so a later
-              ;; manual reconnect starts fresh.
+          (cond
+           ((and (not deliberate)
+                 tmux-control-auto-reconnect
+                 (< tmux-control--auto-reconnect-attempts
+                    tmux-control--auto-reconnect-max))
+            ;; Coming back: keep the cell (it shows its last frame and the
+            ;; "reconnecting" notice), so a flock view does not churn.
+            (tmux-control--schedule-auto-reconnect (current-buffer)))
+           (t
+            ;; No auto-reconnect (off, or the budget is spent): announce and
+            ;; leave the one-key recovery.  Reset a spent budget so a later
+            ;; manual reconnect starts fresh.
+            (unless deliberate
               (setq tmux-control--auto-reconnect-attempts 0)
               (tmux-control--message
                (format "connection lost (%s) -- if the tmux session is still running, C-c C-r reconnects"
                        (string-trim-right message)))
-              (force-mode-line-update t))))))))
+              (force-mode-line-update t))
+            ;; The session is gone for now -- drop its frozen cell from any
+            ;; flock so the dashboard reflects what is actually live.
+            (tmux-control--schedule-reflock))))))))
 
 (defun tmux-control--kill-process ()
   "Delete the tmux control process and any dependent render buffers."


### PR DESCRIPTION
The flock dashboard used to go stale until you toggled it off and on — a newly connected session didn't appear, and a dead one's frozen cell lingered. Now the flocked frame re-grids itself:

- **`tmux-control-connect`** schedules a re-grid → a new session gains a cell.
- **The sentinel** schedules one when a session is *truly* gone (deliberate disconnect, or a death with no pending auto-reconnect) → its frozen cell drops. A session that will **auto-reconnect keeps its cell** (it shows the last frame + the "reconnecting" notice), so the grid doesn't churn.

`tmux-control--schedule-reflock` is **debounced on an idle timer** (coalesces a burst like connect-all or several deaths, and never rearranges windows mid-keystroke) and is a **no-op when nothing is flocked**, so the common un-flocked connect/disconnect paths cost nothing. `tmux-control--reflock` preserves which cell you were in across the re-grid.

This is what lets flock stop being "a dashboard you babysit."

## Verification
Live in a real GUI Emacs: flocked several sessions, **connected a new one → it joined** (4→5 cells); **killed one → its cell dropped** (5→4, the window gone). Tests: `--any-frame-flocked-p`, schedule gating + debounce. 209/209 ERT green, clean byte-compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
