### PR TITLE
Handle normalized control-mode delimiters

### DIFF
--- a/test/tmux-control-integration.el
+++ b/test/tmux-control-integration.el
@@ -542,6 +542,39 @@ buffer while another window is current."
 
 ;;; Tab-bar activity: background output flags a window; visiting it clears it.
 
+(ert-deftest tmux-control-it-new-window-buffer-seeds-after-connect ()
+  "A new window replaces its loading placeholder after connecting.
+Covers issue #116: pre-existing-window tests do not exercise the notification
+and asynchronous seed chain used by `tmux-control-new-window'."
+  (skip-unless (tmux-control-it--available-p))
+  (tmux-control-it--tmux-ok "kill-server")
+  (tmux-control-it--tmux "new-session" "-d" "-s" "t" "-n" "w0" "-x" "80" "-y" "24")
+  (let* ((tmux-control-window-buffers t)
+         (buf (tmux-control-connect nil tmux-control-it--socket "t")))
+    (unwind-protect
+        (progn
+          (tmux-control-it--pump 1.0)
+          (with-current-buffer buf
+            (tmux-control-new-window "created"))
+          (should
+           (tmux-control-it--pump-until
+            6 (lambda ()
+                (with-current-buffer buf
+                  (when-let* ((entry (cl-find-if
+                                      (lambda (e) (not (eq (cdr e) buf)))
+                                      tmux-control--window-buffers))
+                              (window-buffer (cdr entry)))
+                    (with-current-buffer window-buffer
+                      (and tmux-control--active-pane
+                           (not (string-match-p
+                                 "loading window"
+                                 (buffer-substring-no-properties
+                                  (point-min) (point-max))))))))))))
+      (when (buffer-live-p buf)
+        (with-current-buffer buf (ignore-errors (tmux-control-disconnect)))
+        (kill-buffer buf))
+      (tmux-control-it--tmux-ok "kill-server"))))
+
 (ert-deftest tmux-control-it-window-activity ()
   "Output produced in a background window flags it in the tab bar's activity
 set, the current window is never flagged, and switching to a flagged window

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -1476,6 +1476,58 @@ each wrapped in an evolving prompt line and a status bar.")
     (should (equal (plist-get p :cmd) "bash"))
     (should (equal (plist-get p :title) "a\tb\tc"))))
 
+(ert-deftest tmux-control-test-parse-window-state-normalized-separators ()
+  ;; Recover fixed fields without splitting underscores inside arbitrary
+  ;; pane_current_command and pane_title values.
+  (let* ((line "LAY_%7_0_0_80_24_1_5_6_1_my_command_0,0,0,0,0,0,1_title_here")
+         (panes (cdr (tmux-control--parse-window-state (list line))))
+         (p (cdr (assoc "%7" panes))))
+    (should (= (length panes) 1))
+    (should (equal (plist-get p :cmd) "my_command"))
+    (should (equal (plist-get p :title) "title_here"))
+    (should (equal (plist-get p :cursor) '(5 . 6)))))
+
+(ert-deftest tmux-control-test-parse-window-state-separator-in-text ()
+  ;; Delimiter-like text in arbitrary command/title fields must not shift the
+  ;; fixed modes field or drop the pane.
+  (let* ((sep tmux-control--field-separator)
+         (line (mapconcat
+                #'identity
+                (list "LAY" "%8" "0" "0" "80" "24" "1" "5" "6" "1"
+                      (concat "cmd" sep "part")
+                      "0,0,0,0,0,0,1"
+                      (concat "title" sep "1,1,1,1,1,1,1" sep "tail"))
+                sep))
+         (panes (cdr (tmux-control--parse-window-state (list line))))
+         (p (cdr (assoc "%8" panes))))
+    (should (= (length panes) 1))
+    (should (equal (plist-get p :cmd) (concat "cmd" sep "part")))
+    (should (equal (plist-get p :title)
+                   (concat "title" sep "1,1,1,1,1,1,1" sep "tail")))
+    (should (eq (plist-get (plist-get p :modes) :wrap) :on))))
+
+(ert-deftest tmux-control-test-parse-window-state-normalized-mode-text-in-title ()
+  ;; A mode-shaped substring in a normalized legacy title is title content,
+  ;; not the actual modes field.
+  (let* ((line "LAY_%9_0_0_80_24_1_5_6_1_my_command_0,0,0,0,0,0,1_title_1,1,1,1,1,1,1_tail")
+         (panes (cdr (tmux-control--parse-window-state (list line))))
+         (p (cdr (assoc "%9" panes))))
+    (should (equal (plist-get p :cmd) "my_command"))
+    (should (equal (plist-get p :title) "title_1,1,1,1,1,1,1_tail"))
+    (should (eq (plist-get (plist-get p :modes) :wrap) :on))))
+
+(ert-deftest tmux-control-test-parse-window-state-legacy-title-has-new-separator ()
+  ;; Marker presence alone must not select the new format: a legacy title may
+  ;; contain the printable separator literally.
+  (let* ((line (concat
+                "LAY_%10_0_0_80_24_1_5_6_1_bash_0,0,0,0,0,0,1_title_"
+                tmux-control--field-separator "_tail"))
+         (panes (cdr (tmux-control--parse-window-state (list line))))
+         (p (cdr (assoc "%10" panes))))
+    (should (= (length panes) 1))
+    (should (equal (plist-get p :title)
+                   (concat "title_" tmux-control--field-separator "_tail")))))
+
 (ert-deftest tmux-control-test-build-tiling-callback-aborts-when-cleared ()
   ;; The build is async: a teardown (untile, disconnect) during an in-flight
   ;; layout query clears `tmux-control--tiling-build-active', and the reply
@@ -1535,6 +1587,23 @@ each wrapped in an evolving prompt line and a status bar.")
     (should-not (gethash "2" tmux-control--activity))
     (should (plist-get (nth 2 tmux-control--windows) :active))
     (should (plist-get (nth 1 tmux-control--windows) :bell))))
