### PR TITLE
Guard internal scrollback mode command

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -916,6 +916,17 @@ each wrapped in an evolving prompt line and a status bar.")
     (tmux-control-scrollback-mode)
     (should-not truncate-lines)))
 
+(ert-deftest tmux-control-test-direct-scrollback-mode-command-is-guarded ()
+  "M-x scrollback-mode must not destroy a live connection buffer."
+  (with-temp-buffer
+    (tmux-control-mode)
+    (setq-local tmux-control--session "still-live")
+    (let ((this-command 'tmux-control-scrollback-mode))
+      (should-error (command-execute 'tmux-control-scrollback-mode)
+                    :type 'user-error))
+    (should (derived-mode-p 'tmux-control-mode))
+    (should (equal tmux-control--session "still-live"))))
+
 (ert-deftest tmux-control-test-coalesced-wheel-events-bound ()
   ;; A fast flick coalesces into double-/triple-wheel; those must route to
   ;; the same handlers as a single tick, not fall through to pixel-scroll.

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -921,9 +921,9 @@ each wrapped in an evolving prompt line and a status bar.")
   (with-temp-buffer
     (tmux-control-mode)
     (setq-local tmux-control--session "still-live")
-    (let ((this-command 'tmux-control-scrollback-mode))
-      (should-error (command-execute 'tmux-control-scrollback-mode)
-                    :type 'user-error))
+    ;; Guard noninteractive calls too (`eval-expression', wrapper commands),
+    ;; not only M-x where `this-command' happens to name the mode function.
+    (should-error (tmux-control-scrollback-mode) :type 'user-error)
     (should (derived-mode-p 'tmux-control-mode))
     (should (equal tmux-control--session "still-live"))))
 

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -1021,12 +1021,12 @@ and above the bottom the handler re-dispatches wheel-down there too.")
   (tmux-control--disable-margins))
 
 (defun tmux-control--guard-scrollback-mode-command (orig-fun &rest args)
-  "Prevent direct commands from replacing a live buffer with pager mode.
+  "Prevent replacing a live tmux-control buffer with pager mode.
 `tmux-control-scrollback-mode' is an internal major-mode initializer.  Calling
-it through M-x or a direct key binding runs `kill-all-local-variables' in the
-live tmux-control buffer, discarding its connection state before the mode body
-can reject the call.  The public entry point is `tmux-control-scrollback'."
-  (if (eq this-command 'tmux-control-scrollback-mode)
+it in a live buffer runs `kill-all-local-variables', discarding the connection
+state.  The public `tmux-control-scrollback' command creates a separate buffer
+before initializing the mode there."
+  (if (derived-mode-p 'tmux-control-mode)
       (user-error "Use M-x tmux-control-scrollback to open the pager")
     (apply orig-fun args)))
 

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -1020,6 +1020,21 @@ and above the bottom the handler re-dispatches wheel-down there too.")
   (tmux-control--disable-line-numbers)
   (tmux-control--disable-margins))
 
+(defun tmux-control--guard-scrollback-mode-command (orig-fun &rest args)
+  "Prevent direct commands from replacing a live buffer with pager mode.
+`tmux-control-scrollback-mode' is an internal major-mode initializer.  Calling
+it through M-x or a direct key binding runs `kill-all-local-variables' in the
+live tmux-control buffer, discarding its connection state before the mode body
+can reject the call.  The public entry point is `tmux-control-scrollback'."
+  (if (eq this-command 'tmux-control-scrollback-mode)
+      (user-error "Use M-x tmux-control-scrollback to open the pager")
+    (apply orig-fun args)))
+
+(advice-remove #'tmux-control-scrollback-mode
+               #'tmux-control--guard-scrollback-mode-command)
+(advice-add #'tmux-control-scrollback-mode :around
+            #'tmux-control--guard-scrollback-mode-command)
+
 (defun tmux-control--list-sessions (host socket-name)
   "Return existing tmux session names on HOST using SOCKET-NAME.
 


### PR DESCRIPTION
## Summary

- reject direct `M-x tmux-control-scrollback-mode` before it can mutate a live connection buffer
- direct users to the public `tmux-control-scrollback` command
- add regression coverage proving the live major mode and session state survive the rejected command

`tmux-control-scrollback-mode` is generated as an interactive major-mode command. Invoking it directly runs `kill-all-local-variables` in the live tmux buffer, discarding its process/session locals and turning it into a broken read-only pager in place.

## Tests

- source suite: 223/223 passing
- byte-compiled suite: 223/223 passing