### PR TITLE
Add clickable scrollback position indicator

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -304,6 +304,13 @@ moment you scroll back down or type, exactly like iTerm).  Scrolling back to
 the bottom returns to live; scrolling up simply stops at the top of the
 retained history.
 
+While you read history, a compact **↑ 120 lines** indicator appears in the
+header. In the live view it counts rows above the live screen; in the separate
+pager it counts text lines below the viewport in the captured snapshot. Click
+it to return to live output. It disappears at the bottom, and tiled panes
+show it in their mode line. Disable it with
+`(setq tmux-control-scroll-position-indicator nil)`.
+
 For the deeper, pre-session history that lives in tmux rather than Eat, use
 `C-c C-e` (`tmux-control-scrollback`) — the full pager, unchanged.  (Wheel-up
 also opens it directly from the live screen, when the pane is fresh or quiet

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -4287,6 +4287,103 @@ output), :calls (side-effect invocations in order), :active-pane,
             (tmux-control--scrollback-scroll-watch window start)
             (should (= scheduled 1))))))))
 
+(ert-deftest tmux-control-test-scroll-position-live-viewport ()
+  ;; Point can remain at the live cursor during pixel scrolling.  The badge
+  ;; must follow the viewport, update with output, and vanish back at live.
+  (save-window-excursion
+    (with-temp-buffer
+      (tmux-control--reset-buffer)
+      (eat-term-resize tmux-control--terminal 80 24)
+      (tmux-control--write-terminal
+       (mapconcat (lambda (i) (format "row %d\r\n" i))
+                  (number-sequence 1 200) ""))
+      (switch-to-buffer (current-buffer))
+      (let* ((window (selected-window))
+             (top (eat-term-display-beginning tmux-control--terminal))
+             (start (save-excursion (goto-char top) (forward-line -120) (point)))
+             (cursor (point))
+             (tmux-control-scroll-position-indicator t))
+        (set-window-start window start t)
+        (should (equal (substring-no-properties
+                        (tmux-control--scroll-position-indicator))
+                       " ↑ 120 lines "))
+        (should (= (point) cursor))
+        (should (string-prefix-p " ↑ 120 lines " (tmux-control--header-line)))
+        (let ((tmux-control-scroll-position-indicator nil))
+          (should (equal (tmux-control--scroll-position-indicator) "")))
+        (tmux-control--feed-terminal "another row\r\n")
+        (should (equal (substring-no-properties
+                        (tmux-control--scroll-position-indicator))
+                       " ↑ 121 lines "))
+        (set-window-start window
+                          (eat-term-display-beginning tmux-control--terminal) t)
+        (should (equal (tmux-control--scroll-position-indicator) ""))))))
+
+(ert-deftest tmux-control-test-scroll-position-pager ()
+  ;; The pager measures its visible snapshot, independent of point and of
+  ;; history prepended by lazy loading; it makes no claim about live output.
+  (save-window-excursion
+    (with-temp-buffer
+      (tmux-control-scrollback-mode)
+      (let ((inhibit-read-only t)) (insert (make-string 200 ?\n)))
+      (switch-to-buffer (current-buffer))
+      (let ((visible-end 81)
+            (tmux-control-scroll-position-indicator t))
+        (cl-letf (((symbol-function 'window-end) (lambda (&rest _) visible-end)))
+          (let ((badge (tmux-control--scroll-position-indicator)))
+            (should (equal (substring-no-properties badge) " ↑ 120 lines "))
+            (should (eq (lookup-key (get-text-property 0 'keymap badge)
+                                   [header-line mouse-1])
+                        #'tmux-control-scroll-position-live)))
+          (let ((inhibit-read-only t))
+            (goto-char (point-min))
+            (insert (make-string 500 ?\n)))
+          (cl-incf visible-end 500)
+          (should (equal (substring-no-properties
+                          (tmux-control--scroll-position-indicator))
+                         " ↑ 120 lines "))
+          (setq visible-end (1- (point-max)))
+          (should (equal (substring-no-properties
+                          (tmux-control--scroll-position-indicator))
+                         " ↑ 1 line "))
+          (setq visible-end (point-max))
+          (should (equal (tmux-control--scroll-position-indicator) "")))))))
+
+(ert-deftest tmux-control-test-scroll-position-click-target-window ()
+  ;; A click in another window must resume that terminal, including from
+  ;; its separate pager, without relying on an eventual redisplay hook.
+  (save-window-excursion
+    (let ((live (generate-new-buffer " *tc-position-live*"))
+          (pager (generate-new-buffer " *tc-position-pager*")))
+      (unwind-protect
+          (progn
+            (with-current-buffer live
+              (tmux-control--reset-buffer)
+              (eat-term-resize tmux-control--terminal 80 24)
+              (tmux-control--write-terminal
+               (mapconcat (lambda (i) (format "row %d\r\n" i))
+                          (number-sequence 1 100) "")))
+            (let ((window (split-window-below)))
+              (set-window-buffer window live)
+              (set-window-start window 1 t)
+              (let ((event (list 'mouse-1 (list window 'header-line '(0 . 0) 0))))
+                (tmux-control-scroll-position-live event)
+                (should (eq (selected-window) window))
+                (should (= (window-point window)
+                           (eat-term-display-cursor tmux-control--terminal)))
+                (should (equal (tmux-control--scroll-position-indicator) ""))
+                (with-current-buffer pager
+                  (tmux-control-scrollback-mode)
+                  (setq tmux-control--live-buffer live))
+                (set-window-buffer window pager)
+                (tmux-control-scroll-position-live event)
+                (should (eq (window-buffer window) live))
+                (should-not (buffer-live-p pager))
+                (should (= (window-point window)
+                           (eat-term-display-cursor tmux-control--terminal))))))
+        (when (buffer-live-p pager) (kill-buffer pager))
+        (kill-buffer live)))))
+
 (ert-deftest tmux-control-test-live-history-retains-reading-marker ()
   ;; Output that exhausted Eat's 128K default used to delete the row being
   ;; read.  Exercise real terminal retention across two substantial bursts.

--- a/test/tmux-control-test.el
+++ b/test/tmux-control-test.el
@@ -4384,6 +4384,30 @@ output), :calls (side-effect invocations in order), :active-pane,
         (when (buffer-live-p pager) (kill-buffer pager))
         (kill-buffer live)))))
 
+(ert-deftest tmux-control-test-scroll-position-click-without-eat-helper ()
+  ;; A missing private Eat helper must not turn the badge into a no-op or
+  ;; signal void-function.  Resume the cursor and show the live screen.
+  (save-window-excursion
+    (with-temp-buffer
+      (tmux-control--reset-buffer)
+      (eat-term-resize tmux-control--terminal 80 24)
+      (tmux-control--write-terminal
+       (mapconcat (lambda (i) (format "row %d\r\n" i))
+                  (number-sequence 1 100) ""))
+      (switch-to-buffer (current-buffer))
+      (let* ((window (selected-window))
+             (event (list 'mouse-1 (list window 'header-line '(0 . 0) 0))))
+        (goto-char (point-min))
+        (set-window-start window (point-min) t)
+        (should-not (equal (tmux-control--scroll-position-indicator) ""))
+        (cl-letf (((symbol-function 'eat--synchronize-scroll) nil))
+          (tmux-control-scroll-position-live event))
+        (should (= (window-point window)
+                   (eat-term-display-cursor tmux-control--terminal)))
+        (should (>= (window-start window)
+                    (eat-term-display-beginning tmux-control--terminal)))
+        (should (equal (tmux-control--scroll-position-indicator) ""))))))
+
 (ert-deftest tmux-control-test-live-history-retains-reading-marker ()
   ;; Output that exhausted Eat's 128K default used to delete the row being
   ;; read.  Exercise real terminal retention across two substantial bursts.

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -2761,8 +2761,15 @@ KEY includes the buffer modification tick and the counted endpoints.")
                  tmux-control--terminal
                  (eat-term-live-p tmux-control--terminal))
         (set-window-vscroll window 0 t)
-        (let ((eat-terminal tmux-control--terminal))
-          (eat--synchronize-scroll (list window)))
+        (if (fboundp 'eat--synchronize-scroll)
+            (let ((eat-terminal tmux-control--terminal))
+              (eat--synchronize-scroll (list window)))
+          ;; Eat's private helper is not a compatibility guarantee.  Keep
+          ;; the button functional using its public cursor/screen accessors.
+          (set-window-point window
+                            (eat-term-display-cursor tmux-control--terminal))
+          (tmux-control--anchor-windows-to-screen-top (list window))
+          (tmux-control--keep-cursor-visible (list window)))
         (force-mode-line-update)))))
 
 (defun tmux-control--scroll-position-indicator ()

--- a/tmux-control.el
+++ b/tmux-control.el
@@ -448,6 +448,13 @@ A small debounce keeps navigation snappy when previews require a remote
 tmux query over SSH."
   :type 'number)
 
+(defcustom tmux-control-scroll-position-indicator t
+  "Non-nil shows a clickable line count while viewing history.
+The live header counts rows above the live screen; the scrollback pager
+counts text lines below the viewport in its captured snapshot.  Click to
+return to live output.  Tiled panes show it in their mode line instead."
+  :type 'boolean)
+
 (defcustom tmux-control-window-tab-bar t
   "Non-nil shows a header-line tab bar of the session's windows.
 
@@ -1294,7 +1301,8 @@ session (tmux attaches if it exists, otherwise creates it)."
       ;; Header line: the window tab bar and/or the cross-session activity
       ;; strip (independent features sharing one row).  Both must ignore the
       ;; connect seed's repaint burst, so quiet activity for either.
-      (when (or tmux-control-window-tab-bar tmux-control-session-activity
+      (when (or tmux-control-scroll-position-indicator
+                tmux-control-window-tab-bar tmux-control-session-activity
                 tmux-control-session-label)
         (setq-local header-line-format '(:eval (tmux-control--header-line)))
         ;; The connect seed repaints every pane; don't let that flag everything.
@@ -2730,6 +2738,68 @@ server is always named (see `tmux-control--connection-name')."
                 (format "tmux session %s"
                         (tmux-control--connection-name host tmux-control--session)))))
 
+(defvar-local tmux-control--scroll-position-cache nil
+  "Cached (KEY . COUNT) for the visible scroll position.
+KEY includes the buffer modification tick and the counted endpoints.")
+
+(defvar tmux-control--scroll-position-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map [header-line mouse-1] #'tmux-control-scroll-position-live)
+    (define-key map [mode-line mouse-1] #'tmux-control-scroll-position-live)
+    map)
+  "Mouse bindings for the scroll position indicator.")
+
+(defun tmux-control-scroll-position-live (event)
+  "Return the window clicked in EVENT to live output."
+  (interactive "e")
+  (let ((window (posn-window (event-start event))))
+    (when (window-live-p window)
+      (select-window window)
+      (when (derived-mode-p 'tmux-control-scrollback-mode)
+        (tmux-control-live))
+      (when (and (derived-mode-p 'tmux-control-mode)
+                 tmux-control--terminal
+                 (eat-term-live-p tmux-control--terminal))
+        (set-window-vscroll window 0 t)
+        (let ((eat-terminal tmux-control--terminal))
+          (eat--synchronize-scroll (list window)))
+        (force-mode-line-update)))))
+
+(defun tmux-control--scroll-position-indicator ()
+  "Return a clickable history offset for the window being redisplayed.
+Uses viewport positions, never point: pixel scrolling can leave point at
+the live cursor while the window is reading history.  Cache counts so an
+unchanged header does not repeatedly scan retained history."
+  (let ((window (selected-window)))
+    (if (not (and tmux-control-scroll-position-indicator
+                  (eq (window-buffer window) (current-buffer))
+                  (derived-mode-p 'tmux-control-mode
+                                  'tmux-control-scrollback-mode)))
+        ""
+      (let* ((pager (derived-mode-p 'tmux-control-scrollback-mode))
+             (start (if pager (window-end window t) (window-start window)))
+             (end (if pager (point-max)
+                    (when (and tmux-control--terminal
+                               (eat-term-live-p tmux-control--terminal))
+                      (let ((beg (eat-term-display-beginning
+                                  tmux-control--terminal)))
+                        (if (markerp beg) (marker-position beg) beg)))))
+             (key (list (buffer-chars-modified-tick) start end))
+             (count (if (equal key (car tmux-control--scroll-position-cache))
+                        (cdr tmux-control--scroll-position-cache)
+                      (let ((n (if (and start end (< start end))
+                                   (count-lines start end) 0)))
+                        (setq tmux-control--scroll-position-cache (cons key n))
+                        n))))
+        (if (zerop count) ""
+          (propertize (format " ↑ %d %s " count (if (= count 1) "line" "lines"))
+                      'face 'mode-line-emphasis
+                      'mouse-face 'highlight
+                      'help-echo (if pager
+                                     "Lines below this view in the snapshot; click to return to live output"
+                                   "Rows above the live screen; click to return to live output")
+                      'keymap tmux-control--scroll-position-map))))))
+
 (defun tmux-control--header-line ()
   "Compose the live buffer's header line as \"here\" on the left, \"elsewhere\"
 in the right corner.
@@ -2751,7 +2821,8 @@ self-gates on its option."
          (connector (if (and (> (length label) 0) (> (length tabs) 0))
                         (propertize " ›" 'face 'tmux-control-tab-inactive)
                       ""))
-         (left (concat label connector tabs))
+         (left (concat (tmux-control--scroll-position-indicator)
+                       label connector tabs))
          (others (if (and tmux-control-session-activity (not tmux-control--tiled))
                      (tmux-control--flagged-other-session-buffers)
                    nil)))
@@ -2774,6 +2845,7 @@ hint, so entering scrollback does not look like the header vanished.  Falls
 back to a plain info line only when neither the label nor the tabs are
 available."
   (let* ((live tmux-control--live-buffer)
+         (position (tmux-control--scroll-position-indicator))
          ;; Show the CURRENT mode, then what `c' switches to, so it never
          ;; reads as if verbatim were active while compaction is on.
          (cmode (if tmux-control-compact-scrollback
@@ -2792,16 +2864,21 @@ available."
                         (propertize " ›" 'face 'tmux-control-tab-inactive)
                       ""))
          (head (concat label connector (or tabs ""))))
-    (if (> (length head) 0)
-        (concat head (propertize (format "  ⇡ scrollback  g:refresh  %s  q/RET:live "
-                                         cmode)
-                                 'face 'tmux-control-tab-inactive))
-      (format " %s socket:%s session:%s target:%s    g:refresh  %s  q/l/RET:live"
-              (or tmux-control--host "local")
-              tmux-control--socket-name
-              tmux-control--session
-              tmux-control--scrollback-target
-              cmode))))
+    (concat
+     position
+     (if (> (length head) 0)
+         (concat head
+                 (propertize
+                  (format "%s  q/RET:live  g:refresh  %s "
+                          (if (string-empty-p position) "  ⇡ scrollback" "")
+                          cmode)
+                  'face 'tmux-control-tab-inactive))
+       (format " %s socket:%s session:%s target:%s    q/l/RET:live  g:refresh  %s"
+               (or tmux-control--host "local")
+               tmux-control--socket-name
+               tmux-control--session
+               tmux-control--scrollback-target
+               cmode)))))
 
 (defun tmux-control-other-pane ()
   "Switch the live view to the next pane in the current window.
@@ -6983,7 +7060,8 @@ it asynchronously over the control connection."
         ;; "no process" -- alarming for a perfectly live view.  Keep the
         ;; rest (the [semi-char] mode indicator), drop the status.
         (setq mode-line-process (remove ":%s" mode-line-process))
-        (when (or tmux-control-window-tab-bar tmux-control-session-activity
+        (when (or tmux-control-scroll-position-indicator
+                  tmux-control-window-tab-bar tmux-control-session-activity
                 tmux-control-session-label)
           (setq-local header-line-format
                       '(:eval (tmux-control--header-line))))
@@ -7401,7 +7479,7 @@ apart), then the running command and, when distinct, the pane title."
          (pane (tmux-control--mode-line-safe (or tmux-control--active-pane "?")))
          (cmd (tmux-control--mode-line-safe (plist-get info :cmd)))
          (title (tmux-control--mode-line-safe (plist-get info :title))))
-    (concat " "
+    (concat (tmux-control--scroll-position-indicator) " "
             (propertize (format "[%s]" pane) 'face 'mode-line-emphasis)
             (when (and cmd (not (string-empty-p cmd))) (concat " " cmd))
             (when (and title (not (string-empty-p title)) (not (equal title cmd)))


### PR DESCRIPTION
Scrolling through terminal history now shows a compact, clickable `↑ 120 lines` indicator. Clicking it returns the clicked window to live output, and the count disappears at the bottom.

The live view counts rows above the live screen; the older-history pager counts text lines below the viewport in its captured snapshot. Both use viewport positions so the count follows pixel scrolling even when point stays at the live cursor. Tiled panes display the indicator in their mode line. The feature is enabled by default and can be disabled with `tmux-control-scroll-position-indicator`.

The pager header also avoids repeating the scrollback label while the count is visible and puts the return-to-live hint before the other controls.

The click handler guards Eat’s private scroll helper and falls back to the public cursor and screen accessors when it is unavailable, with regression coverage for that compatibility path.

Validation:
- All 256 tests pass against both source and byte-compiled builds; compilation treats warnings as errors.
- Added coverage for viewport-based counts, incoming output, lazy history prepending, hiding at the bottom, and clicking into the correct live window from either view.
- Visually reviewed in Emacs with a terminal-output fixture, including narrow side-by-side windows and the pager; verified both click-to-live paths.

