### PR TITLE
Bump version to 0.5.1

### DIFF
--- a/tmux-control.el
+++ b/tmux-control.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2026  Clay Sheaff
 
 ;; Author: Clay Sheaff
-;; Version: 0.5.0
+;; Version: 0.5.1
 ;; Package-Requires: ((emacs "29.1") (eat "0.9.4"))
 ;; Keywords: terminals, tmux
 ;; URL: https://github.com/csheaff/tmux-control


### PR DESCRIPTION
Bumps version to 0.5.1 following the fix for UTF-8 carriage return preservation in #134.