### PR TITLE
Seed the buffer that asked for the repaint, not the controller

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -2689,6 +2689,51 @@ before the toggle kept a local directory while later ones went remote."
                           "%begin 5 5 0"
                           "%error 999 7 0"))))))
 
+(ert-deftest tmux-control-test-seed-screen-targets-its-own-buffer ()
+  ;; The :cursor-pos/:pane-modes/:capture replies are dispatched by kind in
+  ;; the CONTROLLER, so the tagged seed can only paint the controller.  Run
+  ;; from a child render buffer it painted that child's pane into the
+  ;; controller -- the connect buffer then showed a FOREIGN window's screen
+  ;; (reproduced live: the controller, registered for window @2, rendering
+  ;; pane %0's screen verbatim) while the child stayed stale.  A child must
+  ;; use its own closure-targeted seeder.
+  (let ((ctrl (generate-new-buffer " *tc-ctrl*"))
+        (win (generate-new-buffer " *tc-win*"))
+        (pane (generate-new-buffer " *tc-pane*"))
+        sent seeded-windows seeded-panes)
+    (unwind-protect
+        (cl-letf (((symbol-function 'tmux-control--send-command)
+                   (lambda (command &optional kind) (push (cons kind command) sent)))
+                  ((symbol-function 'tmux-control--seed-window-buffer)
+                   (lambda (buffer id &rest _) (push (cons (buffer-name buffer) id)
+                                                     seeded-windows)))
+                  ((symbol-function 'tmux-control--seed-pane-buffer-async)
+                   (lambda (buffer _controller) (push (buffer-name buffer)
+                                                      seeded-panes))))
+          ;; A per-window render buffer seeds through the window seeder.
+          (with-current-buffer win
+            (setq tmux-control--controller ctrl
+                  tmux-control--window-id "@2"
+                  tmux-control--active-pane "%2")
+            (tmux-control--seed-screen))
+          (should (equal seeded-windows '((" *tc-win*" . "@2"))))
+          (should-not sent)
+          ;; A tiled pane render buffer (no window id) seeds through the pane
+          ;; seeder.
+          (with-current-buffer pane
+            (setq tmux-control--controller ctrl
+                  tmux-control--active-pane "%7")
+            (tmux-control--seed-screen))
+          (should (equal seeded-panes '(" *tc-pane*")))
+          (should-not sent)
+          ;; The controller itself still uses the tagged-reply seed.
+          (with-current-buffer ctrl
+            (setq tmux-control--active-pane "%1")
+            (tmux-control--seed-screen))
+          (should (assq :capture sent))
+          (should (assq :cursor-pos sent)))
+      (dolist (b (list ctrl win pane)) (when (buffer-live-p b) (kill-buffer b))))))
+
 (ert-deftest tmux-control-test-query-callback-gets-nil-on-error ()
   ;; %error completes a closure query with nil so an async consumer can
   ;; show the failure instead of waiting forever.

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -5330,7 +5330,28 @@ guessing from the prompt) and replays the pane's mode state -- alternate
 screen, mouse tracking -- that `capture-pane' contents alone cannot carry.
 tmux replies in command order, so the `:cursor-pos' and `:pane-modes'
 replies land before the `:capture' reply that paints the screen and
-consumes them."
+consumes them.
+
+Those replies are dispatched by KIND in the CONTROLLER buffer, so this
+seed can only ever paint the controller's own terminal.  Called from a
+child render buffer it would therefore paint that buffer's pane INTO THE
+CONTROLLER -- leaving the connect buffer showing a foreign window's
+screen while the buffer that asked for the repaint stayed stale.  A child
+is routed to its own closure-targeted seeder instead."
+  (if (and tmux-control--controller (buffer-live-p tmux-control--controller))
+      (cond
+       (tmux-control--window-id
+        (tmux-control--seed-window-buffer (current-buffer)
+                                          tmux-control--window-id))
+       (tmux-control--active-pane
+        (tmux-control--seed-pane-buffer-async (current-buffer)
+                                              tmux-control--controller)))
+    (tmux-control--seed-own-screen)))
+
+(defun tmux-control--seed-own-screen ()
+  "Seed the CONTROLLER's terminal from its own active pane.
+The tagged-reply seed proper; see `tmux-control--seed-screen', which
+routes child render buffers away from it."
   (when tmux-control--active-pane
     ;; Start each seed without a cursor or modes: the :cursor-pos and
     ;; :pane-modes replies fill them in before :capture, and if a query


### PR DESCRIPTION
## Problem

`tmux-control--seed-screen` drives its seed with **tagged** commands (`:cursor-pos`, `:pane-modes`, `:capture`), and tagged replies are dispatched by kind in the **controller** buffer — the process filter's buffer. So the `:capture` reply always painted the *controller's* terminal, no matter which buffer asked for the seed.

Called from a child render buffer — a per-window buffer (`tmux-control-window-buffers`, **on by default**) or a tiled pane — that painted the child's pane **into the connect buffer**. The connect buffer was then left showing a foreign window's screen, permanently, while the buffer that asked for the repaint stayed stale.

Two everyday paths reach it:

- **`tmux-control-clear-and-repaint`** — the command the README prescribes for exactly this symptom ("if the live view ever drifts a row or looks scrambled, press `C-c C-l`"), so the remedy for a drifted view created a worse one;
- **`tmux-control--heal-if-drifted`**, the opt-in `tmux-control-auto-heal-drift` check.

### How it was found

The repo's chaos soak, pointed at a **remote** session (claylien, tmux 3.6b over real SSH) instead of a local socket, reproduced it deterministically — same seed, same step. The frozen state showed the connect buffer registered for window `@2`, with `tmux-control--active-pane` `%2`, rendering **pane `%0`'s screen verbatim** (`4959` / `p67 one` / `p93 two^C` / `echo c988`, byte-identical to `capture-pane -t %0`).

## Fix

A child render buffer routes to its own closure-targeted seeder — `tmux-control--seed-window-buffer` for a window buffer, `tmux-control--seed-pane-buffer-async` for a tiled pane. The controller's own path is unchanged, split out as `tmux-control--seed-own-screen`.

## Verification

Live on the remote session, running `tmux-control-clear-and-repaint` while looking at **window 0's** buffer:

| | controller screen changed | controller shows | tmux truth for controller's pane |
|---|---|---|---|
| before | **yes** | `MARKER-%0` | `MARKER-%2` |
| after | no | `MARKER-%2` | `MARKER-%2` |

And the repaint now heals the buffer it was invoked in: a window buffer deliberately corrupted to `GARBAGE-XYZ` came back matching `capture-pane` after `C-c C-l`.

New ERT test `tmux-control-test-seed-screen-targets-its-own-buffer` (verified failing before the fix) covers all three cases: window buffer → window seeder, tiled pane buffer → pane seeder, controller → tagged-reply seed. 228/228 green, clean byte-compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
