### PR TITLE
Make pane-directory tracking session-wide

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -417,6 +417,12 @@ so `compile`, `grep`, `consult-ripgrep`, project commands, and ordinary file
 commands naturally operate on the pane's host.  Disabling the mode restores
 the buffer's prior local directory.
 
+Tracking is a property of the **session**, not of one buffer: toggling it in
+any of a session's buffers applies to all of them — the connect buffer, every
+window's buffer, and every tiled pane's buffer — and each one follows its own
+pane, so `M-x tmux-control-pane-directory-mode` once is enough however many
+windows you have open.
+
 Synchronization uses asynchronous queries over the existing control
 connection after pane changes and after a quiet moment in pane output.  tmux
 does not emit a dedicated event for `cd`, so a silent directory change that

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -2519,6 +2519,39 @@ buffer's own directory with a prefix arg or when the option is off."
       (tmux-control-pane-directory-mode -1)
       (should (equal default-directory "/local/")))))
 
+(ert-deftest tmux-control-test-pane-directory-mode-is-session-wide ()
+  "Toggling the mode anywhere applies to the session's other render buffers.
+New render buffers already mirror the controller's opt-in
+\(`tmux-control--initialize-render-buffer-mode'), so a toggle that reached
+only the current buffer left a session half-tracking: windows visited
+before the toggle kept a local directory while later ones went remote."
+  (let ((ctrl (generate-new-buffer " *tc-ctrl*"))
+        (win (generate-new-buffer " *tc-win*"))
+        (pane (generate-new-buffer " *tc-pane*")))
+    (unwind-protect
+        (progn
+          (dolist (buf (list win pane))
+            (with-current-buffer buf
+              (setq tmux-control--controller ctrl)
+              (setq-local default-directory "/local/")))
+          (with-current-buffer ctrl
+            (setq-local default-directory "/local/")
+            (setq tmux-control--window-buffers (list (cons "@1" win))
+                  tmux-control--panes (list (cons "%1" pane)))
+            (tmux-control-pane-directory-mode 1))
+          (should (buffer-local-value 'tmux-control-pane-directory-mode win))
+          (should (buffer-local-value 'tmux-control-pane-directory-mode pane))
+          ;; Turning it off from a child turns the whole session off.
+          (with-current-buffer win (tmux-control-pane-directory-mode -1))
+          (should-not (buffer-local-value 'tmux-control-pane-directory-mode ctrl))
+          (should-not (buffer-local-value 'tmux-control-pane-directory-mode pane))
+          ;; A dead sibling in the registry must not break the fan-out.
+          (kill-buffer pane)
+          (with-current-buffer ctrl (tmux-control-pane-directory-mode 1))
+          (should (buffer-local-value 'tmux-control-pane-directory-mode win)))
+      (dolist (buf (list ctrl win pane))
+        (when (buffer-live-p buf) (kill-buffer buf))))))
+
 (ert-deftest tmux-control-test-pane-directory-interactive-opt-in-restores ()
   "A reconnect marker restores mode even without a global mode hook."
   (with-temp-buffer

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -2703,6 +2703,41 @@ is a nonempty absolute path."
   "Return the controller buffer that owns this buffer's tmux connection."
   (or tmux-control--controller (current-buffer)))
 
+(defvar tmux-control--pane-directory-propagating nil
+  "Non-nil while a pane-directory toggle is fanning out to sibling buffers.
+Bound around the fan-out so each sibling's own mode call does not fan out
+again.")
+
+(defun tmux-control--session-render-buffers ()
+  "Return every live render buffer of this buffer's session, controller first.
+A session renders through the controller plus, depending on the mode, a
+buffer per visited window and a buffer per tiled pane."
+  (let ((ctrl (tmux-control--pane-directory-controller)))
+    (when (buffer-live-p ctrl)
+      (cons ctrl
+            (seq-filter
+             #'buffer-live-p
+             (mapcar #'cdr
+                     (append
+                      (buffer-local-value 'tmux-control--window-buffers ctrl)
+                      (buffer-local-value 'tmux-control--panes ctrl))))))))
+
+(defun tmux-control--propagate-pane-directory-mode (state)
+  "Apply pane-directory mode STATE to this session's other render buffers.
+The opt-in is a property of the SESSION, not of one buffer: a new render
+buffer already mirrors the controller's state
+\(`tmux-control--initialize-render-buffer-mode'), so without this a toggle
+left the windows visited before it tracking differently from the ones
+visited after."
+  (unless tmux-control--pane-directory-propagating
+    (let ((tmux-control--pane-directory-propagating t)
+          (self (current-buffer)))
+      (dolist (buf (tmux-control--session-render-buffers))
+        (unless (eq buf self)
+          (with-current-buffer buf
+            (unless (eq (and tmux-control-pane-directory-mode t) state)
+              (tmux-control-pane-directory-mode (if state 1 -1)))))))))
+
 (defun tmux-control--pane-directory-local-fallback ()
   "Return the local directory saved before pane tracking was enabled."
   (if (and tmux-control-pane-directory-mode
@@ -2831,7 +2866,8 @@ change can be refreshed explicitly with `tmux-control-refresh-pane-directory'."
                   #'tmux-control--pane-directory-buffer-displayed nil t)
         (add-hook 'kill-buffer-hook
                   #'tmux-control--cancel-pane-directory-sync nil t)
-        (tmux-control--schedule-pane-directory-sync t))
+        (tmux-control--schedule-pane-directory-sync t)
+        (tmux-control--propagate-pane-directory-mode t))
     (tmux-control--cancel-pane-directory-sync)
     (remove-hook 'kill-buffer-hook
                  #'tmux-control--cancel-pane-directory-sync t)
@@ -2841,7 +2877,8 @@ change can be refreshed explicitly with `tmux-control-refresh-pane-directory'."
       (if (car tmux-control--pane-directory-saved)
           (setq default-directory (cdr tmux-control--pane-directory-saved))
         (kill-local-variable 'default-directory))
-      (setq tmux-control--pane-directory-saved nil))))
+      (setq tmux-control--pane-directory-saved nil))
+    (tmux-control--propagate-pane-directory-mode nil)))
 
 (defun tmux-control--pane-directory ()
   "Return the live pane's working directory as a `default-directory' string.
@@ -3814,10 +3851,14 @@ so the tmux-control keys get out of the way; the mode line shows
       (cancel-timer tmux-control--auto-reconnect-timer))
     (setq tmux-control--auto-reconnect-timer nil)
     ;; Restore the buffer's original local directory before the major mode
