### PR TITLE
Anchor a tiled pane to the terminal's end, not the buffer's

### DIFF
--- a/test/tmux-control-live-oracle.el
+++ b/test/tmux-control-live-oracle.el
@@ -54,16 +54,20 @@ not read as spurious trailing spaces against the ground truth."
     (apply #'string (nreverse out))))
 
 (defun tmux-control-live--pane-visible (buf)
-  "Return BUF's Eat visible screen (last `height' rows) as normalized lines."
+  "Return BUF's Eat visible screen (last `height' rows) as normalized lines.
+Bounded by the TERMINAL's end rather than the buffer's: `tmux-control--message'
+appends its notes after the terminal, and reading to `point-max' counted them
+as screen rows -- reporting a spurious DIFF for a render that is correct."
   (when (buffer-live-p buf)
     (with-current-buffer buf
-      (let ((h (cdr (eat-term-size tmux-control--terminal))))
+      (let ((h (cdr (eat-term-size tmux-control--terminal)))
+            (end (eat-term-end tmux-control--terminal)))
         (save-excursion
-          (goto-char (point-max))
+          (goto-char end)
           (forward-line (- (1- h)))
           (tmux-control-live--rtrim
            (split-string (tmux-control-live--visible-text
-                          (line-beginning-position) (point-max))
+                          (line-beginning-position) end)
                          "\n")))))))
 
 (defun tmux-control-live--tmux-visible (socket pane)

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -4213,13 +4213,14 @@ output), :calls (side-effect invocations in order), :active-pane,
       (eat-term-process-output tmux-control--terminal
                                "L1\r\nL2\r\nL3\r\nL4\r\nL5")
       (eat-term-redisplay tmux-control--terminal))
-    (let ((window (selected-window)))
-      (set-window-buffer window (current-buffer))
-      (tmux-control--anchor-windows-to-screen-top (list window))
-      (let ((anchored (window-start window)))
-        (tmux-control--message "a warning")
+    (save-window-excursion
+      (let ((window (selected-window)))
+        (set-window-buffer window (current-buffer))
         (tmux-control--anchor-windows-to-screen-top (list window))
-        (should (= (window-start window) anchored))))
+        (let ((anchored (window-start window)))
+          (tmux-control--message "a warning")
+          (tmux-control--anchor-windows-to-screen-top (list window))
+          (should (= (window-start window) anchored)))))
     (eat-term-delete tmux-control--terminal)))
 
 (ert-deftest tmux-control-test-message-echoes ()

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -4199,6 +4199,42 @@ output), :calls (side-effect invocations in order), :active-pane,
         (should (cl-some (lambda (c) (string-prefix-p "new-window" c)) sent))
         (should (cl-some (lambda (c) (string-prefix-p "kill-window" c)) sent))))))
 
