### PR TITLE
Tile from per-window render buffers; fix split-pane auto-tile

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -1153,10 +1153,11 @@ each wrapped in an evolving prompt line and a status bar.")
 
 (ert-deftest tmux-control-test-split-pane-command ()
   ;; Split rides the control connection (`split-window -h'/`-v' at the active
-  ;; pane).  From the single-pane controller view it auto-tiles so both panes
-  ;; show; NOT from a render buffer (which must untile, not tile), NOT when
-  ;; already tiled (the %layout-change re-tiles), and NOT when the option is
-  ;; off.  `kill-pane' targets the active pane after confirmation.
+  ;; pane).  From ANY single-pane view -- the connect buffer or a per-window
+  ;; render buffer (issue #114: the latter used to be mistaken for a tiled
+  ;; pane and skipped) -- it auto-tiles so both panes show; NOT when already
+  ;; tiled (the %layout-change re-tiles), and NOT when the option is off.
+  ;; `kill-pane' targets the active pane after confirmation.
   (let ((cmds '()) (tiles 0) (tiled-p nil))
     (cl-letf (((symbol-function 'tmux-control--ensure-live) #'ignore)
               ((symbol-function 'tmux-control--send-command)
@@ -1181,12 +1182,13 @@ each wrapped in an evolving prompt line and a status bar.")
           (tmux-control-split-pane-right)
           (should (equal cmds '("split-window -h -t %3")))
           (should (= tiles 0)))
-        ;; render buffer (controller set) -> split only
+        ;; per-window render buffer (controller set, not tiled) -> split +
+        ;; auto-tile, same as the connect buffer (issue #114)
         (setq cmds nil tiles 0 tmux-control--controller (current-buffer))
         (let ((tmux-control-split-pane-tiles t))
           (tmux-control-split-pane-right)
-          (should (= tiles 0)))
-        ;; already tiled -> no auto-tile
+          (should (= tiles 1)))
+        ;; already tiled (controller or a tiled pane buffer) -> no auto-tile
         (setq cmds nil tiles 0 tmux-control--controller nil tiled-p (current-buffer))
         (let ((tmux-control-split-pane-tiles t))
           (tmux-control-split-pane-right)
@@ -2155,19 +2157,115 @@ each wrapped in an evolving prompt line and a status bar.")
               ((symbol-function 'tmux-control--run-tmux)
                (lambda (_args) (setq ran-tmux t) ""))
               ((symbol-function 'tmux-control--query)
-               (lambda (cmd cb) (push cmd queries) (funcall cb '("%7"))))
+               (lambda (cmd cb) (push cmd queries) (funcall cb '("@1 %7"))))
               ((symbol-function 'tmux-control--seed-screen)
                (lambda () (cl-incf seeded))))
       (with-temp-buffer
         (setq-local tmux-control--tiled t
                     tmux-control--controller nil
                     tmux-control--active-pane "%0"
-                    tmux-control-window-tab-bar nil)
+                    tmux-control-window-tab-bar nil
+                    tmux-control-window-buffers nil)
         (tmux-control-untile)
         (should-not ran-tmux)                ; no blocking out-of-band ssh
         (should (cl-some (lambda (q) (string-match-p "pane_id" q)) queries))
         (should (equal tmux-control--active-pane "%7")) ; reply applied
         (should (= seeded 1))))))            ; seeded in the callback
+
+(ert-deftest tmux-control-test-untile-window-buffers-hands-off-view ()
+  ;; With per-window render buffers, untiling while the session's current
+  ;; window is NOT the controller's own must hand the view to that window's
+  ;; render buffer (reseeding it -- window buffers do not stream while tiled)
+  ;; and reseed the controller onto its OWN window in the background, rather
+  ;; than seed the controller onto the foreign window's pane, which stranded
+  ;; its %output routing (issue #114 follow-through).
+  (let ((wbuf (generate-new-buffer " tc-test-wbuf"))
+        (displayed '()) (window-seeds '()) (screen-seeds 0))
+    (unwind-protect
+        (cl-letf (((symbol-function 'tmux-control--teardown-tiling) #'ignore)
+                  ((symbol-function 'tmux-control--write-terminal) #'ignore)
+                  ((symbol-function 'tmux-control--resize-to-window) #'ignore)
+                  ((symbol-function 'tmux-control--query)
+                   (lambda (_cmd cb) (funcall cb '("@2 %7"))))
+                  ((symbol-function 'tmux-control--window-buffer)
+                   (lambda (id) (when (equal id "@2") wbuf)))
+                  ((symbol-function 'tmux-control--display-window-buffer)
+                   (lambda (id) (push id displayed) wbuf))
+                  ((symbol-function 'tmux-control--seed-window-buffer)
+                   (lambda (buf id) (push (cons buf id) window-seeds)))
+                  ((symbol-function 'tmux-control--seed-screen)
+                   (lambda () (cl-incf screen-seeds)))
+                  ((symbol-function 'tmux-control--quiet-activity) #'ignore)
+                  ((symbol-function 'tmux-control--refresh-windows) #'ignore)
+                  ((symbol-function 'tmux-control--refresh-pane-window-map)
+                   #'ignore))
+          (with-temp-buffer
+            (let ((ctrl (current-buffer)))
+              (setq-local tmux-control--tiled t
+                          tmux-control--controller nil
+                          tmux-control--window-id "@0"
+                          tmux-control--active-pane "%0"
+                          tmux-control-window-buffers t)
+              (tmux-control-untile)
+              (should (equal displayed '("@2")))         ; view handed to @2
+              ;; the stale @2 render buffer and the controller's own window
+              ;; were both reseeded; the controller was NOT seeded onto %7
+              (should (member (cons wbuf "@2") window-seeds))
+              (should (member (cons ctrl "@0") window-seeds))
+              (should (= screen-seeds 0))
+              (should (equal tmux-control--active-pane "%0")))))
+      (kill-buffer wbuf))))
+
+(ert-deftest tmux-control-test-tile-routes-to-controller ()
+  ;; `tmux-control-tile' invoked in a per-window render buffer (which has
+  ;; `tmux-control--controller' set but is NOT a tiled pane) must run the
+  ;; build on the process-owning controller, not error out (issue #114).
+  (let ((ctrl (generate-new-buffer " tc-test-ctrl"))
+        (built '()) (cmds '()))
+    (unwind-protect
+        (cl-letf (((symbol-function 'tmux-control--ensure-live) #'ignore)
+                  ((symbol-function 'tmux-control--tiled-region-size)
+                   (lambda (_frame _ctrl) '(80 . 24)))
+                  ((symbol-function 'tmux-control--send-command)
+                   (lambda (c &optional _k) (push c cmds)))
+                  ((symbol-function 'tmux-control--build-tiling)
+                   (lambda (b) (push b built))))
+          (with-temp-buffer
+            (setq-local tmux-control--controller ctrl)
+            (tmux-control-tile))
+          (should (equal built (list ctrl)))
+          (should (equal cmds '("refresh-client -C 80x24")))
+          (should (equal (buffer-local-value 'tmux-control--tiled-client-size
+                                             ctrl)
+                         '(80 . 24)))
+          ;; From a live tiled pane buffer it still refuses.
+          (with-current-buffer ctrl (setq-local tmux-control--tiled t))
+          (with-temp-buffer
+            (setq-local tmux-control--controller ctrl)
+            (should-error (tmux-control-tile) :type 'user-error)))
+      (kill-buffer ctrl))))
+
+(ert-deftest tmux-control-test-toggle-tiling-from-window-buffer ()
+  ;; C-c C-t in a per-window render buffer of an untiled session must TILE --
+  ;; it used to read the buffer's `tmux-control--controller' flag as "this is
+  ;; a tiled pane" and try to untile, erroring "Not tiling" (issue #114).  In
+  ;; a buffer that really is part of a live tiling it still untiles.
+  (let ((ctrl (generate-new-buffer " tc-test-ctrl"))
+        (tiled 0) (untiled 0))
+    (unwind-protect
+        (cl-letf (((symbol-function 'tmux-control-tile)
+                   (lambda () (cl-incf tiled)))
+                  ((symbol-function 'tmux-control-untile)
+                   (lambda () (cl-incf untiled))))
+          (with-temp-buffer
+            (setq-local tmux-control--controller ctrl)
+            (tmux-control-toggle-tiling)
+            (should (= tiled 1))
+            (should (= untiled 0))
+            (with-current-buffer ctrl (setq-local tmux-control--tiled t))
+            (tmux-control-toggle-tiling)
+            (should (= untiled 1))))
+      (kill-buffer ctrl))))
 
 ;;; Tiling preserves a foreign (non-tmux) window sharing the frame.
 

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -7003,14 +7003,26 @@ back into it first), so a non-tmux window sharing the frame is preserved
 rather than wiped; when the controller already fills the frame the tiling
 fills the frame as before.  Returns an alist (PANE-ID . WINDOW), or nil when
 the windows could not be built."
-  ;; Prefer the selected window when it already shows the controller or one
-  ;; of our pane buffers, so a re-tile never reaches onto a different frame
-  ;; (an all-frames `get-buffer-window' could) and clobber its layout.
+  ;; Prefer the selected window when it already shows the controller, one of
+  ;; our pane buffers, or a per-window render buffer routed through the
+  ;; controller (a tile started from such a buffer subdivides its window), so
+  ;; a re-tile never reaches onto a different frame (an all-frames
+  ;; `get-buffer-window' could) and clobber its layout.
   (let ((root (or (let ((b (window-buffer (selected-window))))
-                    (when (or (eq b controller) (rassq b panes))
+                    (when (or (eq b controller) (rassq b panes)
+                              (eq (buffer-local-value 'tmux-control--controller
+                                                      b)
+                                  controller))
                       (selected-window)))
                   (cl-some (lambda (np) (get-buffer-window (cdr np) t)) panes)
                   (get-buffer-window controller t)
+                  ;; Any window showing one of the session's per-window render
+                  ;; buffers -- in `tmux-control-window-buffers' mode that is
+                  ;; the live view; the controller itself may be undisplayed.
+                  (cl-some (lambda (wb) (and (buffer-live-p (cdr wb))
+                                             (get-buffer-window (cdr wb) t)))
+                           (buffer-local-value 'tmux-control--window-buffers
+                                               controller))
                   (selected-window))))
     (condition-case err
         (progn
@@ -7299,24 +7311,34 @@ window.  Does not reseed; callers that resume single-pane do that."
   "Tile every pane of the current tmux window into Emacs windows.
 Each pane is rendered live in its own buffer, arranged to match tmux's
 own layout -- the iTerm \"show every pane\" view -- which is handy for a
-split-pane window such as a Claude Code agent team.  Tiles within the
-controller's own window region, so a non-tmux window sharing the frame is
-left alone; when the controller fills the frame the tiling fills it.
-`tmux-control-untile' (or \\`C-c C-t') returns to the single-pane view."
+split-pane window such as a Claude Code agent team.  Works from the
+connect buffer and from any per-window render buffer (the build runs on
+the controller either way, tiling the session's current window).  Tiles
+within the controller's own window region, so a non-tmux window sharing
+the frame is left alone; when the controller fills the frame the tiling
+fills it.  `tmux-control-untile' (or \\`C-c C-t') returns to the
+single-pane view."
   (interactive)
   (tmux-control--ensure-live)
-  (when tmux-control--controller
-    (user-error "This is a tiled pane; use C-c C-t to untile"))
-  (when tmux-control--tiled
-    (user-error "Already tiling this session"))
-  (let ((size (tmux-control--tiled-region-size (selected-frame) (current-buffer))))
-    ;; Ask tmux to size the window to the Emacs area we tile into -- the frame
-    ;; less any non-tmux window sharing it -- so the resulting %layout-change
-    ;; re-tiles to the exact pane sizes.
-    (setq tmux-control--tiled-client-size size)
-    (tmux-control--send-command
-     (format "refresh-client -C %dx%d" (car size) (cdr size)))
-    (tmux-control--build-tiling (current-buffer))))
+  (when (tmux-control--tiled-mode-p)
+    (user-error (if tmux-control--tiled
+                    "Already tiling this session"
+                  "This is a tiled pane; use C-c C-t to untile")))
+  ;; A per-window render buffer (`tmux-control-window-buffers') also has
+  ;; `tmux-control--controller' set, but it is a plain single-pane view, not
+  ;; a tiled pane: route the tile to the process-owning controller, where the
+  ;; tiling state and the %output fan-out live.  The build tiles the
+  ;; session's CURRENT window -- the one this buffer shows.
+  (let ((controller (or tmux-control--controller (current-buffer))))
+    (with-current-buffer controller
+      (let ((size (tmux-control--tiled-region-size (selected-frame) controller)))
+        ;; Ask tmux to size the window to the Emacs area we tile into -- the
+        ;; frame less any non-tmux window sharing it -- so the resulting
+        ;; %layout-change re-tiles to the exact pane sizes.
+        (setq tmux-control--tiled-client-size size)
+        (tmux-control--send-command
+         (format "refresh-client -C %dx%d" (car size) (cdr size)))
+        (tmux-control--build-tiling controller)))))
 
 (defun tmux-control--reassert-tiling-size (controller frame)
   "Ask tmux to match CONTROLLER's tiling area on FRAME when it has resized.
@@ -7357,45 +7379,74 @@ panes against a now-smaller Emacs window."
 (defun tmux-control-untile ()
   "Return from the tiled multi-pane view to the single-pane live view."
   (interactive)
-  (let ((controller (or tmux-control--controller
-                        (and tmux-control--tiled (current-buffer)))))
-    (unless (and controller (buffer-live-p controller)
-                 (buffer-local-value 'tmux-control--tiled controller))
+  (let ((controller (tmux-control--tiling-controller)))
+    (unless controller
       (user-error "Not tiling"))
     (tmux-control--teardown-tiling controller)
     (with-current-buffer controller
       ;; Hard-clear the frozen pre-tiling screen immediately, so the returning
       ;; single-pane view starts blank rather than showing stale tiled content.
       (tmux-control--write-terminal "\e[3J\e[H\e[2J")
-      ;; Re-resolve the session's real active pane (the cached one can be stale
-      ;; after window switches), THEN resize and seed -- all over the live
-      ;; control connection (in-band, non-blocking).  The previous out-of-band
-      ;; ssh `display-message' plus a synchronous capture froze Emacs for one
-      ;; or two full SSH round trips -- a fresh, unmultiplexed connection -- on
-      ;; every untile of a remote session.  Resizing AFTER the pane is resolved
-      ;; keeps the resize-time pane-size reconciliation on the right pane.
+      ;; Re-resolve the session's real current window and active pane (the
+      ;; cached ones can be stale after window switches), THEN resize and
+      ;; seed -- all over the live control connection (in-band, non-blocking).
+      ;; The previous out-of-band ssh `display-message' plus a synchronous
+      ;; capture froze Emacs for one or two full SSH round trips -- a fresh,
+      ;; unmultiplexed connection -- on every untile of a remote session.
+      ;; Resizing AFTER the pane is resolved keeps the resize-time pane-size
+      ;; reconciliation on the right pane.
       (tmux-control--query
-       "display-message -p \"#{pane_id}\""
+       "display-message -p \"#{window_id} #{pane_id}\""
        (lambda (lines)
          (when (buffer-live-p controller)
            (with-current-buffer controller
-             (let ((pane (and lines (string-trim (car lines)))))
-               (when (and pane (string-match-p "\\`%[0-9]+\\'" pane))
-                 (setq tmux-control--active-pane pane)))
-             (tmux-control--resize-to-window)
-             (tmux-control--seed-screen)
-             ;; The tab bar's window/activity state was not tracked while
-             ;; tiled; refresh it for the returning single-pane view.
-             (when tmux-control-window-tab-bar
+             (let* ((reply (and lines (string-trim (car lines))))
+                    (wid (and reply
+                              (string-match
+                               "\\`\\(@[0-9]+\\) \\(%[0-9]+\\)\\'" reply)
+                              (match-string 1 reply)))
+                    (pane (and wid (match-string 2 reply))))
+               (if (and tmux-control-window-buffers wid
+                        (not (equal wid tmux-control--window-id)))
+                   ;; Per-window render buffers, and the current window is not
+                   ;; the controller's own: hand the view to that window's
+                   ;; render buffer, as a window switch would, instead of
+                   ;; seeding the controller onto a foreign window's pane
+                   ;; (which strands its %output routing once the pane->window
+                   ;; map is consulted).  An existing render buffer went stale
+                   ;; while tiled -- tiling fans %output to pane buffers only
+                   ;; -- so reseed it; a fresh one is seeded by its creation.
+                   (progn
+                     (let* ((existing (tmux-control--window-buffer wid))
+                            (buf (tmux-control--display-window-buffer wid)))
+                       (when (and existing (eq buf existing))
+                         (tmux-control--seed-window-buffer existing wid)))
+                     ;; The controller's own screen was hard-cleared above and
+                     ;; its active pane may have drifted while tiled; reseed it
+                     ;; in the background so its own window stays live.
+                     (when tmux-control--window-id
+                       (tmux-control--seed-window-buffer
+                        controller tmux-control--window-id)))
+                 (when pane
+                   (setq tmux-control--active-pane pane))
+                 (tmux-control--resize-to-window)
+                 (tmux-control--seed-screen)))
+             ;; The tab bar's window/activity state -- and the pane->window
+             ;; map per-window output routing depends on -- were not tracked
+             ;; while tiled; refresh them for the returning single-pane view.
+             (when (or tmux-control-window-tab-bar tmux-control-window-buffers)
                (tmux-control--quiet-activity)
                (tmux-control--refresh-windows)
                (tmux-control--refresh-pane-window-map)))))))))
 
 (defun tmux-control-toggle-tiling ()
   "Toggle between the tiled multi-pane view and the single-pane view.
-Bound to \\`C-c C-t'."
+Keys off `tmux-control--tiled-mode-p', not the raw `tmux-control--controller'
+flag: a per-window render buffer also carries that flag, and treating it as
+a tiled pane made this command untile -- \"Not tiling\" -- instead of tiling
+from any window other than the connect buffer's own.  Bound to \\`C-c C-t'."
   (interactive)
-  (if (or tmux-control--controller tmux-control--tiled)
+  (if (tmux-control--tiled-mode-p)
       (tmux-control-untile)
     (tmux-control-tile)))
 
@@ -7411,12 +7462,12 @@ an already-tiled view re-tiles itself on the echoed `%layout-change'."
     (tmux-control--send-command
      (concat "split-window " flag
              (when pane (format " -t %s" pane))))
-    ;; Auto-tile only from the single-pane controller view (a render buffer
-    ;; has `tmux-control--controller' set and must untile, not tile); an
-    ;; already-tiled session re-tiles itself on the %layout-change.
+    ;; Auto-tile from any single-pane view -- the connect buffer or a
+    ;; per-window render buffer (`tmux-control-tile' routes the latter to its
+    ;; controller); an already-tiled session (which includes every tiled pane
+    ;; buffer) re-tiles itself on the %layout-change instead.
     (when (and tmux-control-split-pane-tiles
-               (not already-tiled)
-               (not tmux-control--controller))
+               (not already-tiled))
       (tmux-control-tile))))
 
 (defun tmux-control-split-pane-right ()


### PR DESCRIPTION
Fixes #114.

## Root cause

The tiling entry points predate per-window render buffers (`5c5c4e0` tiling, 2026-06-04 → `e6b2db6` window buffers, 2026-06-09 → `ed667ed` split commands, 2026-06-20) and read any buffer with `tmux-control--controller` set as a *tiled pane*. But window buffers — the default — set that same flag on every window's render buffer, so from any window other than the connect buffer's own:

- `tmux-control--split-pane` skipped the auto-tile, leaving the single-pane view following the new pane (the reported bug);
- `C-c C-t` tried to **un**tile and errored `Not tiling`;
- `M-x tmux-control-tile` refused with `This is a tiled pane`.

## Fix

- Key the guards off `tmux-control--tiled-mode-p` (true only for a live tiling's controller and its pane buffers), not the raw `tmux-control--controller` flag.
- `tmux-control-tile` invoked from a per-window render buffer routes the build to its process-owning controller, which tiles the session's current window — the one that buffer shows. The tile-arrange root resolution also accepts a window showing one of the session's render buffers, so the build subdivides the live view instead of falling through to whatever window is selected.
- Untile gets the symmetric fix: when the current window is not the controller's own, hand the view to that window's render buffer (reseeded — window buffers don't stream while tiled) instead of seeding the controller onto a foreign window's pane, which stranded its `%output` routing; the controller reseeds onto its own window in the background.

## Verification

Reproduced the issue live (local tmux + GUI Emacs, `emacs -Q` + repo code): connect on window 0, switch to window 2, `tmux-control-split-pane-right` → single-pane view following the new pane; `C-c C-t` → `Not tiling`. With the fix, the same steps auto-tile both panes side by side (foreign non-tmux window preserved), both panes stream live, and the round trip was exercised end to end: untile hands the view back to the window's render buffer on the right pane, the controller heals onto its own window, post-untile streaming and window switching work, split from the connect buffer still auto-tiles, and split while tiled still re-tiles via `%layout-change` (no double tile).

ERT: 213/213 green (two tests updated to the new behavior, three added: routed tile, toggle-from-window-buffer, window-buffers untile hand-off). Clean byte-compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)