### PR TITLE
Verify a window's screen when you switch back to it

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,15 @@ emulation that drops a display row when a full-screen TUI repaints, so the
 offset can accumulate over redraws; it's tracked upstream at
 [emacs-eat#263](https://codeberg.org/akib/emacs-eat/issues/263).
 
-To heal it **automatically** instead, set `tmux-control-auto-heal-drift` to
-non-nil: an idle check then compares the rendered screen to tmux's own and
-reseeds a drifted pane on its own.  It's off by default because the check costs
+**Switching to a window always heals it**: a window's buffer keeps streaming
+while you are looking at another one, so it can accumulate that drift in the
+background — arriving at it verifies the screen against tmux and repaints only
+if they differ (one `capture-pane` per switch, no repaint when it already
+matches).
+
+To heal the window you are *already looking at* **automatically**, set
+`tmux-control-auto-heal-drift` to non-nil: an idle check then compares the
+rendered screen to tmux's own and reseeds a drifted pane on its own.  It's off by default because the check costs
 one `capture-pane` round trip per burst of output (taken only when a pane is
 displayed, idle, and on the normal screen) — fine on a fast link, your call on
 a slow one; see the variable's docstring for the exact gating.

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -3081,6 +3081,84 @@ output), :calls (side-effect invocations in order), :active-pane,
 
 ;;; Per-window render buffers.
 
