### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/tmux-control.el
+++ b/tmux-control.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2026  Clay Sheaff
 
 ;; Author: Clay Sheaff
-;; Version: 0.3.0
+;; Version: 0.4.0
 ;; Package-Requires: ((emacs "29.1") (eat "0.9.4"))
 ;; Keywords: terminals, tmux
 ;; URL: https://github.com/csheaff/tmux-control


### PR DESCRIPTION
Tag the first release since v0.2.0. The version header has read 0.3.0 since #84, but the full header redesign (#85–#89), the security-hardening pass (#95–#100), auto-reconnect (#104), and flock self-heal (#105) all landed after that bump and were never tagged — so 0.3.0 was effectively spent without a release. Bumping to **0.4.0** so the security pass ships under its own tag.

Release notes for the GitHub Release are drafted separately; this PR is just the one-line header bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)