### PR TITLE
Preserve carriage returns when decoding UTF-8 output streams

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -299,6 +299,24 @@
     (should (equal (car r) "héllo"))
     (should (equal (cdr r) ""))))
 
+(ert-deftest tmux-control-test-utf8-decode-stream-preserves-carriage-returns ()
+  "Ensure `tmux-control--utf8-decode-stream' does not convert \\r to \\n.
+Emacs's `utf-8' coding system performs newline translation (Mac/DOS EOL
+decoding), which turns \\r into \\n.  Terminal streams require exact byte
+preservation (`utf-8-unix'), otherwise \\r cursor repositions become \\n
+line feeds and corrupt full-screen TUI apps like Claude Code."
+  (let ((r (tmux-control--utf8-decode-stream "" "line1\rline2\r\nline3\r")))
+    (should (equal (car r) "line1\rline2\r\nline3\r"))
+    (should (equal (cdr r) "")))
+  (let* ((e2 (decode-char 'eight-bit #xe2))
+         (b94 (decode-char 'eight-bit #x94))
+         (b80 (decode-char 'eight-bit #x80))
+         (r1 (tmux-control--utf8-decode-stream "" (format "\r%c%c" e2 b94)))
+         (r2 (tmux-control--utf8-decode-stream (cdr r1) (format "%c\r\n" b80))))
+    (should (equal (car r1) "\r"))
+    (should (equal (car r2) "─\r\n"))
+    (should (equal (cdr r2) ""))))
+
 ;;; Input hex encoding.
 
 (ert-deftest tmux-control-test-string-to-hex-args ()

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -5816,9 +5816,9 @@ may itself contain raw eight-bit bytes left when tmux split a multibyte
 character across two %output messages.  DECODED is the complete-UTF-8
 prefix as characters; NEW-CARRY is the leftover incomplete tail to prepend
 next time.  Pure, for unit testing."
-  (let* ((bytes (concat carry (encode-coding-string output 'utf-8)))
+  (let* ((bytes (concat carry (encode-coding-string output 'utf-8-unix)))
          (len (tmux-control--utf8-complete-len bytes)))
-    (cons (decode-coding-string (substring bytes 0 len) 'utf-8)
+    (cons (decode-coding-string (substring bytes 0 len) 'utf-8-unix)
           (substring bytes len))))
 
 (defun tmux-control--current-sync-windows ()


### PR DESCRIPTION
### Summary

Fixes rendering and scrolling corruption in full-screen TUI applications such as Claude Code.

### Problem
`tmux-control--utf8-decode-stream` reassembles multibyte UTF-8 characters across chunk boundaries. It used Emacs's default `'utf-8` coding system for `encode-coding-string` and `decode-coding-string`.

In Emacs Lisp, `'utf-8` performs end-of-line (EOL) conversion: it decodes carriage returns (`\r`, ASCII 13) into line feeds (`\n`, ASCII 10). In a terminal stream, `\r` moves the cursor to column 0 on the same line, whereas `\n` moves the cursor down to the next line. TUI frameworks like Ink (used by Claude Code) frequently issue `\r` to overwrite spinners, box borders, and prompt lines. Converting `\r` to `\n` pushed terminal rows downward and interleaved content. Additionally, scrolling up sent wheel events to Claude Code, causing full-screen redraws that cascaded this corruption.

### Solution
- Switched `tmux-control--utf8-decode-stream` to use `'utf-8-unix'`, disabling EOL conversion and preserving `\r` verbatim.
- Added regression test `tmux-control-test-utf8-decode-stream-preserves-carriage-returns` in `test/tmux-control-test.el`.