### PR TITLE
ci: authenticate nix's GitHub fetch to stop setup-emacs 429s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,13 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      # purcell/setup-emacs fetches Emacs through nix, which resolves
+      # github.com/purcell/nix-emacs-ci via the GitHub API.  Unauthenticated
+      # that API allows only 60 requests/hour, so the matrix jobs intermittently
+      # 429 during setup.  Authenticate nix's fetches with the workflow token
+      # (5000/hour) so setup is reliable.  contents:read is enough for API reads.
+      NIX_CONFIG: "access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}"
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
purcell/setup-emacs installs Emacs via nix, which resolves github.com/purcell/nix-emacs-ci through the GitHub API. Unauthenticated that is capped at 60 req/hour, so the four matrix jobs intermittently 429 during setup and fail before any test runs — it has needed a manual re-run on most PRs this stretch.

Fix: set NIX_CONFIG with an access-token from the workflow GITHUB_TOKEN (5000/hour) so nix authenticates its fetches. contents:read (the only permission) suffices for API reads.

It is a rate-limit mitigation, so it cannot be proven in one green run — but the mechanism is the documented fix and the change is harmless if a given run would not have 429d.

🤖 Generated with [Claude Code](https://claude.com/claude-code)