+
+(ert-deftest tmux-control-test-control-replies-accept-normalized-separators ()
+  ;; Some remote control connections normalize literal TAB format separators
+  ;; to underscores.  Window names containing underscores must remain intact,
+  ;; and the pane routing map must still populate.
+  (with-temp-buffer
+    (setq-local tmux-control--activity (make-hash-table :test 'equal))
+    (tmux-control--update-windows
+     '("2_test_me_1_0_@17" "1_zsh_0_0_@0"))
+    (should (equal (mapcar (lambda (w) (plist-get w :name))
+                           tmux-control--windows)
+                   '("zsh" "test_me")))
+    (should (equal tmux-control--current-window "2"))
+    (should (equal (plist-get (nth 1 tmux-control--windows) :id) "@17"))
+    (tmux-control--update-pane-window-map '("%3_2_@17" "%1_1_@0"))
+    (should (equal (gethash "%3" tmux-control--pane-window)
+                   '("2" . "@17")))))
 
 (ert-deftest tmux-control-test-window-tab-bar-renders ()
   ;; The bar shows every window, marks the busy one, and faces each tab by
@@ -2733,6 +2802,56 @@ before the toggle kept a local directory while later ones went remote."
           (should (assq :capture sent))
           (should (assq :cursor-pos sent)))
       (dolist (b (list ctrl win pane)) (when (buffer-live-p b) (kill-buffer b))))))
+
+(ert-deftest tmux-control-test-window-seed-accepts-normalized-separators ()
+  "A normalized active-pane reply must replace the loading placeholder."
+  (let ((ctrl (generate-new-buffer " *tc-seed-ctrl*"))
+        (buf (generate-new-buffer " *tc-seed-window*"))
+        commands written)
+    (unwind-protect
+        (progn
+          (with-current-buffer buf
+            (setq-local tmux-control--controller ctrl
+                        tmux-control--capture-trailing-p nil))
+          (cl-letf (((symbol-function 'tmux-control--query)
+                     (lambda (command callback)
+                       (push command commands)
+                       (funcall callback
+                                (if (string-prefix-p "list-panes" command)
+                                    '("1_%7_2,3,1_0,0,0,0,0,0,1")
+                                  '("seeded screen")))))
+                    ((symbol-function 'tmux-control--write-terminal)
+                     (lambda (text) (setq written text)))
+                    ((symbol-function 'tmux-control--flush-display) #'ignore)
+                    ((symbol-function 'tmux-control--current-sync-windows)
+                     (lambda () nil))
+                    ((symbol-function 'tmux-control--seed-stale-retry-p)
+                     (lambda (_) nil))
+                    ((symbol-function 'tmux-control--verify-seed) #'ignore))
+            (with-current-buffer buf
+              (tmux-control--seed-window-buffer buf "@9")))
+          (should (string-match-p (regexp-quote tmux-control--field-separator)
+                                  (car (last commands))))
+          (should (equal (buffer-local-value 'tmux-control--active-pane buf)
+                         "%7"))
+          (should (string-match-p "seeded screen" written)))
+      (kill-buffer buf)
+      (kill-buffer ctrl))))
+
+(ert-deftest tmux-control-test-pane-size-accepts-normalized-separator ()
+  (with-temp-buffer
+    (let (applied window-size)
+      (cl-letf (((symbol-function 'tmux-control--apply-eat-size)
+                 (lambda (width height)
+                   (setq applied (cons width height))
+                   nil))
+                ((symbol-function 'tmux-control--maybe-warn-pinned-size)
+                 (lambda (size) (setq window-size size))))
+        (setq-local tmux-control--current-command-kind :pane-size
+                    tmux-control--command-output '("80x24_100x30"))
+        (tmux-control--finish-command-output)
+        (should (equal applied '(80 . 24)))
+        (should (equal window-size '(100 . 30)))))))
 
 (ert-deftest tmux-control-test-query-callback-gets-nil-on-error ()
   ;; %error completes a closure query with nil so an async consumer can

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -2172,13 +2172,71 @@ is left untouched."
 ;; connection -- never a blocking CLI call from the process filter -- so a busy
 ;; remote session is not stalled by tab-bar upkeep.
 
+(defconst tmux-control--field-separator "|:tc:|"
+  "Printable separator for formatted replies sent through control mode.
+Some remote tmux control connections normalize literal TABs in command
+arguments to underscores, making TAB-delimited replies ambiguous.")
+
+(defconst tmux-control--field-separator-regexp
+  (concat "\\(?:" (regexp-quote tmux-control--field-separator) "\\|[_\t]\\)")
+  "Regexp accepting current and legacy control-mode field separators.")
+
+(defun tmux-control--split-control-fields (line)
+  "Split formatted control-mode reply LINE into fields.
+Prefer the printable separator emitted by current commands.  Accept literal
+TABs and underscore-normalized legacy replies for live upgrades and older
+tmux-control clients."
+  (split-string
+   line
+   (cond
+    ((string-match-p (regexp-quote tmux-control--field-separator) line)
+     (regexp-quote tmux-control--field-separator))
+    ((string-match-p "\t" line) "\t")
+    (t "_"))))
+
+(defun tmux-control--window-state-fields-with-separator (line separator)
+  "Parse 13 window-state fields from LINE using literal SEPARATOR.
+The command and title fields are arbitrary text.  Locate the fixed-shape modes
+field after the ten fixed prefix fields, then rejoin separator text inside the
+two arbitrary fields without shifting columns."
+  (let* ((parts (split-string line (regexp-quote separator)))
+         (mode-tail (nthcdr 11 parts))
+         (mode-offset
+          (cl-position-if
+           (lambda (field)
+             (string-match-p
+              "\\`[01]?,[01]?,[01]?,[01]?,[01]?,[01]?,[01]?\\'"
+              field))
+           mode-tail))
+         (mode-index (if mode-offset (+ 11 mode-offset)
+                       (and (>= (length parts) 13) 11))))
+    (when (and mode-index (>= (length parts) 13))
+      (append (cl-subseq parts 0 10)
+              (list (string-join (cl-subseq parts 10 mode-index) separator)
+                    (nth mode-index parts)
+                    (string-join (nthcdr (1+ mode-index) parts) separator))))))
+
+(defun tmux-control--window-state-fields (line)
+  "Return the 13 formatted window-state fields from control reply LINE.
+Accept the current printable separator, legacy literal TABs, and legacy
+underscore-normalized replies."
+  (or (tmux-control--window-state-fields-with-separator
+       line tmux-control--field-separator)
+      (tmux-control--window-state-fields-with-separator line "\t")
+      (tmux-control--window-state-fields-with-separator line "_")))
+
 (defun tmux-control--refresh-windows ()
   "Asynchronously refresh the cached window list that feeds the tab bar."
   (when (and (or tmux-control-window-tab-bar tmux-control-window-buffers)
              (process-live-p tmux-control--process))
     (tmux-control--send-command
-     (format "list-windows -t %s -F '#{window_index}\t#{window_name}\t#{window_active}\t#{window_bell_flag}\t#{window_id}'"
-             (tmux-control--window-target tmux-control--session))
+     (format "list-windows -t %s -F '%s'"
+             (tmux-control--window-target tmux-control--session)
+             (mapconcat
+              #'identity
+              '("#{window_index}" "#{window_name}" "#{window_active}"
+                "#{window_bell_flag}" "#{window_id}")
+              tmux-control--field-separator))
      :windows)))
 
 (defun tmux-control--refresh-pane-window-map ()
@@ -2186,8 +2244,11 @@ is left untouched."
   (when (and (or tmux-control-window-tab-bar tmux-control-window-buffers)
              (process-live-p tmux-control--process))
     (tmux-control--send-command
-     (format "list-panes -s -t %s -F '#{pane_id}\t#{window_index}\t#{window_id}'"
-             (tmux-control--window-target tmux-control--session))
+     (format "list-panes -s -t %s -F '%s'"
+             (tmux-control--window-target tmux-control--session)
+             (mapconcat #'identity
+                        '("#{pane_id}" "#{window_index}" "#{window_id}")
+                        tmux-control--field-separator))
      :pane-window)))
 
 (defun tmux-control--update-windows (lines)
@@ -2198,7 +2259,13 @@ active window for the controller buffer the first time its id is learned --
 the controller renders its own window, so a switch back to it swaps here."
   (let (parsed active active-id)
     (dolist (line lines)
-      (when (string-match "\\`\\([0-9]+\\)\t\\(.*\\)\t\\([01]\\)\t\\([01]\\)\\(?:\t\\(@[0-9]+\\)\\)?\\'" line)
+      (when (string-match
+             (concat "\\`\\([0-9]+\\)" tmux-control--field-separator-regexp
+                     "\\(.*\\)" tmux-control--field-separator-regexp
+                     "\\([01]\\)" tmux-control--field-separator-regexp
+                     "\\([01]\\)\\(?:" tmux-control--field-separator-regexp
+                     "\\(@[0-9]+\\)\\)?\\'")
+             line)
         (let ((idx (match-string 1 line))
               (act (string= (match-string 3 line) "1"))
               (id (match-string 5 line)))
@@ -2243,7 +2310,11 @@ Each value is a cons (WINDOW-INDEX . WINDOW-ID); the id may be nil on a
 reply from before the format carried it."
   (let ((map (make-hash-table :test 'equal)))
     (dolist (line lines)
-      (when (string-match "\\`\\(%[0-9]+\\)\t\\([0-9]+\\)\\(?:\t\\(@[0-9]+\\)\\)?\\'" line)
+      (when (string-match
+             (concat "\\`\\(%[0-9]+\\)" tmux-control--field-separator-regexp
+                     "\\([0-9]+\\)\\(?:" tmux-control--field-separator-regexp
+                     "\\(@[0-9]+\\)\\)?\\'")
+             line)
         (puthash (match-string 1 line)
                  (cons (match-string 2 line) (match-string 3 line))
                  map)))
@@ -5195,7 +5266,7 @@ swallowed as content and the reply queue would desynchronize."
            (tmux-control--refresh-alt-screen-option)
            (tmux-control--refresh-pane-size))))
       (:pane-size
-       ;; The reply carries "PANExSIZE\tWINDOWxSIZE": the PANE size drives
+       ;; The reply carries "PANExSIZE<SEP>WINDOWxSIZE": the PANE size drives
        ;; the renderer (in a split window the active pane is narrower than
        ;; the window, and the grid must match the pane); the WINDOW size is
        ;; what refresh-client actually negotiates, so the pin detection
@@ -5203,7 +5274,7 @@ swallowed as content and the reply queue would desynchronize."
        ;; would cry wolf on every split layout.
        (let* ((val (car (cl-remove-if #'string-empty-p
                                       (mapcar #'string-trim output))))
-              (parts (and val (split-string val "\t")))
+              (parts (and val (tmux-control--split-control-fields val)))
               (size (tmux-control--parse-pane-size
                      (list (or (car parts) ""))))
               (win-size (and (cadr parts)
@@ -6393,8 +6464,8 @@ by the `:pane-size' branch of `tmux-control--finish-command-output'."
   (when (and tmux-control--active-pane
              (process-live-p tmux-control--process))
     (tmux-control--send-command
-     (format "display-message -p -t %s \"#{pane_width}x#{pane_height}\t#{window_width}x#{window_height}\""
-             tmux-control--active-pane)
+     (format "display-message -p -t %s \"#{pane_width}x#{pane_height}%s#{window_width}x#{window_height}\""
+             tmux-control--active-pane tmux-control--field-separator)
      :pane-size)))
 
 (defun tmux-control--maybe-warn-pinned-size (actual)
@@ -6820,14 +6891,21 @@ screen, prefixed by the mode replay (see
   (let ((ctrl (tmux-control--wb-controller)))
     (with-current-buffer ctrl
       (tmux-control--query
-       (format "list-panes -t %s -F \"#{pane_active}\t#{pane_id}\t#{cursor_x},#{cursor_y},#{cursor_flag}\t%s\""
-               window-id
+       (format "list-panes -t %s -F \"#{pane_active}%s#{pane_id}%s#{cursor_x},#{cursor_y},#{cursor_flag}%s%s\""
+               window-id tmux-control--field-separator
+               tmux-control--field-separator tmux-control--field-separator
                tmux-control--pane-modes-format)
        (lambda (lines)
          (let (pane cur vis modes)
            (cl-loop for l in (or lines '())
                     when (string-match
-                          "\\`1\t\\(%[0-9]+\\)\t\\([^\t]*\\)\t\\([^\t]*\\)\\'" l)
+                          (concat "\\`1" tmux-control--field-separator-regexp
+                                  "\\(%[0-9]+\\)"
+                                  tmux-control--field-separator-regexp
+                                  "\\([^_\t]*\\)"
+                                  tmux-control--field-separator-regexp
+                                  "\\([^_\t]*\\)\\'")
+                          l)
                     ;; Extract every group before the parsers run: they do
                     ;; their own `string-match', which clobbers this match
                     ;; data.
@@ -7094,11 +7172,13 @@ controller or pane render buffer where those locals are bound."
       (tmux-control--call "tmux" full))))
 
 (defconst tmux-control--window-state-format
-  (concat "#{window_layout}\t#{pane_id}\t#{pane_left}\t#{pane_top}\t"
-          "#{pane_width}\t#{pane_height}\t#{pane_active}\t"
-          "#{cursor_x}\t#{cursor_y}\t#{cursor_flag}\t#{pane_current_command}\t"
-          tmux-control--pane-modes-format "\t"
-          "#{pane_title}")
+  (mapconcat
+   #'identity
+   (list "#{window_layout}" "#{pane_id}" "#{pane_left}" "#{pane_top}"
+         "#{pane_width}" "#{pane_height}" "#{pane_active}"
+         "#{cursor_x}" "#{cursor_y}" "#{cursor_flag}" "#{pane_current_command}"
+         tmux-control--pane-modes-format "#{pane_title}")
+   tmux-control--field-separator)
   "`list-panes -F' format folding the layout and every pane's geometry,
 cursor, command, terminal modes, and title into one query, so a (re)tile
 costs a single round trip rather than a `display-message' for the layout
@@ -7126,7 +7206,7 @@ with INFO a plist of :left :top :width :height :active :cursor
 unit-testable without a live tmux."
   (let ((layout nil) (panes nil))
     (dolist (line lines)
-      (let ((f (split-string line "\t")))
+      (let ((f (tmux-control--window-state-fields line)))
         ;; The pane id (field 1) comes straight from the untrusted reply stream
         ;; and is later used as a command TARGET (send-input, select-pane,
         ;; capture); accept only a canonical "%N" so a hostile/buggy server
@@ -7147,12 +7227,7 @@ unit-testable without a live tmux."
                             :cmd (nth 10 f)
                             :modes (tmux-control--parse-pane-modes
                                     (list (nth 11 f)))
-                            ;; `pane_title' is the last field, but an app can set
-                            ;; an arbitrary title (OSC 2) including a literal TAB;
-                            ;; rejoin any TAB-split fragments so the title is not
-                            ;; truncated to its pre-TAB piece (and the pane is not
-                            ;; mis-counted).
-                            :title (string-join (nthcdr 12 f) "\t")))
+                            :title (nth 12 f)))
                 panes))))
     (cons layout (nreverse panes))))
 


### PR DESCRIPTION
## Summary

- emit a printable field separator for formatted replies sent through tmux control mode
- accept printable, literal-tab, and underscore-normalized replies across window discovery, pane routing, sizing, new-window seeding, and tiled state parsing
- preserve underscores and delimiter-like text in window names, commands, and pane titles
- add unit regressions plus an end-to-end new-window loading-placeholder test

Closes #116

## Validation

- `make test` (240/240)
- `make test-elc` (240/240)
- `make test-integration` (21/21)