### PR TITLE
Seed replays pane terminal modes (alt screen, mouse) into Eat

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -1029,6 +1029,69 @@ each wrapped in an evolving prompt line and a status bar.")
   (should (eq :unknown (tmux-control--parse-cursor-visible '("13,48,2"))))
   (should (eq :unknown (tmux-control--parse-cursor-visible nil))))
 
+(ert-deftest tmux-control-test-parse-pane-modes ()
+  ;; A well-formed seven-flag field (alt, mouse std/btn/all, SGR, cursor
+  ;; keys, wrap) parses to a plist of :on / :off.  This is copilot's shape:
+  ;; alternate screen plus any-event SGR mouse.
+  (let ((modes (tmux-control--parse-pane-modes '("1,0,0,1,1,0,1"))))
+    (should (eq (plist-get modes :alt-screen) :on))
+    (should (eq (plist-get modes :mouse-standard) :off))
+    (should (eq (plist-get modes :mouse-button) :off))
+    (should (eq (plist-get modes :mouse-all) :on))
+    (should (eq (plist-get modes :mouse-sgr) :on))
+    (should (eq (plist-get modes :cursor-keys) :off))
+    (should (eq (plist-get modes :wrap) :on)))
+  ;; An empty flag -- an older tmux renders an unknown format variable as
+  ;; empty -- parses to nil (unknown), NOT :off: the replay must leave a
+  ;; mode it does not know alone rather than actively reset it.
+  (let ((modes (tmux-control--parse-pane-modes '("1,0,0,1,1,0,"))))
+    (should (eq (plist-get modes :alt-screen) :on))
+    (should (null (plist-get modes :wrap))))
+  ;; Reverse-order/padded reply lists and whitespace are tolerated.
+  (should (eq :on (plist-get (tmux-control--parse-pane-modes
+                              '("" "  0,0,0,0,0,0,1 " ""))
+                             :wrap)))
+  ;; Malformed or empty replies yield nil rather than a bogus mode set.
+  (should-not (tmux-control--parse-pane-modes '("1,0,0,1,1,0"))) ; six flags
+  (should-not (tmux-control--parse-pane-modes '("1,0,0,1,1,0,1,0"))) ; eight
+  (should-not (tmux-control--parse-pane-modes '("can't find pane")))
+  (should-not (tmux-control--parse-pane-modes '("")))
+  (should-not (tmux-control--parse-pane-modes nil)))
+
+(ert-deftest tmux-control-test-mode-seed-sequence ()
+  ;; A full-screen mouse TUI (copilot, lazygit): enter the alternate
+  ;; display, enable any-event mouse tracking with the SGR encoding.  The
+  ;; alt-display switch comes FIRST so the screen paint that follows fills
+  ;; the freshly cleared display.
+  (should (equal (tmux-control--mode-seed-sequence
+                  (tmux-control--parse-pane-modes '("1,0,0,1,1,0,1")))
+                 "\e[?1049h\e[?1003h\e[?1006h\e[?1l\e[?7h"))
+  ;; A plain shell pane: every mode known off resets each one, so a seed
+  ;; after the TUI exited (while Eat was not watching) drops the stale
+  ;; alternate-display and mouse state.  One mouse reset covers all three
+  ;; protocols in Eat.
+  (should (equal (tmux-control--mode-seed-sequence
+                  (tmux-control--parse-pane-modes '("0,0,0,0,0,0,1")))
+                 "\e[?1049l\e[?1000l\e[?1006l\e[?1l\e[?7h"))
+  ;; tmux keeps at most one mouse protocol; the one reported is replayed.
+  (should (string-match-p "\\?1002h" (tmux-control--mode-seed-sequence
+                                      (tmux-control--parse-pane-modes
+                                       '("0,0,1,0,0,0,1")))))
+  (should (string-match-p "\\?1000h" (tmux-control--mode-seed-sequence
+                                      (tmux-control--parse-pane-modes
+                                       '("0,1,0,0,0,0,1")))))
+  ;; Unknown flags (empty fields) emit nothing for that mode: no set, no
+  ;; reset.  All-unknown emits the empty string; unknown modes are nil.
+  (should (equal (tmux-control--mode-seed-sequence
+                  (tmux-control--parse-pane-modes '(",,,,,,")))
+                 ""))
+  ;; A partially-unknown mouse trio must not reset the mouse.
+  (should-not (string-match-p "1000l" (tmux-control--mode-seed-sequence
+                                       (tmux-control--parse-pane-modes
+                                        '("0,0,,0,0,0,1")))))
+  ;; No modes at all (query failed): nil, so the seed paints contents only.
+  (should-not (tmux-control--mode-seed-sequence nil)))
+
 (ert-deftest tmux-control-test-capture-n-supported-p ()
   ;; capture-pane -N landed in tmux 3.1.
   (should (tmux-control--capture-n-supported-p "3.1"))
@@ -1324,15 +1387,15 @@ each wrapped in an evolving prompt line and a status bar.")
 
 (ert-deftest tmux-control-test-parse-window-state ()
   ;; The in-band `list-panes' reply (tab-separated: layout, then each pane's
-  ;; geometry / cursor / cmd / title) parses to (LAYOUT . PANES) -- the layout
-  ;; from the first line, the panes in order with their plists.
+  ;; geometry / cursor / cmd / modes / title) parses to (LAYOUT . PANES) --
+  ;; the layout from the first line, the panes in order with their plists.
   (let* ((lines (list (mapconcat #'identity
                                  '("LAY" "%0" "0" "0" "40" "24" "1"
-                                   "5" "3" "1" "bash" "tty")
+                                   "5" "3" "1" "bash" "0,0,0,0,0,0,1" "tty")
                                  "\t")
                       (mapconcat #'identity
                                  '("LAY" "%1" "41" "0" "39" "24" "0"
-                                   "0" "0" "0" "vim" "edit")
+                                   "0" "0" "0" "vim" "1,0,0,1,1,1,0" "edit")
                                  "\t")))
          (state (tmux-control--parse-window-state lines))
          (panes (cdr state)))
@@ -1344,22 +1407,26 @@ each wrapped in an evolving prompt line and a status bar.")
       (should (eq (plist-get p0 :active) t))
       (should (equal (plist-get p0 :cursor) '(5 . 3)))
       (should (equal (plist-get p0 :cmd) "bash"))
+      (should (eq (plist-get (plist-get p0 :modes) :alt-screen) :off))
       (should (equal (plist-get p0 :title) "tty")))
     (let ((p1 (cdr (assoc "%1" panes))))
       (should (eq (plist-get p1 :active) nil))
-      (should (equal (plist-get p1 :cmd) "vim")))
+      (should (equal (plist-get p1 :cmd) "vim"))
+      (should (eq (plist-get (plist-get p1 :modes) :alt-screen) :on))
+      (should (eq (plist-get (plist-get p1 :modes) :mouse-all) :on)))
     ;; A short/garbled line is skipped, not parsed into a bogus pane.
     (should (null (cdr (tmux-control--parse-window-state '("LAY\t%0\t0"))))))
   ;; Empty trailing fields (an unset pane title, sometimes an empty command)
   ;; must NOT drop the pane or shift columns: `split-string' with an explicit
-  ;; separator keeps empty fields, so the line is still 12 fields.
-  (let* ((line (concat "LAY\t%7\t0\t0\t80\t24\t1\t0\t0\t1\t\t")) ; empty cmd + title
+  ;; separator keeps empty fields, so the line is still 13 fields.
+  (let* ((line (concat "LAY\t%7\t0\t0\t80\t24\t1\t0\t0\t1\t\t\t")) ; empty cmd + modes + title
          (panes (cdr (tmux-control--parse-window-state (list line))))
          (p (cdr (assoc "%7" panes))))
     (should (= (length panes) 1))
     (should p)
     (should (= (plist-get p :width) 80))     ; columns did not shift
     (should (equal (plist-get p :cmd) ""))
+    (should (null (plist-get p :modes)))     ; malformed modes parse to nil
     (should (equal (plist-get p :title) ""))))
 
 (ert-deftest tmux-control-test-parse-window-state-validates-pane-id ()
@@ -1369,7 +1436,7 @@ each wrapped in an evolving prompt line and a status bar.")
   (let* ((fields (lambda (id)
                    (mapconcat #'identity
                               (list "LAY" id "0" "0" "80" "24" "1" "0" "0" "1"
-                                    "bash" "title")
+                                    "bash" "0,0,0,0,0,0,1" "title")
                               "\t")))
          (panes (cdr (tmux-control--parse-window-state
                       (list (funcall fields "%2")
@@ -1388,7 +1455,7 @@ each wrapped in an evolving prompt line and a status bar.")
   ;; pre-TAB fragment, and the pane must not be dropped or mis-counted.
   (let* ((line (mapconcat #'identity
                           '("LAY" "%0" "0" "0" "80" "24" "1"
-                            "5" "6" "1" "bash" "a\tb\tc")
+                            "5" "6" "1" "bash" "0,0,0,0,0,0,1" "a\tb\tc")
                           "\t"))
          (panes (cdr (tmux-control--parse-window-state (list line))))
          (p (cdr (assoc "%0" panes))))
@@ -3976,7 +4043,7 @@ output), :calls (side-effect invocations in order), :active-pane,
         (setq-local tmux-control--active-pane "%3")
         (tmux-control--seed-screen)
         (should (equal (mapcar #'car (nreverse sent))
-                       '(:cursor-pos :capture)))
+                       '(:cursor-pos :pane-modes :capture)))
         (should (equal verified (list (current-buffer))))))))
 
 (ert-deftest tmux-control-test-rtrim-screen-lines ()

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -641,6 +641,29 @@ The value is `:visible' when tmux reports a visible cursor, `:hidden'
 when hidden, and `:unknown' when the state has not been queried.  Used by
 the `:capture' reply handler to keep Eat's cursor visibility in sync with
 tmux.")
+(defvar-local tmux-control--seed-modes nil
+  "Most recent pane terminal modes queried for a screen seed.
+A plist as returned by `tmux-control--parse-pane-modes', or nil when the
+modes have not been queried (or the reply was malformed).  Used by the
+`:capture' reply handler to replay the pane's mode state -- alternate
+screen, mouse tracking, cursor-key mode, autowrap -- into Eat before
+painting.  `capture-pane' replays screen CONTENTS only, so without this a
+seed of a pane whose application enabled those modes before the seed (a
+connect, reconnect, or window visit landing on a running full-screen TUI)
+leaves Eat believing it is a plain normal-screen pane: wheel events are
+then swallowed by the Emacs-side scrollback routing instead of reaching
+the application (see `tmux-control-wheel-scroll').")
+(defconst tmux-control--pane-modes-format
+  (concat "#{alternate_on},#{mouse_standard_flag},#{mouse_button_flag},"
+          "#{mouse_all_flag},#{mouse_sgr_flag},#{keypad_cursor_flag},"
+          "#{wrap_flag}")
+  "Format string folding a pane's terminal-mode flags into one reply field.
+Comma-separated so the whole state rides a single field of a
+`display-message'/`list-panes' reply; parse it with
+`tmux-control--parse-pane-modes'.  These are the DECSET modes tmux tracks
+per pane that Eat both understands and acts on: the alternate screen
+\(1049), the three mouse-tracking protocols (1000/1002/1003) with the SGR
+encoding (1006), application cursor keys (DECCKM), and autowrap (DECAWM).")
 (defvar-local tmux-control--capture-trailing-p nil
   "Non-nil when the connected tmux supports `capture-pane -N' (3.1+).
 With it, the screen seed preserves trailing background cells so full-width
@@ -4914,12 +4937,19 @@ swallowed as content and the reply queue would desynchronize."
              (tmux-control--parse-cursor-pos output))
        (setq tmux-control--seed-cursor-visible
              (tmux-control--parse-cursor-visible output)))
+      (:pane-modes
+       (setq tmux-control--seed-modes
+             (tmux-control--parse-pane-modes output)))
       (:capture
        (tmux-control--write-terminal
-        (tmux-control--screen-seed-sequence
-         (mapconcat #'identity (nreverse output) "\n")
-         tmux-control--seed-cursor
-         tmux-control--seed-cursor-visible))))))
+        (concat
+         ;; Mode replay first: entering the alternate display clears it,
+         ;; and the screen paint that follows fills it in.
+         (tmux-control--mode-seed-sequence tmux-control--seed-modes)
+         (tmux-control--screen-seed-sequence
+          (mapconcat #'identity (nreverse output) "\n")
+          tmux-control--seed-cursor
+          tmux-control--seed-cursor-visible)))))))
 
 ;;;; Optional auto-heal of render drift
 ;;
@@ -5030,20 +5060,30 @@ wide character does not read as spurious trailing space, matching tmux's
 
 (defun tmux-control--seed-screen ()
   "Seed the Eat buffer with the current tmux pane contents.
-Query the pane's real cursor position first, so the seeded screen places
-the cursor exactly where tmux has it instead of guessing from the prompt.
-tmux replies in command order, so the `:cursor-pos' reply lands before
-the `:capture' reply that paints the screen and consumes it."
+Query the pane's real cursor position and terminal modes first, so the
+seeded screen places the cursor exactly where tmux has it (instead of
+guessing from the prompt) and replays the pane's mode state -- alternate
+screen, mouse tracking -- that `capture-pane' contents alone cannot carry.
+tmux replies in command order, so the `:cursor-pos' and `:pane-modes'
+replies land before the `:capture' reply that paints the screen and
+consumes them."
   (when tmux-control--active-pane
-    ;; Start each seed without a cursor: the :cursor-pos reply fills it in
-    ;; before :capture, and if that query fails the seed falls back to the
-    ;; bottom-left rather than reusing a stale position from an old seed.
+    ;; Start each seed without a cursor or modes: the :cursor-pos and
+    ;; :pane-modes replies fill them in before :capture, and if a query
+    ;; fails the seed falls back (bottom-left cursor, no mode replay)
+    ;; rather than reusing stale values from an old seed.
     (setq tmux-control--seed-cursor nil)
     (setq tmux-control--seed-cursor-visible :unknown)
+    (setq tmux-control--seed-modes nil)
     (tmux-control--send-command
      (format "display-message -p -t %s \"#{cursor_x},#{cursor_y},#{cursor_flag}\""
              tmux-control--active-pane)
      :cursor-pos)
+    (tmux-control--send-command
+     (format "display-message -p -t %s \"%s\""
+             tmux-control--active-pane
+             tmux-control--pane-modes-format)
+     :pane-modes)
     (tmux-control--send-command
      (format "capture-pane -p -e%s -t %s"
              ;; -N keeps trailing background cells so full-width fills survive.
@@ -5879,6 +5919,63 @@ no side effects, for unit testing the seed cursor query."
         (tmux-control--cursor-visible-from-flag (match-string 1 val))
       :unknown)))
 
+(defun tmux-control--parse-pane-modes (output)
+  "Parse a `tmux-control--pane-modes-format' field from reply OUTPUT lines.
+Return a plist mapping :alt-screen :mouse-standard :mouse-button
+:mouse-all :mouse-sgr :cursor-keys :wrap each to `:on', `:off', or nil
+when that flag is missing from the reply (an older tmux renders an
+unknown format variable as empty; nil makes the replay leave that mode
+alone rather than reset a state it does not actually know).  Return nil
+when no well-formed field is found.  Pure: no side effects, for unit
+testing the seed mode query."
+  (let ((val (car (cl-remove-if #'string-empty-p
+                                (mapcar #'string-trim output)))))
+    (when (and val (string-match-p "\\`[01]?\\(?:,[01]?\\)\\{6\\}\\'" val))
+      (cl-mapcan (lambda (key flag)
+                   (list key (pcase flag ("1" :on) ("0" :off) (_ nil))))
+                 '(:alt-screen :mouse-standard :mouse-button :mouse-all
+                   :mouse-sgr :cursor-keys :wrap)
+                 (split-string val ",")))))
+
+(defun tmux-control--mode-seed-sequence (modes)
+  "Return terminal escapes replaying pane MODES into Eat, or nil.
+MODES is a `tmux-control--parse-pane-modes' plist; nil (modes unknown)
+returns nil and the seed paints contents only, as before.  A screen seed
+repaints contents but Eat's MODE state otherwise survives from before the
+seed -- wrong whenever the pane's application enabled or dropped a mode
+while Eat was not watching (it was running before connect, or the seed
+follows a reconnect or window switch).  Replaying the modes tmux reports
+keeps Eat's routing decisions (`tmux-control--alt-screen-p',
+`tmux-control--pane-grabs-mouse-p') and input encoding faithful to the
+pane.  Emitted before the screen paint: entering the alternate display
+clears it, and the paint that follows fills it in.  Each escape is
+idempotent in Eat, so replaying an already-correct state is a no-op.
+Pure, for unit testing."
+  (when modes
+    (concat
+     (pcase (plist-get modes :alt-screen)
+       (:on "\e[?1049h")
+       (:off "\e[?1049l"))
+     ;; tmux keeps at most one mouse protocol in effect; replay the one it
+     ;; reports, or reset when it reports none (one reset disables every
+     ;; protocol in Eat).  Any flag unknown leaves mouse state alone.
+     (cond ((eq (plist-get modes :mouse-all) :on) "\e[?1003h")
+           ((eq (plist-get modes :mouse-button) :on) "\e[?1002h")
+           ((eq (plist-get modes :mouse-standard) :on) "\e[?1000h")
+           ((and (eq (plist-get modes :mouse-all) :off)
+                 (eq (plist-get modes :mouse-button) :off)
+                 (eq (plist-get modes :mouse-standard) :off))
+            "\e[?1000l"))
+     (pcase (plist-get modes :mouse-sgr)
+       (:on "\e[?1006h")
+       (:off "\e[?1006l"))
+     (pcase (plist-get modes :cursor-keys)
+       (:on "\e[?1h")
+       (:off "\e[?1l"))
+     (pcase (plist-get modes :wrap)
+       (:on "\e[?7h")
+       (:off "\e[?7l")))))
+
 (defun tmux-control--capture-n-supported-p (version)
   "Return non-nil when tmux VERSION supports `capture-pane -N' (3.1 or later).
 VERSION is a `#{version}' string such as \"3.6a\" or \"next-3.5\"; the first
@@ -6304,23 +6401,31 @@ it asynchronously over the control connection."
   "Resolve WINDOW-ID's active pane and seed BUFFER from it, asynchronously.
 A closure-query chain over the control connection -- never blocking
 Emacs, and ordered by tmux itself.  Two round trips, not three: the
-active pane and its cursor come back in one list-panes reply (this is
-the first-visit latency a remote user sees as a blank window, so every
-round trip counts), then the capture paints the screen."
+active pane, its cursor, and its terminal modes come back in one
+list-panes reply (this is the first-visit latency a remote user sees as
+a blank window, so every round trip counts), then the capture paints the
+screen, prefixed by the mode replay (see
+`tmux-control--mode-seed-sequence')."
   (let ((ctrl (tmux-control--wb-controller)))
     (with-current-buffer ctrl
       (tmux-control--query
-       (format "list-panes -t %s -F \"#{pane_active}\t#{pane_id}\t#{cursor_x},#{cursor_y},#{cursor_flag}\""
-               window-id)
+       (format "list-panes -t %s -F \"#{pane_active}\t#{pane_id}\t#{cursor_x},#{cursor_y},#{cursor_flag}\t%s\""
+               window-id
+               tmux-control--pane-modes-format)
        (lambda (lines)
-         (let (pane cur vis)
+         (let (pane cur vis modes)
            (cl-loop for l in (or lines '())
                     when (string-match
-                          "\\`1\t\\(%[0-9]+\\)\t\\(.*\\)\\'" l)
+                          "\\`1\t\\(%[0-9]+\\)\t\\([^\t]*\\)\t\\([^\t]*\\)\\'" l)
+                    ;; Extract every group before the parsers run: they do
+                    ;; their own `string-match', which clobbers this match
+                    ;; data.
                     do (setq pane (match-string 1 l))
-                       (let ((cline (list (match-string 2 l))))
+                       (let ((cline (list (match-string 2 l)))
+                             (mline (list (match-string 3 l))))
                          (setq cur (tmux-control--parse-cursor-pos cline)
-                               vis (tmux-control--parse-cursor-visible cline)))
+                               vis (tmux-control--parse-cursor-visible cline)
+                               modes (tmux-control--parse-pane-modes mline)))
                     and return nil)
            (when (and pane (buffer-live-p buffer))
              (with-current-buffer buffer
@@ -6336,9 +6441,11 @@ round trip counts), then the capture paints the screen."
                   (when (and cap-lines (buffer-live-p buffer))
                     (with-current-buffer buffer
                       (tmux-control--write-terminal
-                       (tmux-control--screen-seed-sequence
-                        (string-join cap-lines "\n")
-                        cur (or vis :unknown)))
+                       (concat
+                        (tmux-control--mode-seed-sequence modes)
+                        (tmux-control--screen-seed-sequence
+                         (string-join cap-lines "\n")
+                         cur (or vis :unknown))))
                       (tmux-control--flush-display
                        (tmux-control--current-sync-windows)))
                     ;; Same drift detection as the controller seed: output
@@ -6565,11 +6672,14 @@ controller or pane render buffer where those locals are bound."
   (concat "#{window_layout}\t#{pane_id}\t#{pane_left}\t#{pane_top}\t"
           "#{pane_width}\t#{pane_height}\t#{pane_active}\t"
           "#{cursor_x}\t#{cursor_y}\t#{cursor_flag}\t#{pane_current_command}\t"
+          tmux-control--pane-modes-format "\t"
           "#{pane_title}")
   "`list-panes -F' format folding the layout and every pane's geometry,
-cursor, command, and title into one query, so a (re)tile costs a single
-round trip rather than a `display-message' for the layout plus one per pane
-for the cursor.")
+cursor, command, terminal modes, and title into one query, so a (re)tile
+costs a single round trip rather than a `display-message' for the layout
+plus one per pane for the cursor.  `pane_title' stays LAST: an app-set
+title can contain a literal TAB, and the parser rejoins trailing
+fragments (see `tmux-control--parse-window-state').")
 
 (defun tmux-control--window-state-command ()
   "Return the in-band `list-panes' command for the active window's state.
@@ -6586,8 +6696,9 @@ identically for a local or remote session.  Parse the reply with
   "Parse `list-panes' reply LINES into (LAYOUT . PANES).
 LAYOUT is the `window_layout' string; PANES is an alist (PANE-ID . INFO)
 with INFO a plist of :left :top :width :height :active :cursor
-:cursor-visible :cmd and :title.  See `tmux-control--window-state-format'.
-Pure, so the reply shape is unit-testable without a live tmux."
+:cursor-visible :cmd :modes and :title.  See
+`tmux-control--window-state-format'.  Pure, so the reply shape is
+unit-testable without a live tmux."
   (let ((layout nil) (panes nil))
     (dolist (line lines)
       (let ((f (split-string line "\t")))
@@ -6595,7 +6706,7 @@ Pure, so the reply shape is unit-testable without a live tmux."
         ;; and is later used as a command TARGET (send-input, select-pane,
         ;; capture); accept only a canonical "%N" so a hostile/buggy server
         ;; cannot smuggle a crafted target.  A real tmux pane id is always %N.
-        (when (and (>= (length f) 12)
+        (when (and (>= (length f) 13)
                    (string-match-p "\\`%[0-9]+\\'" (nth 1 f)))
           (unless layout (setq layout (nth 0 f)))
           (push (cons (nth 1 f)
@@ -6609,12 +6720,14 @@ Pure, so the reply shape is unit-testable without a live tmux."
                             :cursor-visible
                             (tmux-control--cursor-visible-from-flag (nth 9 f))
                             :cmd (nth 10 f)
+                            :modes (tmux-control--parse-pane-modes
+                                    (list (nth 11 f)))
                             ;; `pane_title' is the last field, but an app can set
                             ;; an arbitrary title (OSC 2) including a literal TAB;
                             ;; rejoin any TAB-split fragments so the title is not
                             ;; truncated to its pre-TAB piece (and the pane is not
                             ;; mis-counted).
-                            :title (string-join (nthcdr 11 f) "\t")))
+                            :title (string-join (nthcdr 12 f) "\t")))
                 panes))))
     (cons layout (nreverse panes))))
 
@@ -6828,8 +6941,11 @@ TRAILING keeps trailing blanks (`-N').  Rides the control connection via
           (when trailing " -N")
           (format " -t %s" pane)))
 
-(defun tmux-control--paint-seed (buffer text cursor cursor-visible)
+(defun tmux-control--paint-seed (buffer text cursor cursor-visible
+                                        &optional modes)
   "Paint BUFFER's terminal from screen TEXT with CURSOR / CURSOR-VISIBLE.
+MODES, when non-nil, is a `tmux-control--parse-pane-modes' plist replayed
+into Eat before the paint (see `tmux-control--mode-seed-sequence').
 Shared by the synchronous and in-band seed paths."
   (when (and (buffer-live-p buffer) text)
     (with-current-buffer buffer
@@ -6839,9 +6955,12 @@ Shared by the synchronous and in-band seed paths."
         ;; Clear the scrollback (\e[3J) before painting, not just the screen,
         ;; so a reseed (e.g. after a resize) does not leave the previous,
         ;; now-reflowed frame stacked above the fresh one -- an app on a tmux
-        ;; with `alternate-screen off' repaints by appending.
+        ;; with `alternate-screen off' repaints by appending.  The mode
+        ;; replay comes first of all: entering the alternate display clears
+        ;; it, and the paint that follows fills it in.
         (tmux-control--write-terminal
-         (concat "\e[3J"
+         (concat (tmux-control--mode-seed-sequence modes)
+                 "\e[3J"
                  (tmux-control--screen-seed-sequence
                   text cursor cursor-visible)))))))
 
@@ -6859,8 +6978,10 @@ the (re)tile build uses `tmux-control--seed-pane-buffer-async' instead."
                (cursor-visible (or (plist-get tmux-control--pane-info
                                               :cursor-visible)
                                   :unknown))
+               (modes (plist-get tmux-control--pane-info :modes))
                (text (ignore-errors (tmux-control--capture-pane-screen pane))))
-          (tmux-control--paint-seed buffer text cursor cursor-visible))))))
+          (tmux-control--paint-seed buffer text cursor cursor-visible
+                                    modes))))))
 
 (defun tmux-control--seed-pane-buffer-async (buffer controller)
   "Capture BUFFER's pane screen in-band and paint it when the reply lands.
@@ -6877,7 +6998,8 @@ safe no-op."
            (pane (buffer-local-value 'tmux-control--active-pane buffer))
            (trailing (buffer-local-value 'tmux-control--capture-trailing-p buffer))
            (cursor (plist-get info :cursor))
-           (cursor-visible (or (plist-get info :cursor-visible) :unknown)))
+           (cursor-visible (or (plist-get info :cursor-visible) :unknown))
+           (modes (plist-get info :modes)))
       (when pane
         (with-current-buffer controller
           (tmux-control--query
@@ -6886,7 +7008,7 @@ safe no-op."
              (when (buffer-live-p buffer)
                (tmux-control--paint-seed
                 buffer (and reply (string-join reply "\n"))
-                cursor cursor-visible)
+                cursor cursor-visible modes)
                (let ((term (buffer-local-value 'tmux-control--terminal buffer))
                      (win (get-buffer-window buffer t)))
                  (when (and term (eat-term-live-p term) (window-live-p win))

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -5938,9 +5938,11 @@ testing the seed mode query."
                  (split-string val ",")))))
 
 (defun tmux-control--mode-seed-sequence (modes)
-  "Return terminal escapes replaying pane MODES into Eat, or nil.
-MODES is a `tmux-control--parse-pane-modes' plist; nil (modes unknown)
-returns nil and the seed paints contents only, as before.  A screen seed
+  "Return terminal escapes replaying pane MODES into Eat.
+MODES is a `tmux-control--parse-pane-modes' plist; nil (the query failed)
+returns nil, and a plist whose flags are all unknown returns the empty
+string -- either way nothing is emitted and the seed paints contents
+only, as before.  A screen seed
 repaints contents but Eat's MODE state otherwise survives from before the
 seed -- wrong whenever the pane's application enabled or dropped a mode
 while Eat was not watching (it was running before connect, or the seed


### PR DESCRIPTION
## Problem

Scrollback over a running full-screen TUI (observed live with GitHub Copilot CLI on nebius-0) did not work: wheel-up did nothing useful, and the `tmux-control-scrollback` pager showed a single screenful.

Root cause: a screen seed (`capture-pane`) replays **contents only**. When a seed lands on a pane whose application had already enabled DECSET modes — connect, reconnect, or a window visit onto a running TUI — Eat never sees the mode-setting escapes the app emitted at startup. It believes the pane is a plain normal-screen, no-mouse pane:

- `tmux-control--alt-screen-p` → nil, `tmux-control--pane-grabs-mouse-p` → nil
- `tmux-control-wheel-scroll` therefore routes wheel-up into the Emacs-side live-history/pager path (which for an alternate-screen pane has ~no tmux history to show) instead of forwarding mouse events to the application
- even a correctly-routed event would be dropped, since Eat encodes mouse input only when it believes a mouse protocol is active

Verified live: the copilot pane reported `alternate_on=1 mouse_all=1 mouse_sgr=1` while Eat reported main display / no mouse grab. Hand-feeding `ESC[?1049h ESC[?1003h ESC[?1006h` into the Eat terminal immediately made wheel events scroll the TUI.

## Fix

Each seed now also queries the pane's mode flags and replays them into Eat as equivalent escapes **before** the screen paint (entering the alt display clears it; the paint fills it in):

- alternate display (1047/1049), mouse protocol in effect + SGR encoding (1000/1002/1003, 1006), application cursor keys (DECCKM), autowrap (DECAWM) — the DECSET modes tmux tracks per pane that Eat understands
- controller seed: one extra in-band `display-message` reply (`:pane-modes`), consumed by `:capture` like the cursor query
- window render buffers: folded into the existing `list-panes` reply — no extra round trip
- tiled panes: folded into `tmux-control--window-state-format` (`pane_title` stays last for the TAB-in-title rejoin) and applied via `tmux-control--paint-seed`

Eat's mode handling is idempotent, so replaying an already-correct state is a no-op. Flags an older tmux renders as empty parse to "unknown" and leave that mode untouched (never actively reset a state we don't know).

## Testing

- `make test` / `make test-elc`: 212/212, compile clean under `byte-compile-error-on-warn`
- `make test-integration` (tmux 3.4): 19/19 — also caught a match-data clobbering bug in the first draft of the list-panes parsing, now covered by extracting all groups before the parsers run
- new unit tests for `tmux-control--parse-pane-modes` and `tmux-control--mode-seed-sequence`, window-state tests extended to the 13-field shape
- verified live against the affected session: reset Eat's modes to the stale state, ran `tmux-control--seed-screen` over the real connection, confirmed the modes replay and that wheel-up/wheel-down scroll the copilot TUI itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)