### PR TITLE
Anchor tiled pane windows to eat-term-display-beginning

### DIFF
--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -4557,7 +4557,7 @@ output), :calls (side-effect invocations in order), :active-pane,
         (set-window-buffer window (current-buffer))
         (tmux-control--anchor-windows-to-screen-top (list window))
         (should (= (window-start window)
-                   (marker-position (eat-term-display-beginning tmux-control--terminal))))))
+                   (eat-term-display-beginning tmux-control--terminal)))))
     (eat-term-delete tmux-control--terminal)))
 
 (ert-deftest tmux-control-test-message-echoes ()

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -4534,6 +4534,32 @@ output), :calls (side-effect invocations in order), :active-pane,
           (should (= (window-start window) anchored)))))
     (eat-term-delete tmux-control--terminal)))
 
+(ert-deftest tmux-control-test-anchor-screen-top-preserves-trailing-blank-rows ()
+  ;; Anchoring to screen top must start at `eat-term-display-beginning'.
+  ;; Counting buffer lines backwards from the terminal's end overshoots into
+  ;; scrollback whenever trailing rows are blank (Eat does not materialize
+  ;; trailing blank rows as newlines), leaving the window scrolled into
+  ;; scrollback history.
+  (with-temp-buffer
+    (tmux-control-mode)
+    (setq tmux-control--terminal (eat-term-make (current-buffer) (point-min)))
+    (eat-term-resize tmux-control--terminal 40 5)
+    (let ((inhibit-read-only t))
+      (dotimes (i 10)
+        (eat-term-process-output tmux-control--terminal (format "OLD %d\r\n" i)))
+      (eat-term-redisplay tmux-control--terminal)
+      ;; Clear screen and output only 2 lines on a 5-line terminal
+      (eat-term-process-output tmux-control--terminal "\e[H\e[2J")
+      (eat-term-process-output tmux-control--terminal "NEW 1\r\nNEW 2")
+      (eat-term-redisplay tmux-control--terminal))
+    (save-window-excursion
+      (let ((window (selected-window)))
+        (set-window-buffer window (current-buffer))
+        (tmux-control--anchor-windows-to-screen-top (list window))
+        (should (= (window-start window)
+                   (marker-position (eat-term-display-beginning tmux-control--terminal))))))
+    (eat-term-delete tmux-control--terminal)))
+
 (ert-deftest tmux-control-test-message-echoes ()
   ;; A note appended below the terminal can sit off-screen (the view shows
   ;; the terminal's screen), so it must also reach the echo area or it is

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -5981,28 +5981,20 @@ cursor position and their cursor line is kept visible."
 
 (defun tmux-control--anchor-windows-to-screen-top (windows)
   "Set each of WINDOWS to start at the top of the terminal's current screen.
-The current screen is the last `eat-term' height rows OF THE TERMINAL --
-counted back from `eat-term-end', not from the end of the buffer, which
-also holds anything appended after the terminal (see
-`tmux-control--message') -- so this reveals a full-screen TUI from its top
+The current screen begins at `eat-term-display-beginning' of the terminal --
+not counted back from the end of the buffer or terminal, which overshoots
+into scrollback whenever the screen has unmaterialized trailing blank
+rows or wrapped lines -- so this reveals a full-screen TUI from its top
 while still showing the latest screen of a scrolling pane.
 `tmux-control--keep-cursor-visible' runs after and only pulls the start
 forward when the cursor would otherwise fall below
 the body (e.g. a tall prompt glyph on a scrolling log), so the follow-bottom
 behavior is preserved."
-  (let ((height (and tmux-control--terminal
-                     (eat-term-live-p tmux-control--terminal)
-                     (cdr (eat-term-size tmux-control--terminal)))))
-    (when (and height (> height 0))
-      ;; Count back from the END OF THE TERMINAL, not the end of the buffer.
-      ;; `tmux-control--message' appends its notes AFTER the terminal, and
-      ;; anchoring on `point-max' let one warning push this pane's view that
-      ;; many lines past the top of its own screen -- permanently, since the
-      ;; anchor is recomputed from the same stale reference on every flush.
-      (let ((top (save-excursion
-                   (goto-char (eat-term-end tmux-control--terminal))
-                   (forward-line (- (1- height)))
-                   (line-beginning-position))))
+  (when (and tmux-control--terminal
+             (eat-term-live-p tmux-control--terminal))
+    (let* ((beg (eat-term-display-beginning tmux-control--terminal))
+           (top (if (markerp beg) (marker-position beg) beg)))
+      (when top
         (dolist (window windows)
           (when (window-live-p window)
             (set-window-start window top t)))))))


### PR DESCRIPTION
Counting buffer lines backwards from `eat-term-end` overshoots into scrollback whenever a screen has trailing blank rows, because Eat does not materialize blank screen rows as newlines.

Anchoring directly to `eat-term-display-beginning` sets `window-start` to the exact start of the active terminal grid, preventing windows from starting inside scrollback.