### PR TITLE
Report tmux's own error text when a command fails

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -2702,6 +2702,24 @@ before the toggle kept a local directory while later ones went remote."
      (should (null called))
      (should-not tmux-control--collecting-command))))
 
+(ert-deftest tmux-control-test-error-reports-tmux-reason ()
+  ;; A failed command reported only the internal reply kind ("tmux command
+  ;; failed (:ignore)"), throwing away the block's content -- which is where
+  ;; tmux says WHY.  Report tmux's own words; fall back to the kind when the
+  ;; block carried no text.
+  (tmux-control-test--with-reply-buffer
+   (setq tmux-control--command-queue (list (cons :ignore (float-time))))
+   (tmux-control--handle-line "%begin 1 9 0")
+   (tmux-control--handle-line "can't find window: @9")
+   (tmux-control--handle-line "%error 2 9 0")
+   (should (string-match-p "can't find window: @9" (buffer-string)))
+   (should-not (string-match-p ":ignore" (buffer-string))))
+  (tmux-control-test--with-reply-buffer
+   (setq tmux-control--command-queue (list (cons :ignore (float-time))))
+   (tmux-control--handle-line "%begin 1 9 0")
+   (tmux-control--handle-line "%error 2 9 0")
+   (should (string-match-p "tmux command failed" (buffer-string)))))
+
 (ert-deftest tmux-control-test-block-collects-notification-shaped-content ()
   ;; Lines that look like %exit/%pause/%continue but arrive INSIDE a reply
   ;; block are captured pane content (a control-mode transcript), not

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -4908,7 +4908,11 @@ backing off to the cap."
       (tmux-control--finish-command-output))
      ((and (string-prefix-p "%error " line)
            (tmux-control--block-terminator-p line))
-      (let ((kind tmux-control--current-command-kind))
+      (let ((kind tmux-control--current-command-kind)
+            ;; tmux sends its reason as the block's content lines; they are
+            ;; the only account of WHY a command failed, so keep them before
+            ;; the reply state is reset.
+            (reason (string-join (reverse tmux-control--command-output) "; ")))
         (setq tmux-control--collecting-command nil)
         (setq tmux-control--command-output nil)
         (setq tmux-control--current-command-kind :ignore)
@@ -4918,7 +4922,13 @@ backing off to the cap."
         (if (functionp kind)
             (funcall kind nil)
           (tmux-control--message
-           (format "tmux command failed (%s)" kind)))))
+           ;; Report what tmux said ("can't find window: @9"), not the
+           ;; internal reply kind, which named nothing a user could act on.
+           ;; The reason is tmux's own text; the command's arguments are
+           ;; deliberately not echoed (they can carry pane input).
+           (if (string-empty-p reason)
+               (format "tmux command failed (%s)" kind)
+             (format "tmux: %s" reason))))))
      ;; While collecting a reply block, any other line is block CONTENT --
      ;; including lines that merely LOOK like notifications (a captured
      ;; control-mode transcript can hold %exit/%pause/%continue).  This sits


### PR DESCRIPTION
## Problem

When tmux answers a command with `%error`, the handler discarded the block's content lines — which is precisely where tmux says *why* — and printed the internal reply-handler kind instead:

```
[tmux-control] tmux command failed (:ignore)
```

That names nothing a user (or a bug report) can act on. I hit it while bug hunting: six of these appeared in a live buffer and told me nothing about which command had failed or why. It is also the missing signal in #116-class reports, where a command silently fails and a buffer is left stranded.

## Fix

Keep the reply block's lines and report tmux's own words:

```
[tmux-control] tmux: can't find window: @9
```

The old phrasing remains as the fallback when the block carried no text.

The command's **arguments are deliberately not echoed**: keystrokes ride `send-keys`, so printing the failing command could reproduce whatever someone typed into a pane. tmux's message already names the target, which is the part that matters.

## Verification

New ERT test `tmux-control-test-error-reports-tmux-reason` (verified failing before the fix — it asserts both the reason path and the empty-block fallback). 225/225 green, clean byte-compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