+(ert-deftest tmux-control-test-arrival-verifies-live-screen ()
+  ;; A window's render buffer keeps streaming in the background, where Eat can
+  ;; accumulate a row of divergence (emacs-eat#263).  Nothing repaints a buffer
+  ;; that is merely switched to -- that is what preserves its scrollback -- so
+  ;; the drift used to survive every arrival (live-reproduced: a corrupted
+  ;; background buffer arrived still corrupted).  Every arrival route already
+  ;; converges on `tmux-control--snap-to-live-screen\', so the check lives
+  ;; there: it runs when a window ARRIVES at the buffer, and not when the
+  ;; buffer-local hook merely fires for unrelated window traffic.
+  (let (healed)
+    (cl-letf (((symbol-function 'tmux-control--heal-on-arrival)
+               (lambda (buffer) (push (buffer-name buffer) healed)))
+              ((symbol-function 'eat--synchronize-scroll) (lambda (_windows) nil)))
+      (with-temp-buffer
+        (tmux-control-mode)
+        (setq tmux-control--terminal (eat-term-make (current-buffer) (point-min)))
+        (eat-term-resize tmux-control--terminal 20 5)
+        (save-window-excursion
+          (let ((window (selected-window)))
+            (set-window-buffer window (current-buffer))
+            ;; Arrival: the window was showing something else.
+            (cl-letf (((symbol-function 'window-old-buffer) (lambda (_w) nil)))
+              (tmux-control--snap-to-live-screen window))
+            (should (= (length healed) 1))
+            ;; Not an arrival: the hook also fires for windows whose buffer did
+            ;; not change, and those must not pay a capture.
+            (setq healed nil)
+            (cl-letf (((symbol-function 'window-old-buffer)
+                       (let ((buf (current-buffer))) (lambda (_w) buf))))
+              (tmux-control--snap-to-live-screen window))
+            (should-not healed)))
+        (eat-term-delete tmux-control--terminal)))))
+
+(ert-deftest tmux-control-test-arrival-verify-dedupes ()
+  ;; One switch reaches the check more than once -- the window swap, the
+  ;; %session-window-changed echo, and the display hook once redisplay runs --
+  ;; and they are the same arrival, so only the first pays a capture.  Both
+  ;; call sites exist because neither alone is enough: the swap misses
+  ;; `switch-to-buffer\' and window-configuration restores, and the hook waits
+  ;; on redisplay (measured: it fired once in a 40-step soak).
+  (let ((checks 0))
+    (cl-letf (((symbol-function 'tmux-control--heal-if-drifted)
+               (lambda (_buffer) (cl-incf checks)))
+              ((symbol-function 'tmux-control--alt-screen-p) (lambda () nil)))
+      (with-temp-buffer
+        (setq tmux-control--active-pane "%1")
+        (tmux-control--heal-on-arrival (current-buffer))
+        (tmux-control--heal-on-arrival (current-buffer))
+        (tmux-control--heal-on-arrival (current-buffer))
+        (should (= checks 1))
+        ;; A later, genuinely separate arrival verifies again.
+        (setq tmux-control--arrival-verified
+              (- (float-time) tmux-control--arrival-verify-interval 1))
+        (tmux-control--heal-on-arrival (current-buffer))
+        (should (= checks 2))))))
+
+(ert-deftest tmux-control-test-heal-on-arrival-skips-alt-screen ()
+  ;; A full-screen application owns its display and repaints itself; the idle
+  ;; drift check skips those panes and arrival must agree, or a repaint from
+  ;; `capture-pane' would fight the application.
+  (let (healed)
+    (cl-letf (((symbol-function 'tmux-control--heal-if-drifted)
+               (lambda (buffer) (push (buffer-name buffer) healed))))
+      (with-temp-buffer
+        (setq tmux-control--active-pane "%1")
+        (cl-letf (((symbol-function 'tmux-control--alt-screen-p) (lambda () t)))
+          (tmux-control--heal-on-arrival (current-buffer))
+          (should-not healed))
+        (cl-letf (((symbol-function 'tmux-control--alt-screen-p) (lambda () nil)))
+          (tmux-control--heal-on-arrival (current-buffer))
+          (should healed)))
+      ;; No pane resolved yet: nothing to compare against.
+      (setq healed nil)
+      (with-temp-buffer
+        (setq tmux-control--active-pane nil)
+        (tmux-control--heal-on-arrival (current-buffer))
+        (should-not healed)))))
+
 (ert-deftest tmux-control-test-window-buffer-registry ()
   ;; Register/lookup round-trips; killing a render buffer deregisters it.
   (with-temp-buffer

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -5353,6 +5353,47 @@ wide character does not read as spurious trailing space, matching tmux's
         (tmux-control--rtrim-screen-lines
          (split-string (apply #'string (nreverse out)) "\n"))))))
 
+(defconst tmux-control--arrival-verify-interval 1.0
+  "Seconds within which a second arrival check for a buffer is redundant.
+One switch reaches the check twice over -- the window-swap call and the
+`%session-window-changed' tmux echoes back, plus the display hook when
+redisplay runs -- and they are the same arrival, so only the first pays a
+capture.")
+
+(defvar-local tmux-control--arrival-verified 0
+  "When this buffer's screen was last verified on arrival (`float-time').")
+
+(defun tmux-control--heal-on-arrival (buffer)
+  "Verify BUFFER's screen against tmux when a window arrives at it.
+A window's render buffer keeps streaming in the background, and Eat can
+accumulate a row of divergence over a long incremental stream (upstream:
+emacs-eat#263).  Nothing repaints a buffer that is merely switched to --
+that is exactly what preserves its accumulated scrollback -- so such
+drift used to survive every arrival and stay for the rest of the session.
+
+Costs one in-band `capture-pane' per arrival, and repaints only on a real
+difference.  Unlike the idle `tmux-control-auto-heal-drift' poll this is
+not optional: it answers a user action, and \"arriving at a window shows
+its live screen\" is the documented contract.  A pane truly on the
+alternate screen is skipped, as in `tmux-control--maybe-heal-drift': a
+full-screen application owns and repaints its own display.
+
+Called from BOTH arrival paths, and self-deduplicating across them (see
+`tmux-control--arrival-verify-interval'): the window-swap covers the
+switch commands immediately, while the display hook covers the routes
+that never reach it -- `switch-to-buffer', a window-configuration
+restore -- and would otherwise be the only path, one that waits on
+redisplay."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (let ((now (float-time)))
+        (when (and tmux-control--active-pane
+                   (not (tmux-control--alt-screen-p))
+                   (> (- now tmux-control--arrival-verified)
+                      tmux-control--arrival-verify-interval))
+          (setq tmux-control--arrival-verified now)
+          (tmux-control--heal-if-drifted buffer))))))
+
 (defun tmux-control--heal-if-drifted (buffer)
   "Capture BUFFER's pane in-band; reseed it only if its render has drifted."
   (let ((target buffer)
@@ -5784,7 +5825,16 @@ buffers are skipped: the tiling layer anchors its own windows
                                                  tmux-control--controller)))
                    (fboundp 'eat--synchronize-scroll))
           (let ((eat-terminal tmux-control--terminal))
-            (eat--synchronize-scroll (list window))))))))
+            (eat--synchronize-scroll (list window)))
+          ;; Snapping to the live screen shows whatever the background stream
+          ;; left in this buffer -- and over a long incremental stream Eat can
+          ;; accumulate a row of divergence from the pane's true screen
+          ;; (upstream: emacs-eat#263).  Nothing repaints a buffer that is
+          ;; merely switched to, since that is exactly what preserves its
+          ;; scrollback, so the drift used to survive every arrival and stay
+          ;; for the rest of the session.  Verify here, where every arrival
+          ;; route already converges, and repaint only on a real difference.
+          (tmux-control--heal-on-arrival buffer))))))
 
 (defun tmux-control--feed-terminal (output)
   "Process decoded terminal OUTPUT into Eat without redisplaying.
@@ -6879,7 +6929,13 @@ no-ops that strand the view until something happens to resync them."
                (or swapped (not (eq prior new)))
                (get-buffer-window new t))
       (with-current-buffer new
-        (tmux-control--resize-to-window)))
+        (tmux-control--resize-to-window))
+      ;; Verify the screen the switch lands on.  The display hook does this
+      ;; too, but only once redisplay runs `window-buffer-change-functions',
+      ;; so a switch made from a command (or a batch of them) would otherwise
+      ;; show the stale screen until Emacs got around to redisplaying.  The
+      ;; check dedupes against the hook, so this is still one capture.
+      (tmux-control--heal-on-arrival new))
     ;; Record the swap unconditionally: `tmux-control--session-display-buffer'
     ;; readers (the flock switcher, connect-or-switch) find the session's
     ;; on-screen buffer through this pointer, and it must track the session's


### PR DESCRIPTION
## Problem

A window's render buffer keeps streaming while you look at another window — that is the point of `tmux-control-window-buffers`. Over a long incremental stream Eat can accumulate a row of divergence from the pane's true screen (upstream: [emacs-eat#263](https://codeberg.org/akib/emacs-eat/issues/263), the one the README's troubleshooting section already describes).

Nothing repaints a buffer that is merely **arrived at** — that is exactly what preserves its accumulated scrollback — so once a background buffer drifted, the drift survived every switch and stayed for the rest of the session.

**Live-reproduced** against a remote session (claylien, tmux 3.6b over SSH). A background window buffer left holding a bad row:

| | screen |
|---|---|
| while in the background | `DRIFTED-BACKGROUNDecho BG-OUTPUT` |
| after switching to it (before this PR) | `DRIFTED-BACKGROUNDecho BG-OUTPUT` |
| `capture-pane` truth | `clay@aurora:~$ echo BG-OUTPUT` |

This is the shape the remote chaos soak kept reporting: the line above the prompt missing, in a window it had switched away from and back to.

## Fix

Verify on arrival, repaint **only** on a real difference, reusing the comparison the opt-in idle heal already uses.

Called from **both** arrival paths, because neither alone is enough:

- the **window swap** (`tmux-control--display-window-buffer`) covers the switch commands the moment they run;
- **`tmux-control--snap-to-live-screen`** covers every route that never reaches the swap — `switch-to-buffer`, a window-configuration restore, returning from the pager.

I built the hook-only version first, because every arrival route converges there and it looked like the clean single place. Then I measured it: `window-buffer-change-functions` run during **redisplay**, and across a 40-step soak the check fired **once**. Elegant and nearly inert. With both call sites it fires 14 times over the same 40 steps, and the seed that had 3 failures goes to 0.

The two paths deduplicate against each other with a short per-buffer interval (`tmux-control--arrival-verify-interval`), so one real arrival still costs one capture — that also absorbs the second call every switch makes anyway, since tmux echoes `%session-window-changed` back for our own switch. Verified per-buffer, so cycling several windows quickly still checks each one.

A pane truly on the alternate screen is skipped, as in `tmux-control--maybe-heal-drift`: a full-screen application owns and repaints its own display. (With `alternate-screen off` — which some setups use — a TUI renders on the normal screen and *is* verified, which is where that drift actually accumulates.)

## Verification

**Parallel A/B soak**: six seeds × 60 steps, `main` and this branch running simultaneously against separate sessions on the same host. A single before/after run proves nothing here — I watched one seed give 0 failures and then 3 on identical code.

| seed | main | with this + #126 |
|---|---|---|
| 4242 | 3 | **0** |
| 99999 | 4 | **0** |
| 31337 | 1 | 1 |
| 2718281 | 0 | 0 |
| 5150 | 1 | 1 |
| 8675309 | 0 | 0 |
| **total** | **9** | **2** |

No seed got worse, and the two biggest offenders went to zero. The two remaining single failures are the same divergence happening *while a window is on screen* rather than on arrival — that is what the opt-in `tmux-control-auto-heal-drift` idle check is for, and it is unchanged here.

Plus: the live repro above now arrives matching `capture-pane` exactly; three new ERT tests (a real arrival verifies and an unrelated hook firing does not; the dedupe holds and expires; alt-screen and no-pane are skipped), all verified failing before the fix; 233/233 green; clean byte-compile.

## Side benefit

A window whose initial seed silently failed — the failure mode in #116 — now repaints itself the next time you arrive at it, instead of sitting on its placeholder forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
