### PR TITLE
Bump version to 0.5.0

### DIFF
--- a/tmux-control.el
+++ b/tmux-control.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2026  Clay Sheaff
 
 ;; Author: Clay Sheaff
-;; Version: 0.4.0
+;; Version: 0.5.0
 ;; Package-Requires: ((emacs "29.1") (eat "0.9.4"))
 ;; Keywords: terminals, tmux
 ;; URL: https://github.com/csheaff/tmux-control


### PR DESCRIPTION
Bumps `;; Version:` to 0.5.0 — a month and 26 commits since v0.4.0 (2026-06-27), with one new opt-in feature and three render-correctness fixes.

## Since v0.4.0

**New**

- **Pane-directory tracking** (#119). `find-file` / `dired` in a tmux-control buffer already default to the pane's own directory on the pane's host; the opt-in `tmux-control-pane-directory-mode` goes further and makes `default-directory` itself follow the pane, so `compile`, `grep`, `consult-ripgrep` and project commands run there too. Tracking is **session-wide** — toggling it in any of a session's buffers applies to all of them (#121).

**Render correctness** — three distinct bugs, all found by pointing the chaos soak at a *remote* session over SSH:

- **The repaint painted the wrong buffer** (#124). `tmux-control--seed-screen` drives its seed with tagged commands, and tagged replies are dispatched in the controller — so a repaint requested from a per-window buffer (the default view) painted that window's pane *into the connect buffer*, permanently. Reached by `tmux-control-clear-and-repaint`, i.e. the command the README prescribes for a drifted view, and by the opt-in auto-heal.
- **Drift was never repaired on arrival** (#127). A window's buffer keeps streaming in the background, where Eat can accumulate a row of divergence; nothing repainted a buffer merely switched to, so the drift survived every switch. Arriving now verifies against tmux and repaints only on a real difference.
- **A seed could paint a stale capture** (#126). Output arriving after tmux ran `capture-pane` but before the paint was rendered and then erased by the paint. Cursor-only verification cannot see it, since the cursor still agrees.
- **Tiled panes**: the view anchor counted from the buffer's end, so one appended `[tmux-control]` note scrolled a pane permanently past the top of its own screen (#122).
- Tiling entry points fixed for per-window render buffers (#115); seeds replay pane terminal modes (alt screen, mouse) into Eat; the alt-screen-off warning is throttled across reconnects.

**Diagnostics & robustness**

- A failed tmux command now reports **tmux's own words** (`tmux: can't find window: @9`) instead of the internal reply kind (#123). Command arguments are deliberately not echoed — keystrokes ride `send-keys`.
- `tmux-control-scrollback-mode` is guarded against being invoked in a live buffer (#120).

**Developer tooling**

- The live oracle reads Eat's display region rather than counting buffer lines back from the end, which over-read into scrollback and reported false `DIFF`s (#125).

## Verification

233 ERT green, clean byte-compile, and a parallel A/B soak against a remote tmux 3.6b over SSH (six seeds × 60 steps, main and this tree run simultaneously against separate sessions): **9 failures on v0.4.0-era main → 2**, no seed worse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