-    ;; hook enables pane-directory tracking for the fresh connection.
+    ;; hook enables pane-directory tracking for the fresh connection.  This
+    ;; teardown is buffer-local bookkeeping for the reconnect, not a user
+    ;; opting out, so it must not fan out to the session's other buffers --
+    ;; which the reconnect is about to re-seed anyway.
     (when (bound-and-true-p tmux-control-pane-directory-mode)
       (setq tmux-control--pane-directory-reenable t)
-      (tmux-control-pane-directory-mode -1))
+      (let ((tmux-control--pane-directory-propagating t))
+        (tmux-control-pane-directory-mode -1)))
     (erase-buffer)
     (tmux-control-mode)
     (tmux-control--restore-pane-directory-mode-after-reset)


### PR DESCRIPTION
## Problem

`tmux-control-pane-directory-mode` (new in #119) is a buffer-local minor mode, but a session renders through several buffers: the connect buffer, one per visited window, and one per tiled pane. New render buffers already **mirror the controller's** opt-in state (`tmux-control--initialize-render-buffer-mode`), so the setting is de facto session-scoped — except the toggle itself only ever reached the current buffer.

The result is a session that half-tracks: windows visited *before* you enable the mode keep a local `default-directory`, windows visited *after* go remote. `compile`, `grep`, `project-find-file` then run on a different machine depending on which window you happen to be in.

Reproduced live against a remote session (tmux 3.6b over SSH): with three window buffers already open, `M-x tmux-control-pane-directory-mode` in the connect buffer left all three on `/Users/clay/code/tmux-control/` while the connect buffer went to `/scp:host:/etc/`.

## Fix

Toggling in any of a session's buffers now applies to all of them, each still following its own pane. The fan-out:

- is guarded against re-entry (`tmux-control--pane-directory-propagating`), so a sibling's own mode call does not fan out again;
- skips dead buffers left in the registries;
- is suppressed for the internal disable inside `tmux-control--reset-buffer` — that is reconnect bookkeeping, not a user opting out, and the reconnect re-seeds the siblings anyway.

## Verification

- New ERT test `tmux-control-test-pane-directory-mode-is-session-wide` (fails before the fix), covering enable from the controller, disable from a child, and a dead sibling in the registry. 224/224 green, clean byte-compile.
- Live over SSH: enabling in the connect buffer moved all three open window buffers to their **own** panes' directories (`/home/clay`, `/var/log`, `/etc`); disabling from one window buffer restored every buffer's local directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
