### PR TITLE
Throttle alt-screen-off warning across reconnects

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -835,33 +835,53 @@ each wrapped in an evolving prompt line and a status bar.")
 
 (ert-deftest tmux-control-test-alt-screen-warning-throttled ()
   ;; Issue #102: one warning per connection when alternate-screen is off,
-  ;; never when honored, never when suppressed.
-  (let (warnings)
+  ;; never when honored, never when suppressed.  The throttle is keyed by
+  ;; connection name (not a buffer-local flag) so it survives a reconnect,
+  ;; which rebuilds the controller buffer and would otherwise re-warn.
+  (let ((warnings nil)
+        (tmux-control--alt-screen-warned-connections
+         (make-hash-table :test 'equal)))
     (cl-letf (((symbol-function 'display-warning)
                (lambda (&rest _) (push t warnings))))
       ;; honored -> no warning
       (with-temp-buffer
         (setq-local tmux-control--alt-screen-honored t)
-        (setq-local tmux-control--alt-screen-warned nil)
+        (setq-local tmux-control--host nil)
+        (setq-local tmux-control--session "honored")
         (let ((tmux-control-warn-on-alternate-screen-off t))
           (tmux-control--maybe-warn-alternate-screen-off))
         (should (null warnings)))
       ;; off + enabled -> exactly one warning across repeated refreshes
       (with-temp-buffer
         (setq-local tmux-control--alt-screen-honored nil)
-        (setq-local tmux-control--alt-screen-warned nil)
         (setq-local tmux-control--host nil)
         (setq-local tmux-control--session "s")
         (let ((tmux-control-warn-on-alternate-screen-off t))
           (tmux-control--maybe-warn-alternate-screen-off)
           (tmux-control--maybe-warn-alternate-screen-off))
-        (should (= (length warnings) 1))
-        (should tmux-control--alt-screen-warned))
+        (should (= (length warnings) 1)))
+      ;; reconnect: a FRESH buffer for the same connection must not re-warn
+      (with-temp-buffer
+        (setq-local tmux-control--alt-screen-honored nil)
+        (setq-local tmux-control--host nil)
+        (setq-local tmux-control--session "s")
+        (let ((tmux-control-warn-on-alternate-screen-off t))
+          (tmux-control--maybe-warn-alternate-screen-off))
+        (should (= (length warnings) 1)))
+      ;; a DIFFERENT connection still warns once
+      (with-temp-buffer
+        (setq-local tmux-control--alt-screen-honored nil)
+        (setq-local tmux-control--host nil)
+        (setq-local tmux-control--session "other")
+        (let ((tmux-control-warn-on-alternate-screen-off t))
+          (tmux-control--maybe-warn-alternate-screen-off))
+        (should (= (length warnings) 2)))
       ;; suppressed -> never
       (setq warnings nil)
       (with-temp-buffer
         (setq-local tmux-control--alt-screen-honored nil)
-        (setq-local tmux-control--alt-screen-warned nil)
+        (setq-local tmux-control--host nil)
+        (setq-local tmux-control--session "suppressed")
         (let ((tmux-control-warn-on-alternate-screen-off nil))
           (tmux-control--maybe-warn-alternate-screen-off))
         (should (null warnings))))))

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -656,10 +656,16 @@ requests the alternate screen, so Eat's alternate-display state is a
 phantom and must be ignored.  Refreshed over the control connection
 whenever the active pane changes.")
 
-(defvar-local tmux-control--alt-screen-warned nil
-  "Non-nil once this connection warned about `alternate-screen off'.
+(defvar tmux-control--alt-screen-warned-connections
+  (make-hash-table :test 'equal)
+  "Connection names already warned about `alternate-screen off'.
 Throttles `tmux-control-warn-on-alternate-screen-off' to one warning per
-connection (held on the controller).")
+connection.  Keyed by `tmux-control--connection-name' rather than held in a
+buffer-local flag so the guarantee survives a reconnect: an in-place
+reconnect rebuilds the controller buffer (via `tmux-control--reset-buffer',
+whose `tmux-control-mode' call runs `kill-all-local-variables'), which would
+otherwise clear a buffer-local flag and re-warn on every reconnect of a
+flapping link.")
 
 ;; Per-window render buffers (`tmux-control-window-buffers').  The connect
 ;; buffer keeps the process and session state and renders its own tmux
@@ -1728,23 +1734,26 @@ tmux runs with `alternate-screen off'."
 
 (defun tmux-control--maybe-warn-alternate-screen-off ()
   "Warn once if the active window does not honor `alternate-screen'.
-Throttled per connection via `tmux-control--alt-screen-warned'; gated on
+Throttled per connection via `tmux-control--alt-screen-warned-connections'
+(keyed by connection name, so it survives a reconnect); gated on
 `tmux-control-warn-on-alternate-screen-off'.  Call after
 `tmux-control--alt-screen-honored' is refreshed."
-  (when (and tmux-control-warn-on-alternate-screen-off
-             (not tmux-control--alt-screen-honored)
-             (not tmux-control--alt-screen-warned))
-    (setq tmux-control--alt-screen-warned t)
-    (display-warning
-     'tmux-control
-     (format
-      "The controlled tmux (%s) has `alternate-screen off'.  Full-screen TUIs \
+  (let ((key (tmux-control--connection-name
+              tmux-control--host tmux-control--session)))
+    (when (and tmux-control-warn-on-alternate-screen-off
+               (not tmux-control--alt-screen-honored)
+               (not (gethash key tmux-control--alt-screen-warned-connections)))
+      (puthash key t tmux-control--alt-screen-warned-connections)
+      (display-warning
+       'tmux-control
+       (format
+        "The controlled tmux (%s) has `alternate-screen off'.  Full-screen TUIs \
 (Copilot CLI, vim, less...) will repaint into pane history and produce \
 repeated/garbled scrollback.  Consider `setw -g alternate-screen on' on the \
 host; if the setting is intentional, enable `tmux-control-compact-scrollback'.  \
 Set `tmux-control-warn-on-alternate-screen-off' to nil to silence this."
-      (tmux-control--connection-name tmux-control--host tmux-control--session))
-     :warning)))
+        key)
+       :warning))))
 
 (defun tmux-control--window-choices ()
   "Return an alist of (DISPLAY . INDEX) for the current session's windows."


### PR DESCRIPTION
## Problem

Repeated identical warnings in `*Warnings*`:

> ⛔ Warning (tmux-control): The controlled tmux (dev:0) has `alternate-screen off'. ...

The "warn once per connection" guard added for #102 used a **buffer-local** flag, `tmux-control--alt-screen-warned`. An in-place auto-reconnect reuses the controller buffer and runs `tmux-control--reset-buffer` → `tmux-control-mode` → `kill-all-local-variables`, which clears that flag. So every reconnect of a flapping link re-armed and re-emitted the same warning.

## Fix

Key the throttle on the **connection name** in a module-level hash table (`tmux-control--alt-screen-warned-connections`) instead of a buffer-local flag. The one-warning-per-connection guarantee now survives a reconnect, while a genuinely different connection still warns once.

## Test

Extended `tmux-control-test-alt-screen-warning-throttled` to cover:
- reconnect case: a fresh buffer for the same connection does **not** re-warn
- a distinct connection still warns once

All 210 tests pass; clean byte-compile with `byte-compile-error-on-warn`.