+(ert-deftest tmux-control-test-anchor-ignores-appended-messages ()
+  ;; The tiled anchor counts the screen's rows back from the END OF THE
+  ;; TERMINAL.  Counting from `point-max' instead let anything appended
+  ;; after the terminal -- `tmux-control--message' writes its notes there --
+  ;; push the anchor down by that many lines, so one warning left a tiled
+  ;; pane permanently scrolled past the top of its own screen.
+  (with-temp-buffer
+    (tmux-control-mode)
+    (setq tmux-control--terminal (eat-term-make (current-buffer) (point-min)))
+    (eat-term-resize tmux-control--terminal 40 5)
+    (let ((inhibit-read-only t))
+      (eat-term-process-output tmux-control--terminal
+                               "L1\r\nL2\r\nL3\r\nL4\r\nL5")
+      (eat-term-redisplay tmux-control--terminal))
+    (let ((window (selected-window)))
+      (set-window-buffer window (current-buffer))
+      (tmux-control--anchor-windows-to-screen-top (list window))
+      (let ((anchored (window-start window)))
+        (tmux-control--message "a warning")
+        (tmux-control--anchor-windows-to-screen-top (list window))
+        (should (= (window-start window) anchored))))
+    (eat-term-delete tmux-control--terminal)))
+
+(ert-deftest tmux-control-test-message-echoes ()
+  ;; A note appended below the terminal can sit off-screen (the view shows
+  ;; the terminal's screen), so it must also reach the echo area or it is
+  ;; invisible.
+  (with-temp-buffer
+    (tmux-control-mode)
+    (let (echoed)
+      (cl-letf (((symbol-function 'message)
+                 (lambda (fmt &rest args) (setq echoed (apply #'format fmt args)))))
+        (tmux-control--message "connection lost"))
+      (should (equal echoed "[tmux-control] connection lost"))
+      (should (string-match-p "connection lost" (buffer-string))))))
+
 (ert-deftest tmux-control-test-eat-cursor-xy-reads-terminal-cursor ()
   ;; The drift detector compares tmux's 0-indexed #{cursor_x},#{cursor_y}
   ;; with Eat's own cursor; the accessor must convert Eat's 1-indexed

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -5743,8 +5743,13 @@ behavior is preserved."
                      (eat-term-live-p tmux-control--terminal)
                      (cdr (eat-term-size tmux-control--terminal)))))
     (when (and height (> height 0))
+      ;; Count back from the END OF THE TERMINAL, not the end of the buffer.
+      ;; `tmux-control--message' appends its notes AFTER the terminal, and
+      ;; anchoring on `point-max' let one warning push this pane's view that
+      ;; many lines past the top of its own screen -- permanently, since the
+      ;; anchor is recomputed from the same stale reference on every flush.
       (let ((top (save-excursion
-                   (goto-char (point-max))
+                   (goto-char (eat-term-end tmux-control--terminal))
                    (forward-line (- (1- height)))
                    (line-beginning-position))))
         (dolist (window windows)
@@ -6432,11 +6437,16 @@ never steals the window the user is looking at."
     (delete-process tmux-control--process)))
 
 (defun tmux-control--message (message)
-  "Append MESSAGE to the current tmux-control buffer."
+  "Append MESSAGE to the current tmux-control buffer and echo it.
+The appended copy lands after the terminal, which the view does not
+necessarily reach -- a tiled pane shows exactly its screen -- so the echo
+area is what makes a warning reliably visible; the buffer copy is the
+record that survives the next keystroke."
   (let ((inhibit-read-only t))
     (goto-char (point-max))
     (insert (propertize (format "\n[tmux-control] %s\n" message)
-                        'face 'font-lock-comment-face))))
+                        'face 'font-lock-comment-face)))
+  (message "[tmux-control] %s" message))
 
 
 ;;;; Per-window render buffers (window scrollback persistence)

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -5733,10 +5733,13 @@ cursor position and their cursor line is kept visible."
 
 (defun tmux-control--anchor-windows-to-screen-top (windows)
   "Set each of WINDOWS to start at the top of the terminal's current screen.
-The current screen is the last `eat-term' height rows of the buffer, so
-this reveals a full-screen TUI from its top while still showing the latest
-screen of a scrolling pane.  `tmux-control--keep-cursor-visible' runs after
-and only pulls the start forward when the cursor would otherwise fall below
+The current screen is the last `eat-term' height rows OF THE TERMINAL --
+counted back from `eat-term-end', not from the end of the buffer, which
+also holds anything appended after the terminal (see
+`tmux-control--message') -- so this reveals a full-screen TUI from its top
+while still showing the latest screen of a scrolling pane.
+`tmux-control--keep-cursor-visible' runs after and only pulls the start
+forward when the cursor would otherwise fall below
 the body (e.g. a tall prompt glyph on a scrolling log), so the follow-bottom
 behavior is preserved."
   (let ((height (and tmux-control--terminal
@@ -6436,17 +6439,17 @@ never steals the window the user is looking at."
     (set-process-sentinel tmux-control--process #'ignore)
     (delete-process tmux-control--process)))
 
-(defun tmux-control--message (message)
-  "Append MESSAGE to the current tmux-control buffer and echo it.
+(defun tmux-control--message (text)
+  "Append TEXT to the current tmux-control buffer and echo it.
 The appended copy lands after the terminal, which the view does not
 necessarily reach -- a tiled pane shows exactly its screen -- so the echo
 area is what makes a warning reliably visible; the buffer copy is the
 record that survives the next keystroke."
   (let ((inhibit-read-only t))
     (goto-char (point-max))
-    (insert (propertize (format "\n[tmux-control] %s\n" message)
+    (insert (propertize (format "\n[tmux-control] %s\n" text)
                         'face 'font-lock-comment-face)))
-  (message "[tmux-control] %s" message))
+  (message "[tmux-control] %s" text))
 
 
 ;;;; Per-window render buffers (window scrollback persistence)


### PR DESCRIPTION
## Problem

`tmux-control--message` appends its notes **after** the Eat terminal region, but `tmux-control--anchor-windows-to-screen-top` counted the screen's rows back from `point-max`. So any note — the alt-screen warning, `tmux command failed`, a seed that could not resolve its pane — pushed a tiled pane's view down by the note's line count.

It is permanent, not transient: the anchor recomputes from the same (now wrong) reference on every output flush, so the pane stays scrolled past the top of its own screen for the rest of the session.

Reproduced live on a tiled remote pane (tmux 3.6b over SSH): with the pane's screen filled with numbered lines, one `tmux-control--message` moved `window-start` from `LINE19` to `LINE29` and it stayed there.

## Fix

- Anchor on `eat-term-end` rather than `point-max`. Live-verified: `window-start` no longer moves when a note is appended, and the render still matches `capture-pane`.
- `tmux-control--message` now also **echoes**. With the anchor honest, a note below the terminal is off-screen exactly when it matters — a tiled pane shows precisely its screen and nothing more — so the echo area is what makes a warning visible. The buffer copy stays as the record that survives the next keystroke.
- The live oracle (`test/tmux-control-live-oracle.el`) had the same `point-max` assumption and so reported a spurious `DIFF` for a *correct* render once a note had been appended; it now stops at the terminal's end. (The chaos harness already read `display-beginning`..`end`, so it was unaffected.)

## Verification

- Two new ERT tests, both failing before the fix: `tmux-control-test-anchor-ignores-appended-messages` (real Eat terminal, real window) and `tmux-control-test-message-echoes`. 225/225 green, clean byte-compile.
- Live over SSH, tiled: anchor stable across an appended note; oracle `MATCH` against `capture-pane` with the note present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
