### PR TITLE
Tiled view: optional per-pane mode-line hide (gapless grid)

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -237,7 +237,9 @@ In the tiled view:
   window makes it tmux's active pane too (other clients follow).
 - Splitting (`C-c |` / `C-c -`, or from tmux), resizing, or closing a pane
   re-tiles automatically, and the mode line labels each pane by its id,
-  command, and title.
+  command, and title.  Set `tmux-control-tiled-hide-mode-line` non-nil to
+  drop those per-pane mode lines so the cells sit flush (a gapless,
+  iTerm-style grid) at the cost of the labels.
 - Resizing the Emacs frame re-divides the tmux window to match, so the
   panes re-fit instead of clipping.
 - Each pane is a normal `tmux-control` buffer, so `C-c C-e` scrollback and

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -2012,6 +2012,11 @@ each wrapped in an evolving prompt line and a status bar.")
       (should (string-match-p "x%%n" raw))
       (should (string-match-p "%%999m" raw)))))
 
+(ert-deftest tmux-control-test-tiled-hide-mode-line-default ()
+  ;; Default keeps the per-pane labels (the gapless grid is opt-in); guard
+  ;; against an accidental default flip.
+  (should (eq (default-value 'tmux-control-tiled-hide-mode-line) nil)))
+
 (ert-deftest tmux-control-test-any-frame-flocked-p ()
   ;; Observe only our own frame, so an unrelated flocked frame (e.g. running
   ;; ERT interactively) cannot skew the result.

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -438,6 +438,15 @@ local session where copying pane output to the system clipboard is wanted."
   ;; to silently re-enable pane-driven clipboard access.
   :risky t)
 
+(defcustom tmux-control-tiled-hide-mode-line nil
+  "Non-nil hides the per-pane mode line in the tiled view.
+Each tiled pane is an ordinary buffer, so by default it shows its mode line
+\(\"[%id] cmd -- title\"), which labels the pane but also leaves a one-row gap
+between stacked panes.  Set this non-nil to drop that mode line so tiled
+panes sit flush -- a cleaner, iTerm-style cell-for-cell grid -- at the cost
+of the per-pane label.  Off by default (labels kept)."
+  :type 'boolean)
+
 (defcustom tmux-control-session-activity t
   "Non-nil flags other connected sessions that have unseen output.
 When you are looking at one session and another connected session produces
@@ -6709,7 +6718,9 @@ its own and routes commands through CONTROLLER."
       (setf (eat-term-parameter tmux-control--terminal 'eat--process) process)
       (setf (eat-term-parameter tmux-control--terminal 'eat--input-process) process)
       (setf (eat-term-parameter tmux-control--terminal 'eat--output-process) process)
-      (setq-local mode-line-format '(:eval (tmux-control--pane-mode-line)))
+      (setq-local mode-line-format
+                  (unless tmux-control-tiled-hide-mode-line
+                    '(:eval (tmux-control--pane-mode-line))))
       ;; Fringes and a scroll bar would steal columns from the body, so the
       ;; Eat grid (sized to the tmux pane) would not fit and full-width TUI
       ;; borders (e.g. a Claude Code panel) would clip.  Drop them so the

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -441,7 +441,7 @@ local session where copying pane output to the system clipboard is wanted."
 (defcustom tmux-control-tiled-hide-mode-line nil
   "Non-nil hides the per-pane mode line in the tiled view.
 Each tiled pane is an ordinary buffer, so by default it shows its mode line
-\(\"[%id] cmd -- title\"), which labels the pane but also leaves a one-row gap
+\(\"[%id] cmd — title\"), which labels the pane but also leaves a one-row gap
 between stacked panes.  Set this non-nil to drop that mode line so tiled
 panes sit flush -- a cleaner, iTerm-style cell-for-cell grid -- at the cost
 of the per-pane label.  Off by default (labels kept)."


### PR DESCRIPTION
Each tiled pane is an ordinary buffer, so it shows its mode line (`[%id] cmd — title`) — which labels the pane but also leaves a one-row gap between stacked panes. This adds `tmux-control-tiled-hide-mode-line` (**default nil — labels kept**): set it non-nil to drop the per-pane mode line so tiled panes sit **flush**, an iTerm-style cell-for-cell grid, at the cost of the per-pane label.

The default preserves the current labelled look (your call — labels by default); the gapless grid is opt-in.

## Verification
Live in a real GUI Emacs with a 2-pane tiled window: a tiled pane buffer's `mode-line-format` is the `(:eval (tmux-control--pane-mode-line))` label form when the option is **off** (default) and `nil` when **on**. Guide note added; default-guard test. 210/210 ERT green, clean byte-compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
