### PR TITLE
Make M-x find-file optionally pane-aware

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -383,8 +383,8 @@ for a remote session, lives on another host. So **`find-file` and `dired`
 default to that pane's directory, on the pane's host**: from a buffer
 mirroring a pane on `dev` sitting in `~/proj`, `C-x C-f` opens at
 `/ssh:dev:~/proj/` and you type just the filename, instead of spelling out the
-full TRAMP path. `C-x 4 f` does the same in another window (keeping the live
-pane in view), and `C-x d` opens Dired there.
+full TRAMP path. `C-x 4 f` opens in another window (keeping the live pane in
+view), and `C-x d` opens Dired there.
 
 The remote path is built with **your configured TRAMP method** for that host
 (`tramp-default-method`, or a per-host entry in `tramp-default-method-alist`) —
@@ -395,6 +395,10 @@ hardcoded `/ssh:…`.
 
 - A prefix argument (`C-u C-x C-f`) opens at this buffer's own **local**
   directory instead, for the occasional local file.
+- Emacs does not apply key remapping when a command is named explicitly, so
+  `M-x find-file` keeps its standard local behavior by default.  To make it
+  pane-aware too, set `tmux-control-pane-aware-m-x-find-file` to non-nil; a
+  prefix argument remains the local escape hatch.
 - Only the file-finding commands are pane-aware. The buffer's
   `default-directory` itself stays local and there is no directory tracking, so
   `M-x compile`, `M-x grep`, and similar still run on the machine running

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -2483,6 +2483,34 @@ buffer's own directory with a prefix arg or when the option is off."
           (tmux-control--call-in-pane-directory 'tmux-control-test--record-dir nil)
           (should (equal seen "/local/")))))))             ; option off -> local
 
+(ert-deftest tmux-control-test-m-x-find-file-is-pane-aware ()
+  "An explicit `M-x find-file' reads its argument at the pane directory.
+This covers M-x, which does not honor command remapping; a prefix argument
+still requests the tmux-control buffer's local directory."
+  (let ((default-directory "/local/")
+        (this-command 'find-file)
+        (tmux-control-pane-aware-find-file t)
+        (tmux-control-pane-aware-m-x-find-file t)
+        seen)
+    (cl-letf (((symbol-function 'derived-mode-p) (lambda (&rest _) t))
+              ((symbol-function 'tmux-control--pane-directory)
+               (lambda () "/rpc:dev:/proj/")))
+      (let ((current-prefix-arg nil))
+        (tmux-control--find-file-read-args-around
+         (lambda (&rest _) (setq seen default-directory))))
+      (should (equal seen "/rpc:dev:/proj/"))
+      (let ((current-prefix-arg '(4)))
+        (tmux-control--find-file-read-args-around
+         (lambda (&rest _) (setq seen default-directory))))
+      (should (equal seen "/local/"))
+      ;; The M-x behavior is separately opt-in even when pane-aware file keys
+      ;; remain enabled.
+      (let ((current-prefix-arg nil)
+            (tmux-control-pane-aware-m-x-find-file nil))
+        (tmux-control--find-file-read-args-around
+         (lambda (&rest _) (setq seen default-directory))))
+      (should (equal seen "/local/")))))
+
 ;;; In-band command replies: id-matched block termination, closure queries.
 
 (defmacro tmux-control-test--with-reply-buffer (&rest body)

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -379,6 +379,17 @@ Set this nil to make those commands open at the buffer's own (local)
 directory instead, like ordinary `find-file'."
   :type 'boolean)
 
+(defcustom tmux-control-pane-aware-m-x-find-file nil
+  "Non-nil makes an explicit `M-x find-file' start at the pane's directory.
+
+The ordinary file key is already pane-aware when
+`tmux-control-pane-aware-find-file' is non-nil.  This separate option extends
+that behavior to a command named explicitly through M-x, which Emacs does not
+route through key remapping.  It is opt-in because implementing that behavior
+requires narrowly advising the built-in `find-file' argument reader.  A prefix
+argument still starts at the tmux-control buffer's own local directory."
+  :type 'boolean)
+
 (defcustom tmux-control-window-preview t
   "How `tmux-control-select-window' previews windows as you choose.
 
@@ -2692,6 +2703,27 @@ this buffer's own (local) directory instead.  Bound to the `find-file' key
 `tmux-control-pane-aware-find-file'."
   (interactive "P")
   (tmux-control--call-in-pane-directory #'find-file arg))
+
+(defun tmux-control--find-file-read-args-around (orig-fun &rest args)
+  "Root an explicit `M-x find-file' prompt at the live pane's directory.
+Key remapping handles keys bound to `find-file', but Emacs intentionally does
+not apply command remapping when a command is named explicitly through M-x.
+The interactive arguments are read before advice on `find-file' itself runs,
+so adjust `default-directory' around its argument reader instead."
+  (let ((default-directory
+         (or (and (eq this-command 'find-file)
+                  (derived-mode-p 'tmux-control-mode)
+                  tmux-control-pane-aware-find-file
+                  tmux-control-pane-aware-m-x-find-file
+                  (not current-prefix-arg)
+                  (tmux-control--pane-directory))
+             default-directory)))
+    (apply orig-fun args)))
+
+;; A remap in `tmux-control-mode-map' covers C-x C-f and other keys.  This
+;; narrow advice covers the one route remapping cannot: `M-x find-file'.
+(advice-add #'find-file-read-args :around
+            #'tmux-control--find-file-read-args-around)
 
 (defun tmux-control-find-file-other-window (&optional arg)
   "Like `tmux-control-find-file', but show the file in another window.

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -2722,6 +2722,9 @@ so adjust `default-directory' around its argument reader instead."
 
 ;; A remap in `tmux-control-mode-map' covers C-x C-f and other keys.  This
 ;; narrow advice covers the one route remapping cannot: `M-x find-file'.
+;; Remove first so reloading the package cannot leave stale advice stacked.
+(advice-remove #'find-file-read-args
+               #'tmux-control--find-file-read-args-around)
 (advice-add #'find-file-read-args :around
             #'tmux-control--find-file-read-args-around)
 


### PR DESCRIPTION
## Summary

- add opt-in `tmux-control-pane-aware-m-x-find-file` support
- start an explicit `M-x find-file` at the active pane directory and host
- preserve local behavior with a prefix argument or when the option is disabled
- document and test the behavior

Emacs does not apply command remapping when a command is invoked explicitly through M-x, so this narrowly advises `find-file-read-args` rather than changing the tmux-control buffer's `default-directory`.

## Tests

- `make test EAT_DIR=$HOME/.emacs.default/straight/build/eat`
- `make test-elc EAT_DIR=$HOME/.emacs.default/straight/build/eat`
- 216/216 passing in both modes